### PR TITLE
feat(dr): recover immich-postgres from S3 on cluster rebuild

### DIFF
--- a/docs/disaster-recovery/cnpg-s3-dr.md
+++ b/docs/disaster-recovery/cnpg-s3-dr.md
@@ -1,6 +1,6 @@
 # CNPG Backup & Disaster Recovery (S3 / Barman)
 
-Central PostgreSQL (`homelab-postgres`) uses **Barman Cloud** via `barmanObjectStore` for continuous WAL archiving and scheduled base backups to S3-compatible storage (Garage on TrueNAS at `http://192.168.10.94:30188` (S3 API; `:30186` is the web UI only), same endpoint as Velero).
+PostgreSQL clusters (`homelab-postgres`, `immich-postgres`) use **Barman Cloud** via `barmanObjectStore` for continuous WAL archiving and scheduled base backups to S3-compatible storage (Garage on TrueNAS at `http://192.168.10.94:30188` (S3 API; `:30186` is the web UI only), same endpoint as Velero).
 
 ## Prerequisites
 
@@ -13,7 +13,7 @@ Central PostgreSQL (`homelab-postgres`) uses **Barman Cloud** via `barmanObjectS
 Flux path: `./infrastructure/overlays/main`
 
 - WAL archived continuously (`archive_timeout` default ~5 min RPO)
-- `ScheduledBackup` `homelab-postgres-daily` at 02:30 UTC
+- `ScheduledBackup` `homelab-postgres-daily` and `immich-postgres-daily` at 02:30 UTC
 - Retention: `30d` on object store
 
 Verify:
@@ -46,13 +46,19 @@ Commit/push or patch locally, then reconcile:
 flux reconcile kustomization infra-main --with-source
 ```
 
-The DR overlay applies [`patches/cluster-recovery.yaml`](../../infrastructure/overlays/disaster-recovery/patches/cluster-recovery.yaml), injecting `bootstrap.recovery` from S3.
+The DR overlay applies recovery patches for both clusters:
+
+- [`patches/cluster-recovery.yaml`](../../infrastructure/overlays/disaster-recovery/patches/cluster-recovery.yaml) — `homelab-postgres`
+- [`patches/cluster-recovery-immich.yaml`](../../infrastructure/overlays/disaster-recovery/patches/cluster-recovery-immich.yaml) — `immich-postgres`
+
+Each injects `bootstrap.recovery` from its S3 prefix under `cnpg-backups/`.
 
 ### 3. Wait for CNPG recovery
 
 ```bash
 kubectl wait --for=condition=Ready cluster/homelab-postgres -n cnpg-system --timeout=30m
-kubectl get cluster -n cnpg-system homelab-postgres -o yaml | grep -A5 phase
+kubectl wait --for=condition=Ready cluster/immich-postgres -n cnpg-system --timeout=30m
+kubectl get cluster -n cnpg-system homelab-postgres immich-postgres -o custom-columns=NAME:.metadata.name,PHASE:.status.phase,READY:.status.conditions[?(@.type==\'Ready\')].status
 ```
 
 Managed roles and `Database` CRs reconcile after the cluster becomes primary.

--- a/infrastructure/overlays/disaster-recovery/kustomization.yaml
+++ b/infrastructure/overlays/disaster-recovery/kustomization.yaml
@@ -10,3 +10,8 @@ patches:
       kind: Cluster
       name: homelab-postgres
       namespace: cnpg-system
+  - path: patches/cluster-recovery-immich.yaml
+    target:
+      kind: Cluster
+      name: immich-postgres
+      namespace: cnpg-system

--- a/infrastructure/overlays/disaster-recovery/patches/cluster-recovery-immich.yaml
+++ b/infrastructure/overlays/disaster-recovery/patches/cluster-recovery-immich.yaml
@@ -1,0 +1,26 @@
+# Strategic merge: bootstrap from latest Barman backup in S3 (see docs/disaster-recovery/cnpg-s3-dr.md)
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: immich-postgres
+  namespace: cnpg-system
+spec:
+  bootstrap:
+    recovery:
+      source: immich-postgres
+  externalClusters:
+    - name: immich-postgres
+      barmanObjectStore:
+        destinationPath: s3://cnpg-backups/immich-postgres
+        endpointURL: http://192.168.10.94:30188
+        serverName: immich-postgres
+        s3Credentials:
+          accessKeyId:
+            name: cnpg-barman-s3-credentials
+            key: ACCESS_KEY_ID
+          secretAccessKey:
+            name: cnpg-barman-s3-credentials
+            key: ACCESS_SECRET_KEY
+        wal:
+          compression: gzip
+          maxParallel: 4


### PR DESCRIPTION
Mirror homelab-postgres DR patch so both CNPG clusters bootstrap via Barman recovery when the disaster-recovery overlay is active.