### PR TITLE
fix(tls): drop ingress-shim cluster-issuer on reflected wildcard ingr…

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -24,9 +24,10 @@ enable/disable, hostname changes, base-domain migration, adding new apps.
 ## Conventions
 
 - Each app lives in **its own namespace** (name = directory name).
-- Ingresses **always** specify `ingressClassName: nginx`,
-  `cert-manager.io/cluster-issuer`, and a wildcard TLS secret
-  (`wildcard-f4mily-net-tls` or `wildcard-cluster-f4mily-net-tls`).
+- Ingresses **always** specify `ingressClassName: nginx` and a reflected
+  wildcard TLS secret (`wildcard-f4mily-net-tls` or `wildcard-cluster-f4mily-net-tls`).
+  **Do not** set `cert-manager.io/cluster-issuer` on Ingresses — central
+  `Certificate` CRs + Reflector issue TLS; ingress-shim would conflict.
 - Pod security: `runAsNonRoot`, `allowPrivilegeEscalation: false`,
   explicit `runAsUser`. See `apps/base/audiobookshelf/deployment.yaml` for
   a reference.

--- a/apps/base/audiobookshelf/deployment.yaml
+++ b/apps/base/audiobookshelf/deployment.yaml
@@ -105,7 +105,6 @@ metadata:
     gethomepage.dev/icon: audiobookshelf.png
     gethomepage.dev/pod-selector: app=audiobookshelf
     # TLS: wildcard-f4mily-net-tls replicated from cert-manager (reflector).
-    # Do not use cert-manager.io/cluster-issuer — ingress-shim conflicts with reflector.
     nginx.org/client-max-body-size: "1000m"
     nginx.org/ssl-redirect: "false"
     nginx.org/redirect-to-https: "true"

--- a/apps/base/authentik/ingress.yaml
+++ b/apps/base/authentik/ingress.yaml
@@ -9,7 +9,6 @@ metadata:
     gethomepage.dev/description: Identity Provider
     gethomepage.dev/group: Tools
     gethomepage.dev/icon: authentik.png
-    cert-manager.io/cluster-issuer: letsencrypt-production
     nginx.org/ssl-redirect: "false"
     nginx.org/redirect-to-https: "true"
 spec:

--- a/apps/base/backrest/ingress.yaml
+++ b/apps/base/backrest/ingress.yaml
@@ -9,7 +9,6 @@ metadata:
     gethomepage.dev/description: Restic backup UI
     gethomepage.dev/group: Infrastructure
     gethomepage.dev/icon: backrest.png
-    cert-manager.io/cluster-issuer: letsencrypt-production
     nginx.org/ssl-redirect: "false"
     nginx.org/redirect-to-https: "true"
 spec:

--- a/apps/base/homepage/ingress.yaml
+++ b/apps/base/homepage/ingress.yaml
@@ -4,7 +4,6 @@ metadata:
   name: homepage
   namespace: homepage
   annotations:
-    cert-manager.io/cluster-issuer: "letsencrypt-production"
     nginx.org/ssl-redirect: "false"
     nginx.org/redirect-to-https: "true"
 spec:

--- a/apps/base/homer/ingress.yaml
+++ b/apps/base/homer/ingress.yaml
@@ -4,34 +4,36 @@ metadata:
   name: homer
   namespace: homer
   annotations:
-    cert-manager.io/cluster-issuer: "letsencrypt-production"
+    # TLS: reflected wildcards — no cluster-issuer (ingress-shim conflicts with reflector).
     nginx.org/ssl-redirect: "false"
     nginx.org/redirect-to-https: "true"
 spec:
   ingressClassName: nginx
   tls:
-  - hosts:
-    - homer.cluster.f4mily.net
-    - f4mily.net
-    secretName: homer-tls
+    - hosts:
+        - homer.cluster.f4mily.net
+      secretName: wildcard-cluster-f4mily-net-tls
+    - hosts:
+        - f4mily.net
+      secretName: wildcard-f4mily-net-tls
   rules:
-  - host: homer.cluster.f4mily.net
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: homer
-            port:
-              number: 80
-  - host: f4mily.net
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: homer
-            port:
-              number: 80
+    - host: homer.cluster.f4mily.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: homer
+                port:
+                  number: 80
+    - host: f4mily.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: homer
+                port:
+                  number: 80

--- a/apps/base/immich/ingress.yaml
+++ b/apps/base/immich/ingress.yaml
@@ -10,7 +10,6 @@ metadata:
     gethomepage.dev/group: Medien
     gethomepage.dev/icon: immich.png
     gethomepage.dev/app: server
-    cert-manager.io/cluster-issuer: letsencrypt-production
     nginx.org/ssl-redirect: "false"
     nginx.org/redirect-to-https: "true"
     nginx.org/proxy-body-size: "0"

--- a/apps/base/jellyfin/ingress.yaml
+++ b/apps/base/jellyfin/ingress.yaml
@@ -10,7 +10,6 @@ metadata:
     gethomepage.dev/group: Medien
     gethomepage.dev/icon: jellyfin.png
     gethomepage.dev/pod-selector: app=jellyfin
