### PR TITLE
fix(storage): align NFS PVs with TrueNAS export roots

### DIFF
--- a/apps/base/audiobookshelf/deployment.yaml
+++ b/apps/base/audiobookshelf/deployment.yaml
@@ -51,14 +51,19 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 5
           volumeMounts:
+            # PV mounts export root /mnt/Storagepool/Media — subPath = path under /mnt/truenas/Media
             - name: config
               mountPath: /config
+              subPath: docker/audiobookshelf/config
             - name: metadata
               mountPath: /metadata
+              subPath: docker/audiobookshelf/metadata
             - name: audiobooks
               mountPath: /audiobooks
+              subPath: MediaStack/audiobooks
             - name: podcasts
               mountPath: /podcasts
+              subPath: MediaStack/podcasts
       volumes:
         - name: config
           persistentVolumeClaim:

--- a/apps/base/authentik/helmrelease.yaml
+++ b/apps/base/authentik/helmrelease.yaml
@@ -26,6 +26,9 @@ spec:
       valuesKey: secret-key
       targetPath: authentik.secret_key
   values:
+    global:
+      security:
+        allowInsecureImages: true
     postgresql:
       enabled: false
     redis:

--- a/apps/base/immich/helmrelease.yaml
+++ b/apps/base/immich/helmrelease.yaml
@@ -34,6 +34,9 @@ spec:
       valuesKey: password
       targetPath: env.DB_PASSWORD
   values:
+    global:
+      security:
+        allowInsecureImages: true
     postgresql:
       enabled: false
     redis:
@@ -56,10 +59,14 @@ spec:
           existingClaim: immich-library
     server:
       persistence:
+        # subPath = directory under NFS export /mnt/Storagepool/Media (see pv-nfs.yaml)
+        library:
+          subPath: Bilder
         fotos:
           enabled: true
           mountPath: /fotos
           existingClaim: immich-fotos
+          subPath: Fotos
       ingress:
         main:
           enabled: false

--- a/apps/base/jellyfin/deployment.yaml
+++ b/apps/base/jellyfin/deployment.yaml
@@ -57,12 +57,16 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 10
           volumeMounts:
+            # PV mounts export root /mnt/Storagepool/Media — subPath = path under /mnt/truenas/Media
             - name: config
               mountPath: /config
+              subPath: jellyfin/config
             - name: cache
               mountPath: /cache
+              subPath: jellyfin/cache
             - name: media
               mountPath: /media
+              subPath: MediaStack/media
               readOnly: true
       volumes:
         - name: config

--- a/apps/base/paperless-ngx/helmrelease.yaml
+++ b/apps/base/paperless-ngx/helmrelease.yaml
@@ -8,6 +8,49 @@ metadata:
 spec:
   interval: 1h
   timeout: 15m
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              group: apps
+              version: v1
+              kind: Deployment
+              name: paperless-ngx
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: paperless-ngx
+              spec:
+                template:
+                  spec:
+                    containers:
+                      - name: paperless-ngx
+                        volumeMounts:
+                          - name: data
+                            subPath: paperless/data
+                          - name: media
+                            subPath: paperless/media
+                          - name: export
+                            subPath: paperless/export
+          - target:
+              group: apps
+              version: v1
+              kind: Deployment
+              name: redis
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: redis
+              spec:
+                template:
+                  spec:
+                    containers:
+                      - name: redis
+                        volumeMounts:
+                          - name: data
+                            subPath: paperless/redis
   chart:
     spec:
       chart: paperless-ngx

--- a/docs/migrations/nfs-migration.md
+++ b/docs/migrations/nfs-migration.md
@@ -1,5 +1,21 @@
 # PVC Migration: Longhorn → NFS (`nfs-media-static`)
 
