### PR TITLE
fix(resources): right-size homelab workloads for schedulable capacity

### DIFF
--- a/apps/base/audiobookshelf/deployment.yaml
+++ b/apps/base/audiobookshelf/deployment.yaml
@@ -33,11 +33,10 @@ spec:
             allowPrivilegeEscalation: false
           resources:
             requests:
-              cpu: 100m
-              memory: 256Mi
+              cpu: 10m
+              memory: 64Mi
             limits:
-              cpu: 500m
-              memory: 1Gi
+              memory: 512Mi
           livenessProbe:
             httpGet:
               path: /healthcheck

--- a/apps/base/authentik/helmrelease.yaml
+++ b/apps/base/authentik/helmrelease.yaml
@@ -56,16 +56,14 @@ spec:
         enabled: false
       resources:
         requests:
-          cpu: 100m
-          memory: 512Mi
+          cpu: 25m
+          memory: 256Mi
         limits:
-          cpu: "1"
           memory: 1Gi
     worker:
       resources:
         requests:
-          cpu: 100m
-          memory: 512Mi
+          cpu: 25m
+          memory: 256Mi
         limits:
-          cpu: "1"
           memory: 1Gi

--- a/apps/base/homepage/deployment.yaml
+++ b/apps/base/homepage/deployment.yaml
@@ -58,12 +58,11 @@ spec:
           capabilities:
             drop: ["ALL"]
         resources:
-          limits:
-            cpu: 500m
-            memory: 256Mi
           requests:
-            cpu: 100m
-            memory: 50Mi
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            memory: 256Mi
       volumes:
       - name: config
         emptyDir: {}

--- a/apps/base/homer/deployment.yaml
+++ b/apps/base/homer/deployment.yaml
@@ -22,6 +22,12 @@ spec:
         volumeMounts:
         - name: config
           mountPath: /www/assets
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            memory: 128Mi
       volumes:
       - name: config
         configMap:

--- a/apps/base/immich/helmrelease.yaml
+++ b/apps/base/immich/helmrelease.yaml
@@ -75,10 +75,9 @@ spec:
           enabled: false
       resources:
         requests:
-          cpu: 200m
-          memory: 512Mi
+          cpu: 50m
+          memory: 256Mi
         limits:
-          cpu: "2"
           memory: 4Gi
     machine-learning:
       enabled: true
@@ -87,5 +86,4 @@ spec:
           cpu: 200m
           memory: 1Gi
         limits:
-          cpu: "2"
           memory: 4Gi

--- a/apps/base/jellyfin/deployment.yaml
+++ b/apps/base/jellyfin/deployment.yaml
@@ -39,10 +39,9 @@ spec:
             allowPrivilegeEscalation: false
           resources:
             requests:
-              cpu: 250m
-              memory: 512Mi
+              cpu: 50m
+              memory: 256Mi
             limits:
-              cpu: "2"
               memory: 4Gi
           livenessProbe:
             httpGet:

--- a/apps/base/kite/deployment.yaml
+++ b/apps/base/kite/deployment.yaml
@@ -79,3 +79,9 @@ spec:
       periodSeconds: 15
       timeoutSeconds: 10
       failureThreshold: 4
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        memory: 512Mi

--- a/apps/base/monitoring/vm-k8s-stack/helmrelease.yaml
+++ b/apps/base/monitoring/vm-k8s-stack/helmrelease.yaml
@@ -29,10 +29,9 @@ spec:
               storage: 20Gi
         resources:
           requests:
-            cpu: 500m
-            memory: 1Gi
+            cpu: 100m
+            memory: 512Mi
           limits:
-            cpu: "2"
             memory: 4Gi
         priorityClassName: homelab-infrastructure
         podMetadata:
@@ -71,10 +70,9 @@ spec:
         selectAllByDefault: true
         resources:
           requests:
-            cpu: 100m
-            memory: 128Mi
+            cpu: 25m
+            memory: 64Mi
           limits:
-            cpu: 500m
             memory: 512Mi
 
     # ============================================
@@ -88,10 +86,9 @@ spec:
           notifier.blackhole: "true"
         resources:
           requests:
