### PR TITLE
fix(n8n): pin 1.123.46, env-based workflow, just n8n-bootstrap

### DIFF
--- a/apps/base/n8n/helmrelease.yaml
+++ b/apps/base/n8n/helmrelease.yaml
@@ -20,6 +20,9 @@ spec:
       valuesKey: encryption-key
       targetPath: main.secret.n8n.encryption_key
   values:
+    image:
+      repository: n8nio/n8n
+      tag: "1.123.46"
     # Service MUST NOT be named "n8n" — K8s injects N8N_PORT=tcp://… and breaks the listener (502).
     # DNS: n8n-app.ai-ops.svc.cluster.local
     fullnameOverride: n8n-app

--- a/apps/base/n8n/workflows/README.md
+++ b/apps/base/n8n/workflows/README.md
@@ -1,10 +1,17 @@
 # n8n Workflows (AI-Ops)
 
-| Workflow | File | Trigger |
-|----------|------|---------|
-| GitOps auto-remediation | `homelab-gitops-remediation.workflow.json` | `POST /webhook/vmalert` (Alertmanager) |
-| Alert triage (Telegram) | `../monitoring/n8n-workflows/homelab-alert-triage.workflow.json` | SOPS URL in monitoring |
+| Workflow | File | Trigger | Credentials |
+|----------|------|---------|-------------|
+| GitOps auto-remediation | `homelab-gitops-remediation.workflow.json` | `POST /webhook/vmalert` | **None in UI** — uses `$env` from `n8n-integration-credentials` |
+| Alert triage (Telegram) | `../monitoring/n8n-workflows/homelab-alert-triage.workflow.json` | SOPS URL in monitoring | Manual: OpenAI + Telegram in n8n UI |
 
-Import in n8n UI → activate → set OpenAI + GitHub PAT (Bearer) credentials.
+## After deploy / upgrade
+
+```bash
+export KUBECONFIG=../homelab-infrastructure/talos/kubeconfig
+just n8n-bootstrap
+```
+
+Imports (or updates) the GitOps workflow and activates it. LLM + GitHub use `LLM_API_KEY`, `LLM_BASE_URL`, `GITHUB_TOKEN` from the HelmRelease / Secret.
 
 Full guide: [`docs/integrations/alerting-n8n-gitops-remediation.md`](../../../docs/integrations/alerting-n8n-gitops-remediation.md)