+## TrueNAS exports (fstab reference)
+
+Only these paths are exported from `192.168.10.94`:
+
+```fstab
+192.168.10.94:/mnt/Storagepool/Documents /mnt/truenas/Documents nfs defaults 0 0
+192.168.10.94:/mnt/Storagepool/Media     /mnt/truenas/Media     nfs defaults 0 0
+```
+
+All static PVs in `infrastructure/base/storage/pv-nfs.yaml` use one of these as `spec.nfs.path`.
+Application data lives in subdirectories (`Bilder`, `jellyfin/config`, `MediaStack/media`, …)
+and is mounted via `volumeMount.subPath` in the app manifests.
+
+Changing `spec.nfs.path` on an existing PV is not supported — delete the PV (after
+releasing the PVC) and let Flux recreate it from Git.
+
 ## Why this exists
 
 PersistentVolumeClaim specs are **immutable** for the fields

--- a/infrastructure/base/storage/kustomization.yaml
+++ b/infrastructure/base/storage/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 resources:
   - longhorn.yaml
   - ingress.yaml
+  - nfs-storageclass.yaml
   - pv-nfs.yaml

--- a/infrastructure/base/storage/nfs-storageclass.yaml
+++ b/infrastructure/base/storage/nfs-storageclass.yaml
@@ -1,0 +1,10 @@
+# Static NFS: PVs in pv-nfs.yaml reference this class; no dynamic provisioner.
+# PVCs must either set volumeName to a pre-created PV or match a PV claimRef.
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: nfs-media-static
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: Immediate
+reclaimPolicy: Retain
+allowVolumeExpansion: false

--- a/infrastructure/base/storage/pv-nfs.yaml
+++ b/infrastructure/base/storage/pv-nfs.yaml
@@ -1,6 +1,17 @@
 # Static NFS volumes on TrueNAS (192.168.10.94).
-# NFS export paths use the pool mount (/mnt/Storagepool/...). Docker host paths
-# (/mnt/truenas/...) must map to these exports — verify on TrueNAS before apply.
+#
+# TrueNAS exports only these paths (must match fstab on Docker host):
+#   192.168.10.94:/mnt/Storagepool/Media      → /mnt/truenas/Media
+#   192.168.10.94:/mnt/Storagepool/Documents → /mnt/truenas/Documents
+#
+# Kubernetes cannot mount subdirectories as separate NFS roots unless they are
+# their own export. Each PV therefore uses an export root; apps mount a
+# subdirectory via volumeMount.subPath (see apps/base/*/deployment.yaml and
+# immich/paperless HelmRelease values).
+#
+# subPath reference (relative to export root):
+#   Media/Bilder, Media/Fotos, Media/paperless/*, Media/jellyfin/*,
+#   Media/MediaStack/*, Media/docker/audiobookshelf/* (create on NAS if missing)
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -19,8 +30,7 @@ spec:
   mountOptions:
     - nfsvers=4.1
   nfs:
-    # Docker: /mnt/truenas/Media/Bilder → /usr/src/app/upload
-    path: /mnt/Storagepool/Media/Bilder
+    path: /mnt/Storagepool/Media
     server: 192.168.10.94
   claimRef:
     name: immich-library
@@ -44,8 +54,7 @@ spec:
   mountOptions:
     - nfsvers=4.1
   nfs:
-    # Docker: /mnt/truenas/Media/Fotos → /fotos (external library in Immich UI)
-    path: /mnt/Storagepool/Media/Fotos
+    path: /mnt/Storagepool/Media
     server: 192.168.10.94
   claimRef:
     name: immich-fotos
@@ -69,7 +78,7 @@ spec:
   mountOptions:
     - nfsvers=4.1
   nfs:
-    path: /mnt/Storagepool/Media/paperless/data
+    path: /mnt/Storagepool/Media
     server: 192.168.10.94
   claimRef:
     name: paperless-ngx-data
@@ -93,7 +102,7 @@ spec:
   mountOptions:
     - nfsvers=4.1
   nfs:
-    path: /mnt/Storagepool/Media/paperless/media
+    path: /mnt/Storagepool/Media
     server: 192.168.10.94
   claimRef:
     name: paperless-ngx-media
@@ -117,7 +126,7 @@ spec:
   mountOptions:
     - nfsvers=4.1
   nfs:
