### PR TITLE
fix: unblock infra-base Flux reconciliation

### DIFF
--- a/apps/base/immich/helmrelease.yaml
+++ b/apps/base/immich/helmrelease.yaml
@@ -13,7 +13,7 @@ spec:
       chart: immich
       version: "0.9.3"
       sourceRef:
-        kind: OCIRepository
+        kind: HelmRepository
         name: immich-charts
         namespace: flux-system
   valuesFrom:

--- a/infrastructure/base/backup/kustomization.yaml
+++ b/infrastructure/base/backup/kustomization.yaml
@@ -6,4 +6,4 @@ resources:
   - helmrelease.yaml
   - daily-backup.yaml
   - weekly-backup.yaml
-  - servicemonitor.yaml
+  # servicemonitor.yaml: re-enable when apps monitoring (VictoriaMetrics) is installed

--- a/infrastructure/base/network/ingress/kustomization.yaml
+++ b/infrastructure/base/network/ingress/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - helmrelease.yaml
-  - servicemonitor.yaml
+  # servicemonitor.yaml (VMServiceScrape): re-enable when apps monitoring is installed

--- a/infrastructure/base/sources/helm-repositories.yaml
+++ b/infrastructure/base/sources/helm-repositories.yaml
@@ -116,14 +116,12 @@ spec:
   interval: 24h
   url: https://breuerfelix.github.io/helm-charts
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
-kind: OCIRepository
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
 metadata:
   name: immich-charts
   namespace: flux-system
 spec:
   interval: 24h
-  url: oci://ghcr.io/immich-app/immich-charts
-  ref:
-    tag: "0.9.3"
+  url: https://immich-app.github.io/immich-charts
 


### PR DESCRIPTION
Use Immich HTTP HelmRepository instead of broken ghcr OCI, and defer ServiceMonitor/VMServiceScrape until VictoriaMetrics is deployed.