-    cert-manager.io/cluster-issuer: letsencrypt-production
     nginx.org/ssl-redirect: "false"
     nginx.org/redirect-to-https: "true"
 spec:

--- a/apps/base/kite/deployment.yaml
+++ b/apps/base/kite/deployment.yaml
@@ -47,8 +47,6 @@ spec:
         gethomepage.dev/group: Infrastructure
         gethomepage.dev/icon: kubernetes.png
         gethomepage.dev/app: kite
-        cert-manager.io/cluster-issuer: letsencrypt-production
-        cert-manager.io/uses-release-name: "true"
         nginx.org/ssl-redirect: "false"
         nginx.org/redirect-to-https: "true"
       hosts:

--- a/apps/base/linkwarden/ingress.yaml
+++ b/apps/base/linkwarden/ingress.yaml
@@ -9,7 +9,6 @@ metadata:
     gethomepage.dev/description: Bookmarks
     gethomepage.dev/group: Cloud & Auth
     gethomepage.dev/icon: linkwarden.png
-    cert-manager.io/cluster-issuer: letsencrypt-production
     nginx.org/ssl-redirect: "false"
     nginx.org/redirect-to-https: "true"
 spec:

--- a/apps/base/monitoring/vm-k8s-stack/ingress-grafana.yaml
+++ b/apps/base/monitoring/vm-k8s-stack/ingress-grafana.yaml
@@ -10,7 +10,7 @@ metadata:
     gethomepage.dev/group: Infrastructure
     gethomepage.dev/app: grafana
     gethomepage.dev/icon: grafana.png
-    cert-manager.io/cluster-issuer: letsencrypt-production
+    # TLS: wildcard-cluster-f4mily-net-tls via reflector (no cluster-issuer).
     nginx.org/ssl-redirect: "false"
     nginx.org/redirect-to-https: "true"
   labels:
@@ -20,7 +20,7 @@ spec:
   tls:
     - hosts:
         - grafana.cluster.f4mily.net
-      secretName: grafana-tls
+      secretName: wildcard-cluster-f4mily-net-tls
   rules:
     - host: grafana.cluster.f4mily.net
       http:

--- a/apps/base/monitoring/vm-k8s-stack/ingress-victoria-metrics.yaml
+++ b/apps/base/monitoring/vm-k8s-stack/ingress-victoria-metrics.yaml
@@ -10,7 +10,7 @@ metadata:
     gethomepage.dev/group: Infrastructure
     gethomepage.dev/icon: victoriametrics.png
     gethomepage.dev/app: vmsingle
-    cert-manager.io/cluster-issuer: letsencrypt-production
+    # TLS: wildcard-cluster-f4mily-net-tls via reflector (no cluster-issuer).
     nginx.org/ssl-redirect: "false"
     nginx.org/redirect-to-https: "true"
   labels:
@@ -20,7 +20,7 @@ spec:
   tls:
     - hosts:
         - metrics.cluster.f4mily.net
-      secretName: victoria-metrics-tls
+      secretName: wildcard-cluster-f4mily-net-tls
   rules:
     - host: metrics.cluster.f4mily.net
       http:

--- a/apps/base/n8n/ingress.yaml
+++ b/apps/base/n8n/ingress.yaml
@@ -11,7 +11,7 @@ metadata:
     gethomepage.dev/group: Tools
     gethomepage.dev/icon: n8n.png
     gethomepage.dev/app: n8n
-    cert-manager.io/cluster-issuer: letsencrypt-production
+    # TLS: wildcard-cluster-f4mily-net-tls via reflector (no cluster-issuer).
     nginx.org/ssl-redirect: "false"
     nginx.org/redirect-to-https: "true"
     # Webhook POST bodies can be large (full AM payload + LLM context)

--- a/apps/base/nextcloud/ingress.yaml
+++ b/apps/base/nextcloud/ingress.yaml
@@ -9,7 +9,6 @@ metadata:
     gethomepage.dev/description: File sharing
     gethomepage.dev/group: Office
     gethomepage.dev/icon: nextcloud.png
-    cert-manager.io/cluster-issuer: letsencrypt-production
     nginx.org/ssl-redirect: "false"
     nginx.org/redirect-to-https: "true"
     nginx.org/proxy-body-size: "0"

--- a/apps/base/paperless-ngx/ingress.yaml
+++ b/apps/base/paperless-ngx/ingress.yaml
@@ -10,7 +10,6 @@ metadata:
     gethomepage.dev/group: Office
     gethomepage.dev/icon: paperless-ngx.png
     gethomepage.dev/app: paperless-ngx
-    cert-manager.io/cluster-issuer: letsencrypt-production
     nginx.org/ssl-redirect: "false"
     nginx.org/redirect-to-https: "true"
 spec:

--- a/apps/base/pcm/ingress.yaml
+++ b/apps/base/pcm/ingress.yaml
@@ -9,7 +9,6 @@ metadata:
     gethomepage.dev/description: PCM
     gethomepage.dev/group: Development
     gethomepage.dev/icon: mdi-tune-vertical