-    path: /mnt/Storagepool/Media/paperless/export
+    path: /mnt/Storagepool/Media
     server: 192.168.10.94
   claimRef:
     name: paperless-ngx-export
@@ -141,7 +150,7 @@ spec:
   mountOptions:
     - nfsvers=4.1
   nfs:
-    path: /mnt/Storagepool/Media/paperless/redis
+    path: /mnt/Storagepool/Media
     server: 192.168.10.94
   claimRef:
     name: redis-data
@@ -165,8 +174,7 @@ spec:
   mountOptions:
     - nfsvers=4.1
   nfs:
-    # Docker: /docker/audiobookshelf/config — export this path or migrate data here
-    path: /mnt/Storagepool/docker/audiobookshelf/config
+    path: /mnt/Storagepool/Media
     server: 192.168.10.94
   claimRef:
     name: audiobookshelf-config
@@ -190,7 +198,7 @@ spec:
   mountOptions:
     - nfsvers=4.1
   nfs:
-    path: /mnt/Storagepool/docker/audiobookshelf/metadata
+    path: /mnt/Storagepool/Media
     server: 192.168.10.94
   claimRef:
     name: audiobookshelf-metadata
@@ -214,8 +222,7 @@ spec:
   mountOptions:
     - nfsvers=4.1
   nfs:
-    # Docker: /mnt/truenas/Media/MediaStack/audiobooks → /audiobooks
-    path: /mnt/Storagepool/Media/MediaStack/audiobooks
+    path: /mnt/Storagepool/Media
     server: 192.168.10.94
   claimRef:
     name: audiobookshelf-audiobooks
@@ -239,14 +246,12 @@ spec:
   mountOptions:
     - nfsvers=4.1
   nfs:
-    # Docker: /mnt/truenas/Media/MediaStack/podcasts → /podcasts
-    path: /mnt/Storagepool/Media/MediaStack/podcasts
+    path: /mnt/Storagepool/Media
     server: 192.168.10.94
   claimRef:
     name: audiobookshelf-podcasts
     namespace: audiobookshelf
 ---
-# Jellyfin: docker host /mnt/truenas/... == NFS export /mnt/Storagepool/... on 192.168.10.94
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -265,8 +270,7 @@ spec:
   mountOptions:
     - nfsvers=4.1
   nfs:
-    # host: /docker/jellyfin/config
-    path: /mnt/Storagepool/Media/jellyfin/config
+    path: /mnt/Storagepool/Media
     server: 192.168.10.94
   claimRef:
     name: jellyfin-config
@@ -290,8 +294,7 @@ spec:
   mountOptions:
     - nfsvers=4.1
   nfs:
-    # host: /docker/jellyfin/cache
-    path: /mnt/Storagepool/Media/jellyfin/cache
+    path: /mnt/Storagepool/Media
     server: 192.168.10.94
   claimRef:
     name: jellyfin-cache
@@ -316,8 +319,7 @@ spec:
     - nfsvers=4.1
     - ro
   nfs:
-    # host: /mnt/truenas/Media/MediaStack/media (read-only in compose)
-    path: /mnt/Storagepool/Media/MediaStack/media
+    path: /mnt/Storagepool/Media
     server: 192.168.10.94
   claimRef:
     name: jellyfin-media
@@ -341,7 +343,7 @@ spec:
   mountOptions:
     - nfsvers=4.1
   nfs:
-    path: /mnt/Storagepool/Media/nextcloud
+    path: /mnt/Storagepool/Media
     server: 192.168.10.94
   claimRef:
     name: nextcloud-data


### PR DESCRIPTION
TrueNAS only exports /mnt/Storagepool/Media and Documents; subpaths cannot be separate NFS mount targets. Point all Media PVs at the export root and use volumeMount.subPath in apps (audiobookshelf, jellyfin, immich, paperless via postRenderers).

Add nfs-media-static StorageClass (no provisioner) so Helm-created PVCs can bind to static PVs. Also set global.security.allowInsecureImages for Bitnami legacy Redis on authentik and immich.