### PR TITLE
feat(n8n): 2.21.7 pin, v2 env, auth docs

### DIFF
--- a/apps/base/n8n/helmrelease.yaml
+++ b/apps/base/n8n/helmrelease.yaml
@@ -22,7 +22,7 @@ spec:
   values:
     image:
       repository: n8nio/n8n
-      tag: "2.21.2"
+      tag: "2.21.7"
     # Service MUST NOT be named "n8n" — K8s injects N8N_PORT=tcp://… and breaks the listener (502).
     # DNS: n8n-app.ai-ops.svc.cluster.local
     fullnameOverride: n8n-app
@@ -78,6 +78,17 @@ spec:
           value: https://n8n.cluster.f4mily.net/
         N8N_PROXY_HOPS:
           value: "1"
+        # n8n 2.x: Code nodes use task runners; internal mode is OK for single-replica homelab.
+        N8N_RUNNERS_ENABLED:
+          value: "true"
+        N8N_RUNNERS_MODE:
+          value: internal
+        # GitOps remediation workflow reads $env in Code nodes (see workflows/).
+        N8N_BLOCK_ENV_ACCESS_IN_NODE:
+          value: "false"
+        # Public editor URL behind ingress TLS (required for OIDC redirect if licensed later).
+        N8N_EDITOR_BASE_URL:
+          value: https://n8n.cluster.f4mily.net/
         GITHUB_API_URL:
           value: https://api.github.com
         GITHUB_REPO_OWNER:

--- a/apps/base/n8n/workflows/README.md
+++ b/apps/base/n8n/workflows/README.md
@@ -15,3 +15,5 @@ just n8n-bootstrap
 Imports (or updates) the GitOps workflow and activates it. LLM + GitHub use `LLM_API_KEY`, `LLM_BASE_URL`, `GITHUB_TOKEN` from the HelmRelease / Secret.
 
 Full guide: [`docs/integrations/alerting-n8n-gitops-remediation.md`](../../../docs/integrations/alerting-n8n-gitops-remediation.md)
+
+Auth (why no Authentik OIDC yet): [`docs/integrations/n8n-auth.md`](../../../docs/integrations/n8n-auth.md)

--- a/docs/integrations/alerting-n8n-gitops-remediation.md
+++ b/docs/integrations/alerting-n8n-gitops-remediation.md
@@ -49,7 +49,7 @@ Webhook (in-cluster): `http://n8n-app.ai-ops.svc.cluster.local:5678/webhook/vmal
    ```
 
 2. Ensure both `*.secret.yaml` are listed in `kustomization.yaml`.
