### PR TITLE
fix(kite,monitoring): Kite 0.12.2, Alertmanager reconcile, Renovate

### DIFF
--- a/apps/base/kite/deployment.yaml
+++ b/apps/base/kite/deployment.yaml
@@ -16,11 +16,18 @@ metadata:
     kustomize.toolkit.fluxcd.io/depends-on: cert-manager.io/Certificate/cert-manager/wildcard-f4mily-net
 spec:
   interval: 1h
+  timeout: 15m
   targetNamespace: kite
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
   chart:
     spec:
       chart: kite
-      version: "0.8.1"
+      version: "0.12.2"
       sourceRef:
         kind: HelmRepository
         name: kite-repo
@@ -30,9 +37,7 @@ spec:
     # Recreate strategy required for RWO volumes
     strategy:
       type: Recreate
-    image:
-      repository: ghcr.io/kite-org/kite
-      tag: "v0.12.2"
+    # Image tag defaults to chart appVersion (v0.12.2) — do not override via Renovate helm-values
     service:
       port: 8080
     host: https://kite.cluster.f4mily.net
@@ -64,7 +69,7 @@ spec:
         persistence:
           pvc:
             enabled: true
-            storageClass: longhorn
+            storageClass: longhorn-1
             accessModes:
               - ReadWriteOnce
             size: 1Gi

--- a/apps/base/monitoring/vm-k8s-stack/helmrelease.yaml
+++ b/apps/base/monitoring/vm-k8s-stack/helmrelease.yaml
@@ -102,7 +102,7 @@ spec:
         replicaCount: 1
         secrets:
           - alertmanager-ntfy-credentials
-          - alertmanager-n8n-webhook
+          # alertmanager-n8n-webhook: add after `just sops-create alertmanager-n8n-webhook` (see template)
         resources:
           requests:
             cpu: 10m
@@ -133,12 +133,12 @@ spec:
               group_wait: 30s
               repeat_interval: 12h
               continue: true
-            # Homelab P0 → n8n KI-Triage (parallel zu ntfy); URL in SOPS alertmanager-n8n-webhook
-            - matchers:
-                - homelab/owner="platform"
-                - severity=~"critical|warning"
-              receiver: n8n-triage
-              continue: true
+            # n8n KI-Triage: enable after alertmanager-n8n-webhook secret exists (template in notifications/)
+            # - matchers:
+            #     - homelab/owner="platform"
+            #     - severity=~"critical|warning"
+            #   receiver: n8n-triage
+            #   continue: true
             - matchers:
                 - severity=critical
               receiver: ntfy-monitoring
@@ -171,10 +171,10 @@ spec:
                   authorization:
                     type: Bearer
                     credentials_file: /etc/vm/secrets/alertmanager-ntfy-credentials/token
-          - name: n8n-triage
-            webhook_configs:
-              - url_file: /etc/vm/secrets/alertmanager-n8n-webhook/url
-                send_resolved: true
+          # - name: n8n-triage
+          #   webhook_configs:
+          #     - url_file: /etc/vm/secrets/alertmanager-n8n-webhook/url
+          #       send_resolved: true
           # Closed-loop GitOps: VMRule OOM/CrashLoop → n8n workflow /webhook/vmalert
           - name: n8n-remediation
             webhook_configs:

--- a/docs/runbooks/monitoring-stack.md
+++ b/docs/runbooks/monitoring-stack.md
@@ -4,6 +4,17 @@
 
 `MonitoringVMAlertDown` or `MonitoringAlertmanagerDown`.
 
+## Alertmanager stuck `expanding` / no notifications
+
+If `alertmanager-n8n-webhook` is listed under `spec.secrets` but the Secret does not exist, Alertmanager never becomes ready and **all** routes (including vmalert → ntfy) stall.
+
+```bash
+kubectl get secret -n monitoring alertmanager-n8n-webhook
+kubectl get vmalertmanager -n monitoring vm-am -o yaml | grep -A2 updateStatus
+```
+
+Fix: either create the secret (`apps/base/monitoring/notifications/alertmanager-n8n-webhook.secret.yaml.template`) and uncomment the `n8n-triage` route in `vm-k8s-stack/helmrelease.yaml`, or keep triage disabled (GitOps default) so only `n8n-remediation` (in-cluster URL, no extra secret) and ntfy routes apply.
+
 ## Checks
 
 ```bash

--- a/renovate.json
+++ b/renovate.json
@@ -74,8 +74,34 @@
   ],
   "packageRules": [
     {
+      "description": "Kite: bump Helm chart via flux only (appVersion sets container image)",
+      "matchFileNames": [
+        "apps/base/kite/**"
+      ],
       "matchManagers": [
         "flux"
+      ],
+      "groupName": "kite",
+      "groupSlug": "kite",
+      "minimumReleaseAge": "3 days",
+      "automerge": false
+    },
+    {
+      "description": "Do not let helm-values override kite image tag out of sync with chart",
+      "matchFileNames": [
+        "apps/base/kite/**"
+      ],
+      "matchManagers": [
+        "helm-values"
+      ],
+      "enabled": false
+    },
+    {
+      "matchManagers": [
+        "flux"
+      ],
+      "matchFileNames": [
+        "!apps/base/kite/**"
       ],
       "groupName": "flux helm releases",
       "groupSlug": "flux-helm-releases",
@@ -85,6 +111,9 @@
     {
       "matchManagers": [
         "helm-values"
+      ],
+      "matchFileNames": [
+        "!apps/base/kite/**"
       ],
       "groupName": "helm chart versions",
       "groupSlug": "helm-chart-versions",


### PR DESCRIPTION
## Summary

- **Kite:** Upgrade Helm chart `0.8.1` → `0.12.2` (latest upstream). Remove Renovate-bumped `image.tag` that ran ahead of the chart and left Helm stalled with a second pod stuck on the RWO PVC. Use `longhorn-1` (cluster default SC).
- **Alertmanager / vmalert path:** `alertmanager-n8n-webhook` Secret was referenced but never created — Alertmanager stayed `expanding` and blocked the whole notification chain. Disable `n8n-triage` until the SOPS secret exists; `n8n-remediation` (hardcoded in-cluster URL) unchanged.
- **Renovate:** Dedicated `kite` flux group; disable `helm-values` on `apps/base/kite/**` so chart version and image stay aligned via `appVersion`.

## Root causes (cluster)

| Symptom | Cause |
|---------|--------|
| Kite `ContainerCreating` | Chart/image skew + two ReplicaSets sharing one RWO PVC |
| “vmalert broken” | Alertmanager not ready (`updateStatus: expanding`) due to missing secret mount |

## Test plan

- [x] `flux reconcile helmrelease kite -n kite` and `vm-k8s-stack -n monitoring`
- [ ] `kubectl get vmalertmanager vm-am -n monitoring` → ready (not `expanding`)
- [ ] `kubectl get pods -n kite` → single Running pod on chart 0.12.2
- [ ] If old failed RS remains: `kubectl delete pod -n kite -l app.kubernetes.io/instance=kite-kite --field-selector=status.phase!=Running`
- [ ] Fire test alert → ntfy; optional `just n8n-test-webhook` for remediation

## Post-merge (optional)

Enable n8n KI-Triage after creating `alertmanager-n8n-webhook` secret and uncomment route in `helmrelease.yaml`.