### PR TITLE
feat(netbird): expose cluster via mesh routing peers

### DIFF
--- a/apps/base/netbird/daemonset.yaml
+++ b/apps/base/netbird/daemonset.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: netbird
+  namespace: netbird
+spec:
+  selector:
+    matchLabels:
+      app: netbird
+  template:
+    metadata:
+      labels:
+        app: netbird
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      priorityClassName: homelab-infrastructure
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: netbird
+          image: netbirdio/netbird:0.35.7
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: NB_SETUP_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: netbird-setup
+                  key: setup-key
+            - name: NB_MANAGEMENT_URL
+              value: https://netbird.f4mily.net
+            - name: NB_HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: NB_LOG_LEVEL
+              value: info
+          securityContext:
+            privileged: true
+            capabilities:
+              add:
+                - NET_ADMIN
+                - SYS_ADMIN
+                - SYS_RESOURCE
+          livenessProbe:
+            exec:
+              command: ["netbird", "status", "--check", "live"]
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 5
+          readinessProbe:
+            exec:
+              command: ["netbird", "status", "--check", "ready"]
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 5
+          startupProbe:
+            exec:
+              command: ["netbird", "status", "--check", "startup"]
+            periodSeconds: 5
+            timeoutSeconds: 10
+            failureThreshold: 30
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 128Mi

--- a/apps/base/netbird/kustomization.yaml
+++ b/apps/base/netbird/kustomization.yaml
@@ -2,4 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yaml
-# Netbird Client: hostNetwork in overlays/main konfigurieren
+  - netbird-setup.secret.yaml
+  - daemonset.yaml

--- a/apps/base/netbird/netbird-setup.secret.yaml
+++ b/apps/base/netbird/netbird-setup.secret.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+data:
+    setup-key: ENC[AES256_GCM,data:M4Adjz1HpilV27/wdF4SMj34QqQ1ULszg6gSRyfsiTe3eDdkvo6ybyDLTSu0FArL,iv:s4laMVtfqEetiXioBWYWBKpr36IZ5PsezpNI241r/gI=,tag:3wfX9AjC73usLzPMNvUCNw==,type:str]
+kind: Secret
+metadata:
+    name: netbird-setup
+    namespace: netbird
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3QVZnN1Zib05KMmd6K1BN
+            L1ZpbWFoM2krSWUxM1RQeWFOREJuUDN2eVZZCnRvOFVFYm1pNFhUR2I2L1JVaWxV
+            SHpCaHMzWEZuczE3a1ZlUmhXai9zZHMKLS0tIDVSMThHS01BR0x1a3lLWll1Sytv
+            Q1g5cE9JUUhuUERSRU1hV2Q4MTRBTUUKUy3uFWnuKqaybwdXVdp/0GYWOSH7FJxo
+            RGo9DyHJpOxXOov2KKjMml9EcFv26vYA6MOBSwWXGTKOJgB3oQRAiw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1u5lcvuuwd4lk7f3xewjk70j75yuh68myr89qkd0e8d44zgyjleeqw03vqs
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-05-20T08:29:00Z"
+    mac: ENC[AES256_GCM,data:x0nqR0J6b0GVBoa4MF1hDvtoFsi2f7iopVj3uokaJP/oCbUp+L22yme9P/EStm/NjykaVTrEoUkXjWNjoNgXYh9UerEFJtPADzYLUBj7nB5xx6eWTXeIHJ/eJjCs8zugW6hlO3tEabCfgo1iOB+swaZN6TDF9aCSaFkZedBBZf0=,iv:K6Rb1JoYyJxA5it3TiH+mj293E2p8ADVUZe9Yamr0hU=,tag:QBpm4rtgVUlai7HVi/UZfg==,type:str]
+    version: 3.13.0

--- a/apps/base/netbird/netbird-setup.secret.yaml.template
+++ b/apps/base/netbird/netbird-setup.secret.yaml.template
@@ -1,0 +1,6 @@
+# Netbird setup key (reusable + ephemeral peers recommended for Kubernetes).
+#
+#   cd apps/base/netbird
+#   just sops-create netbird-setup netbird setup-key="YOUR-SETUP-KEY-UUID"
+#
+# Dashboard: https://netbird.f4mily.net — assign peers to group used in Network Routes.