--- a/apps/base/n8n/workflows/homelab-gitops-remediation.workflow.json
+++ b/apps/base/n8n/workflows/homelab-gitops-remediation.workflow.json
@@ -1,5 +1,6 @@
 {
   "name": "Homelab GitOps Remediation (VM → LLM → GitHub PR)",
+  "active": true,
   "nodes": [
     {
       "parameters": {
@@ -49,30 +50,17 @@
     },
     {
       "parameters": {
-        "model": "gpt-4o-mini",
-        "options": { "temperature": 0.1, "maxTokens": 2500 },
-        "messages": {
-          "values": [
-            {
-              "role": "system",
-              "content": "Du bist ein Kubernetes GitOps Engineer. Antworte NUR mit gültigem JSON (kein Markdown, kein ```):\n{\n  \"action\": \"patch|noop|needs_human\",\n  \"risk\": \"low|medium|high\",\n  \"summary_de\": \"string\",\n  \"target_file\": \"relativer Pfad unter gitops-homelab/ (z.B. apps/base/foo/patches/auto-oom.yaml)\",\n  \"patch_yaml\": \"multi-line YAML: Kustomize strategic merge patch ODER neue kleine Manifest-Datei\",\n  \"pr_title\": \"string\",\n  \"pr_body\": \"string (Markdown)\"\n}\n\nRegeln:\n- Nur Änderungen unter gitops-homelab/ im Repo homelab-gitops (GitHub); niemals kubectl apply.\n- Bevorzuge NEUE Patch-Dateien unter apps/base/<app>/patches/ statt bestehende Deployments zu überschreiben.\n- Erlaubte Fixes: memory limits/requests, envFrom, imagePullPolicy, offensichtliche Config-Fehler.\n- Bei OOMKilled: +25–50% memory limit wenn plausibel.\n- Bei CrashLoopBackOff: keine blinden image-tag-Downgrades.\n- action=noop wenn unklar; needs_human bei StatefulSet/CNPG/DB/Velero.\n- patch_yaml muss gültiges Kubernetes YAML sein."
-            },
-            {
-              "content": "=Alert: {{ $json.alertname }}\nNamespace: {{ $json.namespace }}\nPod: {{ $json.pod }}\nContainer: {{ $json.container }}\nError: {{ $json.error }}\nSummary: {{ $json.summary }}\nDescription: {{ $json.description }}\nRunbook: {{ $json.runbookUrl }}\n\nMonorepo layout: gitops-homelab/apps/base/<app>/"
-            }
-          ]
-        }
+        "jsCode": "const alert = $('Parse VM Payload').first().json;\nconst base = ($env.LLM_BASE_URL || 'https://api.openai.com/v1').replace(/\\/$/, '');\nconst system = `Du bist ein Kubernetes GitOps Engineer. Antworte NUR mit gültigem JSON (kein Markdown, kein \\`\\`\\`):\n{\n  \"action\": \"patch|noop|needs_human\",\n  \"risk\": \"low|medium|high\",\n  \"summary_de\": \"string\",\n  \"target_file\": \"relativer Pfad unter gitops-homelab/\",\n  \"patch_yaml\": \"multi-line YAML\",\n  \"pr_title\": \"string\",\n  \"pr_body\": \"string (Markdown)\"\n}\nRegeln: nur gitops-homelab/ im Repo homelab-gitops; neue Dateien unter apps/base/<app>/patches/ bevorzugen; kein kubectl apply.`;\nconst user = `Alert: ${alert.alertname}\\nNamespace: ${alert.namespace}\\nPod: ${alert.pod}\\nContainer: ${alert.container}\\nError: ${alert.error}\\nSummary: ${alert.summary}\\nDescription: ${alert.description}`;\nconst res = await this.helpers.httpRequest({\n  method: 'POST',\n  url: `${base}/chat/completions`,\n  headers: {\n    Authorization: `Bearer ${$env.LLM_API_KEY}`,\n    'Content-Type': 'application/json',\n  },\n  body: {\n    model: 'gpt-4o-mini',\n    temperature: 0.1,\n    max_tokens: 2500,\n    messages: [\n      { role: 'system', content: system },\n      { role: 'user', content: user },\n    ],\n  },\n  json: true,\n});\nconst content = res?.choices?.[0]?.message?.content ?? '';\nreturn [{ json: { message: { content } } } }];"
       },
       "id": "a1000001-0001-4000-8000-000000000004",
       "name": "LLM Kustomize Patch",
-      "type": "@n8n/n8n-nodes-langchain.openAi",
-      "typeVersion": 1.8,
-      "position": [780, 420],
-      "credentials": { "openAiApi": { "id": "CONFIGURE_ME", "name": "OpenAI Homelab" } }
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [780, 420]
     },
     {
       "parameters": {
-        "jsCode": "const alert = $('Parse VM Payload').first().json;\nconst api = ($env.GITHUB_API_URL || 'https://api.github.com').replace(/\\/$/, '');\nlet plan = {};\ntry {\n  const raw = $input.first().json.message?.content ?? $input.first().json.text ?? '';\n  const m = String(raw).match(/\\{[\\s\\S]*\\}/);\n  plan = m ? JSON.parse(m[0]) : { action: 'needs_human', summary_de: 'LLM nicht parsebar' };\n} catch (e) {\n  plan = { action: 'needs_human', summary_de: 'LLM parse error: ' + e.message };\n}\nif (plan.action !== 'patch' || !plan.patch_yaml || !plan.target_file) {\n  return [{ json: { ...alert, plan, proceed: false, api } }];\n}\nconst slug = `${alert.namespace}-${alert.pod}`.replace(/[^a-zA-Z0-9-]/g, '-').slice(0, 40);\nconst branch = `auto/remediate-${slug}-${Date.now().toString(36)}`;\nconst owner = $env.GITHUB_REPO_OWNER || 'kreativmonkey';\nconst repo = $env.GITHUB_REPO_NAME || 'homelab-gitops';\nconst base = $env.GITHUB_DEFAULT_BRANCH || 'main';\nconst manifestsPath = $env.GITOPS_MANIFESTS_PATH || 'gitops-homelab';\nconst filePath = plan.target_file.startsWith(manifestsPath)\n  ? plan.target_file\n  : `${manifestsPath}/${plan.target_file.replace(/^\\/+/, '')}`;\nreturn [{\n  json: {\n    ...alert,\n    plan,\n    proceed: true,\n    api,\n    branch,\n    owner,\n    repo,\n    base,\n    filePath,\n    contentB64: Buffer.from(plan.patch_yaml, 'utf8').toString('base64'),\n    commitMessage: `fix(auto): ${alert.alertname} ${alert.namespace}/${alert.pod}`,\n    repoApi: `${api}/repos/${owner}/${repo}`,\n  },\n}];"
+        "jsCode": "const alert = $('Parse VM Payload').first().json;\nconst api = ($env.GITHUB_API_URL || 'https://api.github.com').replace(/\\/$/, '');\nlet plan = {};\ntry {\n  const raw = $input.first().json.message?.content ?? $input.first().json.text ?? '';\n  const m = String(raw).match(/\\{[\\s\\S]*\\}/);\n  plan = m ? JSON.parse(m[0]) : { action: 'needs_human', summary_de: 'LLM nicht parsebar' };\n} catch (e) {\n  plan = { action: 'needs_human', summary_de: 'LLM parse error: ' + e.message };\n}\nif (plan.action !== 'patch' || !plan.patch_yaml || !plan.target_file) {\n  return [{ json: { ...alert, plan, proceed: false, api } }];\n}\nconst slug = `${alert.namespace}-${alert.pod}`.replace(/[^a-zA-Z0-9-]/g, '-').slice(0, 40);\nconst branch = `auto/remediate-${slug}-${Date.now().toString(36)}`;\nconst owner = $env.GITHUB_REPO_OWNER || 'kreativmonkey';\nconst repo = $env.GITHUB_REPO_NAME || 'homelab-gitops';\nconst base = $env.GITHUB_DEFAULT_BRANCH || 'main';\nconst manifestsPath = $env.GITOPS_MANIFESTS_PATH || 'gitops-homelab';\nconst filePath = plan.target_file.startsWith(manifestsPath)\n  ? plan.target_file\n  : `${manifestsPath}/${plan.target_file.replace(/^\\/+/, '')}`;\nreturn [{\n  json: {\n    ...alert,\n    plan,\n    proceed: true,\n    api,\n    branch,\n    owner,\n    repo,\n    base,\n    filePath,\n    contentB64: Buffer.from(plan.patch_yaml, 'utf8').toString('base64'),\n    commitMessage: `fix(auto): ${alert.alertname} ${alert.namespace}/${alert.pod}`,\n    repoApi: `${api}/repos/${owner}/${repo}`,\n    githubAuth: `Bearer ${$env.GITHUB_TOKEN}`,\n  },\n}];"
       },
       "id": "a1000001-0001-4000-8000-000000000005",
       "name": "Plan PR",
@@ -105,28 +93,46 @@
     {
       "parameters": {
         "url": "={{ $json.repoApi }}/git/ref/heads/{{ $json.base }}",
-        "authentication": "genericCredentialType",
-        "genericAuthType": "httpHeaderAuth",
+        "authentication": "none",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "={{ $('Plan PR').item.json.githubAuth }}"
+            },
+            {
+              "name": "Accept",
+              "value": "application/vnd.github+json"
+            }
+          ]
+        },
         "options": { "timeout": 30000 }
       },
       "id": "a1000001-0001-4000-8000-000000000007",
       "name": "GitHub Get Base SHA",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [1520, 320],
-      "credentials": {
-        "httpHeaderAuth": {
-          "id": "CONFIGURE_ME",
-          "name": "GitHub PAT"
-        }
-      }
+      "position": [1520, 320]
     },
     {
       "parameters": {
         "method": "POST",
         "url": "={{ $('Plan PR').item.json.repoApi }}/git/refs",
-        "authentication": "genericCredentialType",
-        "genericAuthType": "httpHeaderAuth",
+        "authentication": "none",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "={{ $('Plan PR').item.json.githubAuth }}"
+            },
+            {
+              "name": "Accept",
+              "value": "application/vnd.github+json"
+            }
+          ]
+        },
         "sendBody": true,
         "specifyBody": "json",
         "jsonBody": "={\"ref\":\"refs/heads/{{ $('Plan PR').item.json.branch }}\",\"sha\":\"{{ $json.object.sha }}\"}",