-    cert-manager.io/cluster-issuer: letsencrypt-production
     nginx.org/ssl-redirect: "false"
     nginx.org/redirect-to-https: "true"
 spec:

--- a/apps/base/searxng/ingress.yaml
+++ b/apps/base/searxng/ingress.yaml
@@ -9,7 +9,6 @@ metadata:
     gethomepage.dev/description: Privacy search
     gethomepage.dev/group: Tools
     gethomepage.dev/icon: searxng.png
-    cert-manager.io/cluster-issuer: letsencrypt-production
     nginx.org/ssl-redirect: "false"
     nginx.org/redirect-to-https: "true"
 spec:

--- a/apps/base/speedtest-tracker/ingress.yaml
+++ b/apps/base/speedtest-tracker/ingress.yaml
@@ -9,7 +9,6 @@ metadata:
     gethomepage.dev/description: Speed tests
     gethomepage.dev/group: Infrastructure
     gethomepage.dev/icon: speedtest-tracker.png
-    cert-manager.io/cluster-issuer: letsencrypt-production
     nginx.org/ssl-redirect: "false"
     nginx.org/redirect-to-https: "true"
 spec:

--- a/apps/base/tandoor/ingress.yaml
+++ b/apps/base/tandoor/ingress.yaml
@@ -9,7 +9,6 @@ metadata:
     gethomepage.dev/description: Recipes
     gethomepage.dev/group: Medien
     gethomepage.dev/icon: tandoor-recipes.png
-    cert-manager.io/cluster-issuer: letsencrypt-production
     nginx.org/ssl-redirect: "false"
     nginx.org/redirect-to-https: "true"
 spec:

--- a/apps/base/teslamate/ingress-grafana.yaml
+++ b/apps/base/teslamate/ingress-grafana.yaml
@@ -11,7 +11,6 @@ metadata:
     gethomepage.dev/icon: grafana.png
     gethomepage.dev/app: teslamate-grafana
     gethomepage.dev/pod-selector: app=teslamate-grafana
-    cert-manager.io/cluster-issuer: letsencrypt-production
     nginx.org/ssl-redirect: "false"
     nginx.org/redirect-to-https: "true"
 spec:

--- a/apps/base/teslamate/ingress.yaml
+++ b/apps/base/teslamate/ingress.yaml
@@ -11,7 +11,6 @@ metadata:
     gethomepage.dev/icon: teslamate.png
     gethomepage.dev/app: teslamate
     gethomepage.dev/pod-selector: app=teslamate
-    cert-manager.io/cluster-issuer: letsencrypt-production
     nginx.org/ssl-redirect: "false"
     nginx.org/redirect-to-https: "true"
 spec:

--- a/apps/base/unifi-controller/ingress.yaml
+++ b/apps/base/unifi-controller/ingress.yaml
@@ -9,7 +9,6 @@ metadata:
     gethomepage.dev/description: Network controller
     gethomepage.dev/group: Infrastructure
     gethomepage.dev/icon: unifi.png
-    cert-manager.io/cluster-issuer: letsencrypt-production
     nginx.org/ssl-redirect: "false"
     nginx.org/redirect-to-https: "true"
 spec:

--- a/apps/base/uptime-kuma/ingress.yaml
+++ b/apps/base/uptime-kuma/ingress.yaml
@@ -9,7 +9,6 @@ metadata:
     gethomepage.dev/description: Uptime monitoring
     gethomepage.dev/group: Infrastructure
     gethomepage.dev/icon: uptime-kuma.png
-    cert-manager.io/cluster-issuer: letsencrypt-production
     nginx.org/ssl-redirect: "false"
     nginx.org/redirect-to-https: "true"
 spec:

--- a/apps/base/watchyourlan/ingress.yaml
+++ b/apps/base/watchyourlan/ingress.yaml
@@ -9,7 +9,6 @@ metadata:
     gethomepage.dev/description: LAN discovery
     gethomepage.dev/group: Infrastructure
     gethomepage.dev/icon: watchyourlan.png
-    cert-manager.io/cluster-issuer: letsencrypt-production
     nginx.org/ssl-redirect: "false"
     nginx.org/redirect-to-https: "true"
 spec:

--- a/infrastructure/base/storage/ingress.yaml
+++ b/infrastructure/base/storage/ingress.yaml
@@ -10,7 +10,7 @@ metadata:
     gethomepage.dev/group: Infrastructure
     gethomepage.dev/icon: longhorn.png
     gethomepage.dev/app: longhorn
-    cert-manager.io/cluster-issuer: "letsencrypt-production"
+    # TLS: wildcard-cluster-f4mily-net-tls via reflector (no cluster-issuer).
     nginx.org/client-max-body-size: "1000m"
     nginx.org/ssl-redirect: "false"
     nginx.org/redirect-to-https: "true"


### PR DESCRIPTION
…esses

Central Certificate CRs + Reflector own TLS. Per-ingress issuer annotations caused duplicate ACME orders and unstable secrets. Grafana/VMUI and Homer now use wildcard secrets; Homer uses split tls for cluster vs apex domain.