-3. Flux reconcile; n8n image is pinned in HelmRelease (`n8nio/n8n:1.123.46`).
+3. Flux reconcile; n8n image is pinned in HelmRelease (`n8nio/n8n:2.21.7`). See [n8n-auth.md](n8n-auth.md) for UI OAuth vs webhooks.
 4. Import workflow (uses pod env — **no** n8n Credentials UI for GitOps flow):
 
    ```bash

--- a/docs/integrations/n8n-auth.md
+++ b/docs/integrations/n8n-auth.md
@@ -1,0 +1,72 @@
+# n8n authentication (UI vs webhooks)
+
+## Current state
+
+| Layer | Status |
+|-------|--------|
+| **Ingress** | HTTPS only (`n8n.cluster.f4mily.net`), no auth |
+| **n8n UI login** | Local owner account (first setup) |
+| **Authentik OIDC** | Not configured (unlike Grafana) |
+| **Alertmanager → n8n** | In-cluster `http://n8n-app.ai-ops.svc.cluster.local:5678/webhook/vmalert` (bypasses ingress) |
+
+Grafana has full **Generic OAuth** via Authentik (`grafana-oauth.configmap.yaml`, `grafana-authentik-oauth` secret, Helm `auth.generic_oauth`). n8n has **none** of that — by design for the automation-first deploy, not because n8n cannot do OAuth in general.
+
+## Why native OAuth/OIDC is not in GitOps
+
+1. **License** — [n8n SSO docs](https://docs.n8n.io/hosting/configuration/environment-variables/sso/) state that single sign-on (OIDC/SAML) is available on **Business and Enterprise** plans. Self-hosted **Community** does not include SSO; env vars such as `N8N_SSO_OIDC_*` exist from v2.18+ but require a paid license to activate.
+
+2. **Never implemented** — No Authentik blueprint, no `n8n-authentik-oauth` SOPS secret, no `N8N_SSO_*` env in `apps/base/n8n/helmrelease.yaml`.
+
+3. **Webhooks must stay open (in-cluster)** — Closed-loop remediation uses unauthenticated webhooks on the cluster Service. UI OAuth at the app layer does not affect that path; ingress-level auth must **exclude** `/webhook/*` if added later.
+
+## Options (homelab)
+
+### A) Keep as-is (current)
+
+- UI: local n8n user + HTTPS ingress.
+- Automation: in-cluster webhooks + `$env` secrets (no n8n credential store for GitOps flow).
+
+### B) Authentik **forward auth** on ingress (Community-friendly)
+
+Protect the editor with Authentik Proxy Provider + F5 NGINX `server-snippets` / Policy (`auth_request` to outpost). **Exclude** `/webhook` (and optionally `/rest/oauth2-credential/callback` if using node OAuth).
+
+- Pros: Same IdP as Grafana, no n8n license.
+- Cons: Not integrated into n8n user management; separate from n8n “Sign in with OIDC” UI.
+
+### C) Native OIDC (Enterprise/Business license)
+
+When you have a license key:
+
+1. Authentik OAuth2 provider — redirect URI:
+   `https://n8n.cluster.f4mily.net/rest/sso/oidc/callback`
+2. Discovery endpoint: `https://login.f4mily.net/application/o/n8n/.well-known/openid-configuration` (slug after blueprint).
+3. Helm env (see [SSO environment variables](https://docs.n8n.io/hosting/configuration/environment-variables/sso/)):
+
+```yaml
+N8N_SSO_MANAGED_BY_ENV: "true"
+N8N_SSO_OIDC_LOGIN_ENABLED: "true"
+N8N_SSO_OIDC_DISCOVERY_ENDPOINT: https://login.f4mily.net/application/o/n8n/.well-known/openid-configuration
+N8N_SSO_OIDC_CLIENT_ID: # from SOPS
+N8N_SSO_OIDC_CLIENT_SECRET_FILE: /etc/n8n-sso/client-secret
+```
+
+`N8N_EDITOR_BASE_URL` is already set in the HelmRelease for correct callback URLs.
+
+## n8n 2.x upgrade notes (2.21.7)
+
+See [n8n v2.0 breaking changes](https://docs.n8n.io/2-0-breaking-changes/).
+
+| Topic | Homelab choice |
+|-------|----------------|
+| Task runners | `N8N_RUNNERS_ENABLED=true`, `N8N_RUNNERS_MODE=internal` (single replica; no `n8nio/runners` sidecar) |
+| Code node `$env` | `N8N_BLOCK_ENV_ACCESS_IN_NODE=false` (required for GitOps remediation workflow) |
+| SQLite | Unchanged on PVC |
+| Publish vs activate | Re-import workflow; **publish** active remediation workflow in UI if migration report flags it |
+
+External task runners (`n8nio/runners` sidecar, broker port 5679) are only needed for **external** runner mode or Python Code nodes — not used here.
+
+## References
+
+- Helm: `apps/base/n8n/helmrelease.yaml`
+- Grafana pattern: `docs/integrations/grafana-authentik.md`
+- GitOps remediation: `docs/integrations/alerting-n8n-gitops-remediation.md`


### PR DESCRIPTION
## Summary

- Pin n8n to **2.21.7** (main already has 2.21.2 from Renovate #55).
- Add n8n 2.x runtime env: internal task runners, `N8N_BLOCK_ENV_ACCESS_IN_NODE=false` for GitOps Code nodes, `N8N_EDITOR_BASE_URL`.
- Document why Authentik OIDC is not wired (`docs/integrations/n8n-auth.md`) — native SSO needs Business/Enterprise; in-cluster webhooks unchanged.

Builds on merged #54 (env workflow, `just n8n-bootstrap`) and #55 (2.x image).

## Test plan

- [ ] Flux reconciles `HelmRelease/n8n` in `ai-ops`
- [ ] `https://n8n.cluster.f4mily.net` loads; review Settings → Migration Report
- [ ] `just n8n-bootstrap` — workflow active, `/webhook/vmalert` test POST
- [ ] Remediation execution uses `$env` LLM/GitHub nodes successfully