@@ -136,20 +142,26 @@
       "name": "GitHub Create Branch",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [1760, 320],
-      "credentials": {
-        "httpHeaderAuth": {
-          "id": "CONFIGURE_ME",
-          "name": "GitHub PAT"
-        }
-      }
+      "position": [1760, 320]
     },
     {
       "parameters": {
         "method": "PUT",
         "url": "={{ $('Plan PR').item.json.repoApi }}/contents/{{ encodeURIComponent($('Plan PR').item.json.filePath) }}",
-        "authentication": "genericCredentialType",
-        "genericAuthType": "httpHeaderAuth",
+        "authentication": "none",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "={{ $('Plan PR').item.json.githubAuth }}"
+            },
+            {
+              "name": "Accept",
+              "value": "application/vnd.github+json"
+            }
+          ]
+        },
         "sendBody": true,
         "specifyBody": "json",
         "jsonBody": "={\"message\":\"{{ $('Plan PR').item.json.commitMessage }}\",\"content\":\"{{ $('Plan PR').item.json.contentB64 }}\",\"branch\":\"{{ $('Plan PR').item.json.branch }}\"}",
@@ -159,20 +171,26 @@
       "name": "GitHub Put File",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [2000, 320],
-      "credentials": {
-        "httpHeaderAuth": {
-          "id": "CONFIGURE_ME",
-          "name": "GitHub PAT"
-        }
-      }
+      "position": [2000, 320]
     },
     {
       "parameters": {
         "method": "POST",
         "url": "={{ $('Plan PR').item.json.repoApi }}/pulls",
-        "authentication": "genericCredentialType",
-        "genericAuthType": "httpHeaderAuth",
+        "authentication": "none",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "={{ $('Plan PR').item.json.githubAuth }}"
+            },
+            {
+              "name": "Accept",
+              "value": "application/vnd.github+json"
+            }
+          ]
+        },
         "sendBody": true,
         "specifyBody": "json",
         "jsonBody": "={\"title\":\"{{ $('Plan PR').item.json.plan.pr_title || $('Plan PR').item.json.commitMessage }}\",\"head\":\"{{ $('Plan PR').item.json.branch }}\",\"base\":\"{{ $('Plan PR').item.json.base }}\",\"body\":\"{{ ($('Plan PR').item.json.plan.pr_body || $('Plan PR').item.json.plan.summary_de || '').replace(/\"/g, '\\\\\"') }}\\n\\n---\\nAuto-remediation for **{{ $('Plan PR').item.json.alertname }}** in `{{ $('Plan PR').item.json.namespace }}/{{ $('Plan PR').item.json.pod }}`.\"}",