-            cpu: 50m
+            cpu: 10m
             memory: 64Mi
           limits:
-            cpu: 200m
             memory: 256Mi
 
     # ============================================
@@ -177,10 +174,9 @@ spec:
 
       resources:
         requests:
-          cpu: 50m
+          cpu: 25m
           memory: 128Mi
         limits:
-          cpu: 256m
           memory: 512Mi
 
       # Give grafana time to download and install the VM plugin before health checks

--- a/apps/base/paperless-ngx/helmrelease.yaml
+++ b/apps/base/paperless-ngx/helmrelease.yaml
@@ -84,6 +84,34 @@ spec:
                         volumeMounts:
                           - name: data
                             subPath: paperless/redis
+          - target:
+              group: apps
+              version: v1
+              kind: Deployment
+              name: paperless-ngx
+            patch: |
+              - op: add
+                path: /spec/template/spec/containers/0/resources
+                value:
+                  requests:
+                    cpu: 50m
+                    memory: 256Mi
+                  limits:
+                    memory: 1Gi
+          - target:
+              group: apps
+              version: v1
+              kind: Deployment
+              name: redis
+            patch: |
+              - op: add
+                path: /spec/template/spec/containers/0/resources
+                value:
+                  requests:
+                    cpu: 10m
+                    memory: 64Mi
+                  limits:
+                    memory: 256Mi
   chart:
     spec:
       chart: paperless-ngx

--- a/apps/base/sterling-pdf/deployment.yaml
+++ b/apps/base/sterling-pdf/deployment.yaml
@@ -78,11 +78,10 @@ spec:
         failureThreshold: 10
     resources:
       requests:
-        memory: "512Mi"
-        cpu: "200m"
+        cpu: 100m
+        memory: 512Mi
       limits:
-        memory: "2Gi"
-        cpu: "1000m"
+        memory: 2Gi
     ingress:
       enabled: true
       ingressClassName: nginx

--- a/infrastructure/base/database/cnpg/helmrelease.yaml
+++ b/infrastructure/base/database/cnpg/helmrelease.yaml
@@ -36,10 +36,9 @@ spec:
       create: true
     resources:
       requests:
-        cpu: 50m
+        cpu: 25m
         memory: 128Mi
       limits:
-        cpu: 250m
         memory: 256Mi
     securityContext:
       allowPrivilegeEscalation: false

--- a/infrastructure/base/network/ingress/helmrelease.yaml
+++ b/infrastructure/base/network/ingress/helmrelease.yaml
@@ -23,12 +23,11 @@ spec:
       kind: daemonset
       priorityClassName: "homelab-infrastructure"
       resources:
-        limits:
-          cpu: 250m
-          memory: 128Mi
         requests:
-          cpu: 50m
+          cpu: 10m
           memory: 64Mi
+        limits:
+          memory: 256Mi
       service:
         type: ClusterIP
     prometheus:

--- a/infrastructure/overlays/main/database-clusters/cluster.yaml
+++ b/infrastructure/overlays/main/database-clusters/cluster.yaml
@@ -29,7 +29,6 @@ spec:
       cpu: 50m
       memory: 128Mi
     limits:
-      cpu: 250m
       memory: 512Mi
 
   monitoring:

--- a/infrastructure/overlays/main/database-clusters/immich-postgres/cluster.yaml
+++ b/infrastructure/overlays/main/database-clusters/immich-postgres/cluster.yaml
@@ -33,7 +33,6 @@ spec:
       cpu: 100m
       memory: 512Mi
     limits:
-      cpu: "2"
       memory: 2Gi
 
   monitoring:


### PR DESCRIPTION
Lower CPU/memory requests on enabled apps and core infra to realistic idle floors; keep memory limits for OOM protection. Omit CPU limits on burstable homelab workloads (3-node cluster with spare CPU) to avoid CFS throttling; retain higher floors for JVM (Sterling), Immich ML, and CNPG postgres requests unchanged on homelab/immich clusters.

Metrics API was unavailable during sizing; re-check with kubectl top after metrics-server or VM scrapes are healthy.