### PR TITLE
fix(renovate): normalize Forgejo action dep names

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -54,7 +54,7 @@
         "/^\\.(forgejo|github)/workflows/.*\\.ya?ml$/"
       ],
       "matchStrings": [
-        "uses:\\s*(?<depName>[^@\\s]+)@(?<currentValue>[^\\s#]+)"
+        "uses:\\s*(?:https://github\\.com/)?(?<depName>[^@\\s/]+/[^@\\s]+)@(?<currentValue>[^\\s#]+)"
       ],
       "datasourceTemplate": "github-tags"
     }


### PR DESCRIPTION
Strip optional https://github.com/ prefix in workflow action regex so github-tags resolves owner/repo instead of full URL (fixes install-nix-action lookup).