@@ -182,19 +200,13 @@
       "name": "GitHub Open PR",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [2240, 320],
-      "credentials": {
-        "httpHeaderAuth": {
-          "id": "CONFIGURE_ME",
-          "name": "GitHub PAT"
-        }
-      }
+      "position": [2240, 320]
     },
     {
       "parameters": {
-        "content": "## GitHub PAT (HTTP Header Auth)\n\nName: `GitHub PAT`\n- Header: `Authorization`\n- Value: `Bearer <github_pat_…>`\n\nScopes (classic): `repo`\\nFine-grained: Contents + Pull requests **Read and write** on `kreativmonkey/homelab-gitops`.\n\nRepo: https://github.com/kreativmonkey/homelab-gitops (paths under `gitops-homelab/`).\n\n## Test\n```bash\ncurl -sS -X POST http://n8n-app.ai-ops.svc.cluster.local:5678/webhook/vmalert \\\n  -H 'Content-Type: application/json' \\\n  -d '{\"status\":\"firing\",\"alerts\":[{\"labels\":{\"alertname\":\"KubePodCrashLoopBackOff\",\"namespace\":\"default\",\"pod\":\"demo\",\"container\":\"app\",\"homelab/auto_remediate\":\"true\"},\"annotations\":{\"summary\":\"test\"}}]}'\n```",
-        "height": 380,
-        "width": 440
+        "content": "## GitOps Remediation (env-based)\n\nUses K8s secrets via `$env` (no n8n Credentials UI):\n- `LLM_API_KEY`, `LLM_BASE_URL`\n- `GITHUB_TOKEN`\n\nBootstrap: `just n8n-bootstrap` after deploy.",
+        "height": 200,
+        "width": 380
       },
       "id": "a1000001-0001-4000-8000-00000000000b",
       "name": "Sticky Note",
@@ -225,5 +237,5 @@
     "GitHub Put File": { "main": [[{ "node": "GitHub Open PR", "type": "main", "index": 0 }]] }
   },
   "settings": { "executionOrder": "v1" },