--- a/apps/overlays/main/kustomization.yaml
+++ b/apps/overlays/main/kustomization.yaml
@@ -28,7 +28,7 @@ resources:
   - ../../base/immich
 
   # --- Infrastructure & Tools -------------------------------------------
-  # - ../../base/netbird             # wip: namespace only, no workload
+  - ../../base/netbird
   # - ../../base/backrest            # wip: ingress only, no workload
   - ../../base/searxng
   # - ../../base/uptime-kuma         # wip: ingress only, no workload

--- a/docs/applications.md
+++ b/docs/applications.md
@@ -61,7 +61,7 @@ here so it is obvious what is **planned** but not deployed:
 | App                | Status | Reason                                    |
 |--------------------|--------|-------------------------------------------|
 | tandoor            | wip    | ingress only, missing HelmRelease         |
-| netbird            | wip    | namespace only                            |
+| netbird            | on     | DaemonSet (hostNetwork), routing to cluster |
 | backrest           | wip    | ingress only, missing HelmRelease         |
 | searxng            | on     | Deployment + ingress at search.f4mily.net |
 | uptime-kuma        | wip    | ingress only, missing Deployment          |

--- a/docs/cluster-access.md
+++ b/docs/cluster-access.md
@@ -73,6 +73,8 @@ sops -d infrastructure/base/sources/hetzner.secret.yaml
 For day-to-day secret operations there are `just` helpers in this repo
 (`just sops-edit`, `just sops-create`, `just barman-s3-credentials`, …).
 
+Netbird-Mesh-Zugriff auf den Cluster: siehe [netbird-cluster-access.md](netbird-cluster-access.md).
+
 ## 5. Talos administration
 
 ```bash

--- a/docs/netbird-cluster-access.md
+++ b/docs/netbird-cluster-access.md
@@ -1,0 +1,50 @@
+# Netbird — Cluster-Zugriff
+
+Der Homelab-Cluster tritt dem selbst gehosteten Netbird-Management unter
+**https://netbird.f4mily.net** bei. Pro Node läuft ein Netbird-Client als
+`DaemonSet` mit `hostNetwork` (Namespace `netbird`).
+
+## GitOps
+
+| Ressource | Beschreibung |
+|-----------|--------------|
+| `apps/base/netbird/daemonset.yaml` | Client auf jedem Node |
+| `apps/base/netbird/netbird-setup.secret.yaml` | Setup-Key (SOPS) |
+
+## Netbird Dashboard (manuell)
+
+Nach dem ersten Peer-Join im Dashboard konfigurieren:
+
+### 1. Setup-Key / Gruppe
+
+Der Setup-Key sollte **reusable** und **ephemeral peers** nutzen. Weise Peers der Gruppe **`kubernetes-routers`** (oder deiner Wahl) zu.
+
+### 2. Network Routes
+
+Leite diese Netze über die Peer-Gruppe der Kubernetes-Router:
+
+| Zielnetz | Zweck |
+|----------|--------|
+| `10.244.0.0/16` | Pod-CIDR |
+| `10.96.0.0/12` | Service-CIDR |
+| `192.168.10.0/24` | Node-LAN (API `192.168.10.245`, Ingress hostNetwork) |
+
+Distribution: Gruppe deiner Netbird-Clients (z. B. alle verbundenen Geräte).
+
+### 3. Access Control
+
+Policy: Quelle = deine Client-Gruppe, Ziel = `kubernetes-routers` (oder breiter nach Bedarf).
+
+## Erreichbarkeit
+
+- **Kubernetes-API:** `https://192.168.10.245:6443` (über Route zum LAN)
+- **Ingress-Apps:** `*.f4mily.net` / `*.cluster.f4mily.net` → DNS zeigt auf `192.168.10.245` (siehe `homelab-infrastructure/dns/servers.tf`)
+
+## Prüfen
+
+```bash
+kubectl get pods -n netbird -o wide
+kubectl logs -n netbird -l app=netbird --tail=20
+```
+
+Im Netbird-Dashboard sollten drei Peers (`talos-cp1` …) als Connected erscheinen.


### PR DESCRIPTION
DaemonSet with hostNetwork joins self-hosted management at netbird.f4mily.net; document dashboard routes for pod, service, and LAN CIDRs.