### PR TITLE
Fix CrashLoopBackOff for n8n-test Pod

### DIFF
--- a/gitops-homelab/apps/base/n8n/patches/crashloopbackoff-fix.yaml
+++ b/gitops-homelab/apps/base/n8n/patches/crashloopbackoff-fix.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: n8n-test
+  namespace: default
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+        image: n8n:latest
+        env:
+        - name: N8N_HOST
+          value: 'n8n-test'
+        - name: N8N_PORT
+          value: '5678'
+        - name: N8N_PROTOCOL
+          value: 'http'
+        resources:
+          limits:
+            memory: '512Mi'
+            cpu: '500m'
+          requests:
+            memory: '256Mi'
+            cpu: '250m'


### PR DESCRIPTION
# Problem
Der Pod `n8n-test` hat einen `CrashLoopBackOff`-Fehler, der durch die aktuelle Konfiguration verursacht wird.

# Lösung
Diese Änderung passt die Ressourcenanforderungen und Umgebungsvariablen an, um sicherzustellen, dass der Pod stabil läuft. Bitte überprüfen Sie die Änderungen und testen Sie die Bereitstellung.

---
Auto-remediation for **KubePodCrashLoopBackOff** in `default/n8n-test`.