-  "meta": { "templateCredsSetupCompleted": false }
+  "meta": { "templateCredsSetupCompleted": true }
 }

--- a/docs/integrations/alerting-n8n-gitops-remediation.md
+++ b/docs/integrations/alerting-n8n-gitops-remediation.md
@@ -48,9 +48,14 @@ Webhook (in-cluster): `http://n8n-app.ai-ops.svc.cluster.local:5678/webhook/vmal
      llm-base-url='https://api.openai.com/v1'
    ```
 
-2. Uncomment both `*.secret.yaml` in `kustomization.yaml`.
-3. Import `apps/base/n8n/workflows/homelab-gitops-remediation.workflow.json`.
-4. n8n credential **GitHub PAT**: Header `Authorization` = `Bearer <token>`.
+2. Ensure both `*.secret.yaml` are listed in `kustomization.yaml`.
+3. Flux reconcile; n8n image is pinned in HelmRelease (`n8nio/n8n:1.123.46`).
+4. Import workflow (uses pod env — **no** n8n Credentials UI for GitOps flow):
+
+   ```bash
+   export KUBECONFIG=../homelab-infrastructure/talos/kubeconfig
+   just n8n-bootstrap
+   ```
 
 ### GitHub token
 
@@ -60,6 +65,8 @@ Webhook (in-cluster): `http://n8n-app.ai-ops.svc.cluster.local:5678/webhook/vmal
 - Pull requests: Read and write
 
 **Classic**: Scope `repo`.
+
+Token is read from Secret key `github-token` → pod env `GITHUB_TOKEN` (not stored in n8n credential store).
 
 ## Workflow (GitHub REST)
 

--- a/justfile
+++ b/justfile
@@ -141,3 +141,16 @@ cnpg-db-credential secret_name username password:
     cd infrastructure/overlays/main/database-clusters/credentials
     just sops-create "{{secret_name}}" cnpg-system \
       "username={{username}}" "password={{password}}"
+
+# Import GitOps remediation workflow into running n8n (uses K8s env secrets, no UI credentials)
+n8n-bootstrap:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    : "${KUBECONFIG:?Set KUBECONFIG (e.g. homelab-infrastructure/talos/kubeconfig)}"
+    wf="apps/base/n8n/workflows/homelab-gitops-remediation.workflow.json"
+    pod="$(kubectl get pod -n ai-ops -l app.kubernetes.io/instance=n8n-app -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || \
+      kubectl get pod -n ai-ops -l app.kubernetes.io/name=n8n -o jsonpath='{.items[0].metadata.name}')"
+    [[ -n "$pod" ]] || { echo "error: no n8n pod in ai-ops"; exit 1; }
+    kubectl cp "$wf" "ai-ops/${pod}:/tmp/homelab-gitops-remediation.workflow.json"
+    kubectl exec -n ai-ops "$pod" -- n8n import:workflow --input=/tmp/homelab-gitops-remediation.workflow.json
+    echo "Workflow imported and set active in JSON. Open https://n8n.cluster.f4mily.net → verify Webhook /webhook/vmalert"

--- a/renovate.json
+++ b/renovate.json
@@ -49,6 +49,19 @@
     },
     {
       "customType": "regex",
+      "description": "n8n container image tag in HelmRelease",
+      "managerFilePatterns": [
+        "/apps/base/n8n/helmrelease\\.yaml$/"
+      ],
+      "matchStrings": [
+        "tag:\\s*\"(?<currentValue>[^\"]+)\""
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "n8nio/n8n",
+      "versioningTemplate": "docker"
+    },
+    {
+      "customType": "regex",
       "description": "CI workflow action versions (Forgejo and GitHub)",
       "managerFilePatterns": [
         "/^\\.(forgejo|github)/workflows/.*\\.ya?ml$/"


### PR DESCRIPTION
Bump image from 1.122.4; workflow uses LLM/GITHUB env vars (no UI credentials). Add just n8n-bootstrap to import active GitOps workflow after deploy.