### PR TITLE
feat(immich): upgrade to v2.7.5 and fix Renovate tag detection

### DIFF
--- a/apps/base/immich/helmrelease.yaml
+++ b/apps/base/immich/helmrelease.yaml
@@ -53,16 +53,16 @@ spec:
       DB_HOSTNAME: immich-postgres-rw.cnpg-system.svc.cluster.local
       DB_PORT: "5432"
       DB_DATABASE_NAME: immich
-      # v1.119 supports pgvector or pgvecto.rs only; VectorChord needs Immich v2+.
-      DB_VECTOR_EXTENSION: pgvector
+      # VectorChord on immich-postgres; omit DB_VECTOR_EXTENSION so Immich auto-detects vchord.
+    # Shared tag for immich-server + immich-machine-learning (chart 0.9.x).
+    image:
+      # renovate: datasource=docker depName=ghcr.io/immich-app/immich-server versioning=semver
+      tag: v2.7.5
     immich:
       persistence:
         library:
           existingClaim: immich-library
     server:
-      image:
-        # renovate: datasource=docker depName=ghcr.io/immich-app/immich-server
-        tag: v1.119.0
       persistence:
         library:
           subPath: Bilder

--- a/docs/migrations/immich-docker-to-kubernetes.md
+++ b/docs/migrations/immich-docker-to-kubernetes.md
@@ -12,7 +12,7 @@ PVCs).
 
 | Component | Docker (production) | Kubernetes (homelab) |
 |-----------|---------------------|----------------------|
-| App | `immich_server` — `ghcr.io/immich-app/immich-server:release` | Helm chart `immich` — image tag `v1.119.0` (pin in `helmrelease.yaml`) |
+| App | `immich_server` — `ghcr.io/immich-app/immich-server:release` (prod: **v2.7.5**) | Helm chart `immich` — shared `values.image.tag` (e.g. `v2.7.5` in `helmrelease.yaml`) |
 | ML | `immich_machine_learning` | Chart subchart `machine-learning` |
 | DB | `immich_postgres` — `ghcr.io/immich-app/postgres:14-vectorchord…` | CNPG `immich-postgres` — `ghcr.io/tensorchord/cloudnative-vectorchord:16.9-0.4.3` |
 | Redis | `immich_redis` (Valkey 8) | In-cluster Redis (Bitnami legacy image, **no persistence**) |
@@ -34,19 +34,18 @@ migrated; Redis is ephemeral.
 - [ ] NFS PVCs bound: `immich-library`, `immich-fotos` in namespace `immich`.
 - [ ] Dev shell: `nix develop` (provides `kubectl`, `pg_restore`, `flux`).
 - [ ] Maintenance window (Immich offline for DB export/import).
-- [ ] **Version check:** align production Immich tag with cluster `helmrelease.yaml`
-  (`server.image.tag`). Production uses `:release`; cluster pins `v1.119.0`.
-  Major version skew can break schema restore — note prod version before cutover:
+- [ ] **Version check:** align production Immich tag with cluster `values.image.tag` in
+  `helmrelease.yaml`. Production uses `:release` (currently **v2.7.5**); cluster should
+  match before DB restore. Note prod version before cutover:
 
 ```bash
 docker inspect immich_server --format '{{.Config.Image}}'
 docker exec immich_server immich-admin version 2>/dev/null || true
 ```
 
-- [ ] **Vector extension:** production Postgres image ships VectorChord; cluster
-  Helm sets `DB_VECTOR_EXTENSION: pgvector` for Immich **v1.119**. After restore,
-  verify `\dx` and Immich startup logs. Upgrading to Immich v2+ may require
-  `DB_VECTOR_EXTENSION` / chart changes — see
+- [ ] **Vector extension:** production and cluster use VectorChord on `immich-postgres`.
+  Do **not** set `DB_VECTOR_EXTENSION=pgvector` on v2.x — Immich auto-detects `vchord`.
+  Verify `\dx` and startup logs after restore — see
   [Immich: pre-existing Postgres](https://docs.immich.app/administration/postgres-standalone).
 
 ## Phase 1 — Stop writes on Docker (production host)

--- a/renovate.json
+++ b/renovate.json
@@ -33,10 +33,23 @@
         "/\\.ya?ml$/"
       ],
       "matchStrings": [
-        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(?:\\s+versioning=(?<versioning>\\S+))?(?:\\s+extractVersion=(?<extractVersion>\\S+))?\\s*\\n[^\\n]*?[\"']?(?<currentValue>[A-Za-z0-9][^\\s\"':]*)[\"']?\\s*(?:#.*)?$",
+        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(?:\\s+versioning=(?<versioning>\\S+))?(?:\\s+extractVersion=(?<extractVersion>\\S+))?\\s*\\n(?:[^\\n]*\\n)*?\\s*tag:\\s*[\"']?(?<currentValue>[^\\s\"'#]+)[\"']?\\s*(?:#.*)?$",
         "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(?:\\s+versioning=(?<versioning>\\S+))?(?:\\s+extractVersion=(?<extractVersion>\\S+))?\\s*\\n[^\\n]*?:\\s*[\"']?[^:\\s\"']+:(?<currentValue>[^\"'\\s]+)[\"']?\\s*(?:#.*)?$"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    },
+    {
+      "customType": "regex",
+      "description": "Immich shared image.tag (values.image.tag — avoids false match on redis/bitnami tags)",
+      "managerFilePatterns": [
+        "/apps/base/immich/helmrelease\\.yaml$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=docker depName=ghcr\\.io/immich-app/immich-server[^\\n]*\\n\\s+tag:\\s*[\"']?(?<currentValue>v[^\\s\"']+)[\"']?"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "ghcr.io/immich-app/immich-server",
+      "versioningTemplate": "semver"
     },
     {
       "customType": "regex",


### PR DESCRIPTION
## Summary

- Upgrade cluster Immich to **v2.7.5** via chart-native `values.image.tag` (shared server + machine-learning).
- Remove `DB_VECTOR_EXTENSION=pgvector` so v2 auto-detects VectorChord on `immich-postgres`.
- Fix Renovate: generic marker regex now matches `tag: <version>` after `# renovate:` (was capturing the word `tag`); add dedicated Immich `customManager` fallback.
- Update migration doc for v2.7.5 / VectorChord.

## Context

Flux reconciles from **GitHub** `main`. Renovate/docs/CNPG marker changes are already merged; this PR adds the Immich version bump and the Renovate regex fix for `values.image.tag`.

## Test plan

- [ ] Forgejo CI / GitHub checks green
- [ ] After merge: `flux reconcile helmrelease -n immich immich --force`
- [ ] `kubectl -n immich rollout status deployment/immich-server`
- [ ] Smoke test https://immich.cluster.f4mily.net (empty DB + NFS library scan)
- [ ] After next Immich release: Renovate opens PR for `ghcr.io/immich-app/immich-server`


Made with [Cursor](https://cursor.com)