### PR TITLE
fix(kite): unblock 0.12.2 upgrade — keep PVC storageClass

### DIFF
--- a/apps/base/kite/deployment.yaml
+++ b/apps/base/kite/deployment.yaml
@@ -69,7 +69,8 @@ spec:
         persistence:
           pvc:
             enabled: true
-            storageClass: longhorn-1
+            # Must match existing PVC storageClassName (immutable after bind). New installs: longhorn-1 is fine.
+            storageClass: longhorn
             accessModes:
               - ReadWriteOnce
             size: 1Gi

--- a/docs/runbooks/kite.md
+++ b/docs/runbooks/kite.md
@@ -1,0 +1,33 @@
+# Kite (HelmRelease)
+
+## Symptom
+
+- `HelmRelease/kite` **Stalled** / rollback to chart `0.8.1`
+- Pod stuck `ContainerCreating` (two ReplicaSets, one RWO PVC)
+- Upgrade error: `PersistentVolumeClaim ... spec is immutable` (`storageClassName`)
+
+## Cause
+
+Helm cannot change `storageClassName` on an existing bound PVC. Chart upgrades (e.g. `0.8.1` → `0.12.2`) must keep the same `db.sqlite.persistence.pvc.storageClass` as the live PVC (`longhorn` on this cluster).
+
+## Fix after GitOps change
+
+```bash
+# Clear Stalled and retry upgrade (chart 0.12.2, storageClass unchanged)
+flux suspend helmrelease kite -n kite
+flux resume helmrelease kite -n kite
+flux reconcile helmrelease kite -n kite --with-source
+
+kubectl get helmrelease -n kite kite
+kubectl get pods -n kite
+```
+
+If an old failed pod remains:
+
+```bash
+kubectl delete pod -n kite -l app.kubernetes.io/instance=kite-kite --field-selector=status.phase!=Running
+```
+
+## New installs
+
+For a fresh PVC you may use `longhorn-1` (cluster default). Do not change `storageClass` on a bound claim without migrating data (new PVC + copy or accept empty DB).

--- a/docs/runbooks/monitoring-stack.md
+++ b/docs/runbooks/monitoring-stack.md
@@ -47,6 +47,17 @@ kubectl get deploy,po -n monitoring -l app.kubernetes.io/name=ntfy-bridge
 kubectl rollout restart deployment/ntfy-bridge -n monitoring
 ```
 
+## vmsingle CrashLoop (`read-only file system` / `flock.lock`)
+
+VictoriaMetrics needs exclusive RW access to `/victoria-metrics-data`. If the pod loops with `read-only file system`:
+
+```bash
+kubectl delete pod -n monitoring -l app.kubernetes.io/name=vmsingle
+kubectl wait -n monitoring --for=condition=ready pod -l app.kubernetes.io/name=vmsingle --timeout=120s
+```
+
+If it persists: Longhorn UI → volume for `vmsingle-*` PVC → check health; last resort detach/reattach volume or restore from backup (metrics gap).
+
 ## Flux
 
 ```bash


### PR DESCRIPTION
## Summary

PR #60 upgraded Kite to chart `0.12.2` but changed PVC `storageClassName` to `longhorn-1`. Kubernetes rejects that on bound PVCs — Helm rolled back to `0.8.1` and left the release **Stalled**.

This PR keeps `storageClass: longhorn` (matches live PVC) so chart `0.12.2` can apply. Adds runbooks for Kite unstuck and vmsingle flock issues.

## Test plan

- [ ] Merge → `flux reconcile helmrelease kite -n kite --with-source`
- [ ] `kubectl get helmrelease -n kite kite` → Ready, chart 0.12.2
- [ ] Single Running pod, UI https://kite.cluster.f4mily.net