### PR TITLE
fix: Immich cutover, TeslaMate migration, Renovate image detection

### DIFF
--- a/apps/base/authentik/blueprints/teslamate-grafana-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/teslamate-grafana-oauth.configmap.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authentik-teslamate-grafana-blueprint
+  namespace: authentik
+  labels:
+    app.kubernetes.io/part-of: authentik
+data:
+  teslamate-grafana.yaml: |
+    version: 1
+    metadata:
+      name: Homelab TeslaMate Grafana OIDC
+      labels:
+        blueprints.goauthentik.io/description: OAuth2 provider for TeslaMate Grafana
+    entries:
+      - model: authentik_providers_oauth2.oauth2provider
+        id: teslamate-grafana-provider
+        identifiers:
+          name: Provider for TeslaMate Grafana
+        attrs:
+          name: Provider for TeslaMate Grafana
+          client_type: confidential
+          client_id: fa6de72374e823c83b6d5aa0f209a9a29a01b6ba
+          # Set to teslamate-grafana-oauth secret client-secret after reconcile (see docs/integrations/teslamate-grafana-authentik.md)
+          client_secret: teslamate-grafana-change-me
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+          redirect_uris:
+            - matching_mode: strict
+              url: https://teslamate-grafana.cluster.f4mily.net/login/generic_oauth
+          post_logout_redirect_uris:
+            - https://teslamate-grafana.cluster.f4mily.net/logout
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, entitlements]]
+      - model: authentik_core.application
+        identifiers:
+          slug: tesla-grafana
+        attrs:
+          name: TeslaMate Grafana
+          slug: tesla-grafana
+          provider: !KeyOf teslamate-grafana-provider
+          launch_url: https://teslamate-grafana.cluster.f4mily.net
+          meta_launch_url: https://teslamate-grafana.cluster.f4mily.net

--- a/apps/base/authentik/helmrelease.yaml
+++ b/apps/base/authentik/helmrelease.yaml
@@ -54,6 +54,7 @@ spec:
     blueprints:
       configMaps:
         - authentik-grafana-blueprint
+        - authentik-teslamate-grafana-blueprint
     server:
       ingress:
         enabled: false

--- a/apps/base/authentik/kustomization.yaml
+++ b/apps/base/authentik/kustomization.yaml
@@ -4,5 +4,6 @@ resources:
   - namespace.yaml
   - authentik-secret-key.secret.yaml
   - blueprints/grafana-oauth.configmap.yaml
+  - blueprints/teslamate-grafana-oauth.configmap.yaml
   - helmrelease.yaml
   - ingress.yaml

--- a/apps/base/homepage/configmap.yaml
+++ b/apps/base/homepage/configmap.yaml
@@ -12,7 +12,9 @@ data:
     ---
     title: "Homelab Dashboard"
     language: "de"
-    showStats: true
+    # Eager stats fire ~2×N parallel /api/kubernetes/* calls; intermittent 500 responses
+    # ({error: ...} without stats) crash Homepage v1.13.1 (stats.cpuLimit). Stats on click still work.
+    showStats: false
     statusStyle: dot
   kubernetes.yaml: |
     mode: cluster

--- a/apps/base/homepage/deployment.yaml
+++ b/apps/base/homepage/deployment.yaml
@@ -14,7 +14,7 @@ spec:
         app: homepage
       annotations:
         # Bump to force rollout when only ConfigMap content changes.
-        config-version: "2026-05-21e"
+        config-version: "2026-05-23a"
     spec:
       serviceAccountName: homepage
       automountServiceAccountToken: true

--- a/apps/base/immich/helmrelease.yaml
+++ b/apps/base/immich/helmrelease.yaml
@@ -53,16 +53,16 @@ spec:
       DB_HOSTNAME: immich-postgres-rw.cnpg-system.svc.cluster.local
       DB_PORT: "5432"
       DB_DATABASE_NAME: immich
-      # v1.119 supports pgvector or pgvecto.rs only; VectorChord needs Immich v2+.
-      DB_VECTOR_EXTENSION: pgvector
+      # VectorChord on immich-postgres; omit DB_VECTOR_EXTENSION so Immich auto-detects vchord.
+    # Shared tag for immich-server + immich-machine-learning (chart 0.9.x).
+    image:
+      # renovate: datasource=docker depName=ghcr.io/immich-app/immich-server versioning=semver
+      tag: v2.7.5
     immich:
       persistence:
         library:
           existingClaim: immich-library
     server:
-      image:
-        # renovate: datasource=docker depName=ghcr.io/immich-app/immich-server
-        tag: v1.119.0
       persistence:
         library:
           subPath: Bilder

--- a/apps/base/immich/ingress.yaml
+++ b/apps/base/immich/ingress.yaml
@@ -12,7 +12,7 @@ metadata:
     gethomepage.dev/app: server
     nginx.org/ssl-redirect: "false"
     nginx.org/redirect-to-https: "true"
-    nginx.org/proxy-body-size: "0"
+    nginx.org/client-max-body-size: "0"
 spec:
   ingressClassName: nginx
   tls:

--- a/apps/base/immich/ingress.yaml
+++ b/apps/base/immich/ingress.yaml
@@ -17,10 +17,10 @@ spec:
   ingressClassName: nginx
   tls:
     - hosts:
-        - immich.cluster.f4mily.net
-      secretName: wildcard-cluster-f4mily-net-tls
+        - immich.f4mily.net
+      secretName: wildcard-f4mily-net-tls
   rules:
-    - host: immich.cluster.f4mily.net
+    - host: immich.f4mily.net
       http:
         paths:
           - path: /

--- a/apps/base/teslamate/deployment-grafana.yaml
+++ b/apps/base/teslamate/deployment-grafana.yaml
@@ -28,6 +28,9 @@ spec:
           ports:
             - containerPort: 3000
               name: http
+          envFrom:
+            - configMapRef:
+                name: teslamate-grafana-config
           env:
             - name: DATABASE_USER
               valueFrom:
@@ -45,6 +48,20 @@ spec:
               value: homelab-postgres-rw.cnpg-system.svc.cluster.local
             - name: DATABASE_PORT
               value: "5432"
+            - name: GF_AUTH_GENERIC_OAUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: teslamate-grafana-oauth
+                  key: client-id
+            - name: GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: teslamate-grafana-oauth
+                  key: client-secret
+            - name: GF_SERVER_DOMAIN
+              value: teslamate-grafana.cluster.f4mily.net
+            - name: GF_SERVER_ROOT_URL
+              value: https://teslamate-grafana.cluster.f4mily.net/
           livenessProbe:
             httpGet:
               path: /api/health

--- a/apps/base/teslamate/deployment.yaml
+++ b/apps/base/teslamate/deployment.yaml
@@ -53,6 +53,10 @@ spec:
               value: homelab-postgres-rw.cnpg-system.svc.cluster.local
             - name: DATABASE_PORT
               value: "5432"
+            - name: CHECK_ORIGIN
+              value: "false"
+            - name: VIRTUAL_HOST
+              value: teslamate.cluster.f4mily.net
           livenessProbe:
             httpGet:
               path: /

--- a/apps/base/teslamate/deployment.yaml
+++ b/apps/base/teslamate/deployment.yaml
@@ -23,20 +23,23 @@ spec:
           type: RuntimeDefault
       containers:
         - name: teslamate
-          image: docker.io/teslamate/teslamate:latest
-          imagePullPolicy: Always
+          # Pin version (DB already on 3.x migrations); bump via Renovate, not :latest.
+          image: docker.io/teslamate/teslamate:3.0.0
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 4000
               name: http
+          # Load ENCRYPTION_KEY from file so the value is never treated as a path (keys may start with "/").
+          command:
+            - /bin/dash
+            - -ec
+            - |
+              export ENCRYPTION_KEY="$(tr -d '\n\r' </etc/teslamate/encryption_key)"
+              exec tini -- /entrypoint.sh bin/teslamate start
           envFrom:
             - configMapRef:
                 name: teslamate-config
           env:
-            - name: ENCRYPTION_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: teslamate-app
-                  key: ENCRYPTION_KEY
             - name: DATABASE_USER
               valueFrom:
                 secretKeyRef:
@@ -83,9 +86,22 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
+            runAsNonRoot: true
+            runAsUser: 10000
+            runAsGroup: 10001
           volumeMounts:
             - name: import
               mountPath: /opt/app/import
+            - name: encryption-key
+              mountPath: /etc/teslamate
+              readOnly: true
       volumes:
         - name: import
           emptyDir: {}
+        - name: encryption-key
+          secret:
+            secretName: teslamate-app
+            items:
+              - key: ENCRYPTION_KEY
+                path: encryption_key
+            # defaultMode 0644: readable by container user (nonroot 10000); 0400 would be root-only.

--- a/apps/base/teslamate/ingress.yaml
+++ b/apps/base/teslamate/ingress.yaml
@@ -13,6 +13,10 @@ metadata:
     gethomepage.dev/pod-selector: app=teslamate
     nginx.org/ssl-redirect: "false"
     nginx.org/redirect-to-https: "true"
+    # Phoenix LiveView (/live/websocket)
+    nginx.org/websocket-services: "teslamate"
+    nginx.org/proxy-read-timeout: "3600s"
+    nginx.org/proxy-send-timeout: "3600s"
 spec:
   ingressClassName: nginx
   tls:

--- a/apps/base/teslamate/kustomization.yaml
+++ b/apps/base/teslamate/kustomization.yaml
@@ -3,8 +3,12 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - configmap.yaml
+  - teslamate-grafana-config.configmap.yaml
+  - teslamate-grafana-oauth.secret.yaml
   - teslamate-app.secret.yaml
+  - mosquitto-config.configmap.yaml
   - mosquitto.yaml
+  - mosquitto-external-service.yaml
   - deployment.yaml
   - deployment-grafana.yaml
   - service.yaml

--- a/apps/base/teslamate/mosquitto-config.configmap.yaml
+++ b/apps/base/teslamate/mosquitto-config.configmap.yaml
@@ -1,0 +1,12 @@
+# Production Docker stack used mosquitto -c /mosquitto-no-auth.conf (plain MQTT 1883).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mosquitto-config
+  namespace: teslamate
+data:
+  mosquitto.conf: |
+    listener 1883
+    allow_anonymous true
+    persistence true
+    persistence_location /mosquitto/data/

--- a/apps/base/teslamate/mosquitto-external-service.yaml
+++ b/apps/base/teslamate/mosquitto-external-service.yaml
@@ -1,0 +1,16 @@
+# Home Assistant / LAN clients (production published host:1883).
+apiVersion: v1
+kind: Service
+metadata:
+  name: mosquitto-external
+  namespace: teslamate
+spec:
+  type: ClusterIP
+  externalIPs:
+    - 192.168.10.245
+  selector:
+    app: mosquitto
+  ports:
+    - name: mqtt
+      port: 1883
+      targetPort: mqtt

--- a/apps/base/teslamate/mosquitto.yaml
+++ b/apps/base/teslamate/mosquitto.yaml
@@ -24,11 +24,14 @@ spec:
           args:
             - mosquitto
             - -c
-            - /mosquitto-no-auth.conf
+            - /mosquitto/config/mosquitto.conf
           ports:
             - containerPort: 1883
               name: mqtt
           volumeMounts:
+            - name: mosquitto-config
+              mountPath: /mosquitto/config
+              readOnly: true
             - name: mosquitto-data
               mountPath: /mosquitto/data
             - name: mosquitto-log
@@ -46,6 +49,9 @@ spec:
             capabilities:
               drop: ["ALL"]
       volumes:
+        - name: mosquitto-config
+          configMap:
+            name: mosquitto-config
         - name: mosquitto-data
           emptyDir: {}
         - name: mosquitto-log

--- a/apps/base/teslamate/teslamate-app.secret.yaml
+++ b/apps/base/teslamate/teslamate-app.secret.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-    ENCRYPTION_KEY: ENC[AES256_GCM,data:FAPQEb+HaAEiiXWgXfxVvZyfyuB6zWEkztWwbrTaW/mB1C+ROGHPDb3F+kT0hkoDzdqt2YATK2ZCBjf2horc7p+9pF/Xw8d/Nugox/eB1lkR6Vmv/fnr3Q==,iv:18oP6KLVrw+j17aw4ynvbu9x8KLbR2RUMeIlKL6YDYs=,tag:FiQgNQOGl1xwB5Kx8CTaCQ==,type:str]
+    ENCRYPTION_KEY: ENC[AES256_GCM,data:U5k6hstleOtfXjh61/YeJGPkL4JmrSbloSQlJGZkckkoui1Y/RJVoygPyDAeC8B8v5bj/2bACMmqRuGL8iUKnKFSMwikGlWjr/xm4xvuOaTVxGPO4qBBZA==,iv:4rTqtSXXFM9MCw8GYS9RXDRrtz32Iqnj5HZT1KsgNi4=,tag:EtUhPIdWXzW23m2FUa7CuA==,type:str]
 kind: Secret
 metadata:
     name: teslamate-app
@@ -9,14 +9,14 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQbEtVQnh6N1R5OHV0OUM0
-            TmM0ZWhMNC9rNUgwTlNscTQ5S2dtRFlYZ1NjCjRpNzJwUmN4dWdFRlRGaFNIb0tm
-            K2ZEb2pucDhQRnFDMDQ3RVNTRERpWG8KLS0tIHFvQjRnMGtEM2xtTTVCMjVoSUZR
-            dFpQL0lPM3lXZGNLTHBmOW9OQlVGNmcKMEUXuMaW61CqAuBSvW5n7mtmF4RX0Dxs
-            EFIbVCVVjggv+FZ7SQBP22lBZ+zogmcPkYPxRpMT5qmrfiHWBgmsXw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRMk5pUVdVNmhLQVZ1M0dm
+            YncrckxtRDlyZ0Mxdm9RTHBMeWRNNzVuTGhrCmcwSU5Mc0xsVU5DV2E1SnlQa3pF
+            UlBCam5XNlBpeDF0RVJ4OUk4b3lrS1EKLS0tIEo3NFpWejc1cmJsUGRWY3I3VGNl
+            WEpLc20yaFZvYnRhcHdTUnQrZEo2UTgKjFhgF5kofshzgWt9Fl5rs+DPxErPDQtR
+            5n0F3KnddhVCDpUoK+5L3OTniHhQcHMYmoDODRRzmU+ZIeHCULDhtA==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1u5lcvuuwd4lk7f3xewjk70j75yuh68myr89qkd0e8d44zgyjleeqw03vqs
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-05-20T07:03:10Z"
-    mac: ENC[AES256_GCM,data:GWbviaOUGGHMiz6oGfq0odGW1dYU/oBW1z20EHJeT6gsGFYw151qTRPCf/3tHTB/WjdSfRZHQPBkSON8oY8Z+QqN2DTmkIy1gN90jipatCRe7hi/tDmNLSCeQbZKeA8q+9h1LDRnXPi79C04me6BihIPEE5g5Cho88IX1LRYbfY=,iv:NngbIUnDY6dNsAMMvEzAKd4398DefLzAlWJ2z+C4h5Y=,tag:e871QdXYGeCr+HYxIZKVUg==,type:str]
-    version: 3.13.0
+    lastmodified: "2026-05-23T08:14:47Z"
+    mac: ENC[AES256_GCM,data:WG4wcDc26Kwrrv2JD2HLY2kSK1mUX+4IZ9V8K1Wf/uwIlmrE5Zjixn9ShfwgBmZkCgA8GtTe5fd3g250g956TDpSOfOSGrlLbkeIQ3kkP5dlczlKlj8VdHw++t6Cu0RJLFgwnGaUV61+Vytw6AenWeZHWuCM0GiAkItD6KA2GdA=,iv:f3eHRiqWVAl7JluypwDDv0WiLVvdUuGArkChKDFYq1A=,tag:XcvvwMLDBArzT1lOns1+Aw==,type:str]
+    version: 3.13.1

--- a/apps/base/teslamate/teslamate-grafana-config.configmap.yaml
+++ b/apps/base/teslamate/teslamate-grafana-config.configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: teslamate-grafana-config
+  namespace: teslamate
+data:
+  OAUTH_URL: https://login.f4mily.net
+  GF_AUTH_GENERIC_OAUTH_ENABLED: "true"
+  GF_AUTH_GENERIC_OAUTH_NAME: authentik
+  GF_AUTH_GENERIC_OAUTH_SCOPES: openid profile email groups
+  GF_AUTH_GENERIC_OAUTH_AUTH_URL: https://login.f4mily.net/application/o/authorize/
+  GF_AUTH_GENERIC_OAUTH_TOKEN_URL: https://login.f4mily.net/application/o/token/
+  GF_AUTH_GENERIC_OAUTH_API_URL: https://login.f4mily.net/application/o/userinfo/
+  GF_AUTH_SIGNOUT_REDIRECT_URL: https://login.f4mily.net/application/o/tesla-grafana/end-session/
+  GF_AUTH_OAUTH_AUTO_LOGIN: "true"
+  GF_AUTH_GENERIC_OAUTH_ROLE_ATTRIBUTE_PATH: contains(groups[*], 'teslaAdmin') && 'Admin' || contains(groups[*], 'teslaViewer') && 'Editor' || 'Viewer'
+  GF_SERVER_SERVE_FROM_SUB_PATH: "false"

--- a/apps/base/teslamate/teslamate-grafana-oauth.secret.yaml
+++ b/apps/base/teslamate/teslamate-grafana-oauth.secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+data:
+    client-id: ENC[AES256_GCM,data:FiEcQge+oSXu8kzJZP6L7G1t4KuyDPZShMyNLrvmHSp+IL8e5DX/IPXF4okNSSiPBvW3qRTtc3c=,iv:AbHnu7dVMh6yif9vXBv6kVnTNi9o93pA/Qo28DcINs4=,tag:QcjbnpJoCk7syRVc+lyJ6w==,type:str]
+    client-secret: ENC[AES256_GCM,data:7D+xYCUinfsGrivLqiQ+3+cpi5wc3hK083Oj9xfFMqFY5+60xRZ0UwYlNBvkF6AkyFbpOPtsyV5Msqk+9RfALhJ/FCDf4T3U0pBJM2+3JnVfbcMyk+wS37loG8Ro41ky77fUHn4RuG3R7XiV37vx9MCPMaabgSYPmZZQk3ltB4KVkamq2AMhsIv6o8dJwm2T+1y0p8ULHQVquB9IDm3bzaTChPmofriZCcVhAA==,iv:hxYD+KNKpvU40kPEAReDshzyewmlaha/oHbNx/QqtLI=,tag:6lI1w/1N6ETm5YRRky0cDQ==,type:str]
+kind: Secret
+metadata:
+    name: teslamate-grafana-oauth
+    namespace: teslamate
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBoMVkwNWNPb2R1d0ZUamJ5
+            WDBOVzI3Y1BUK0loRmNzNWdNbERKbFhmNGlRCmNvaTlZenhwZkdCdmtVNG1lQktF
+            Q2tVV2k0QzFTZVVpR1dOZzk0VGJxUTAKLS0tIDJGYjh3L0pST1EzOUV2MjZtcDFP
+            cjViREprUVo2VUR3VHJTZzlxY3ZnSVkKfj1JZGxG8z84Jz3Fjxd6EQjq3AYBU/LR
+            nZOLThqddABTy5urhCgrRnrsgeOu2v3uHd/08JjA0r35k6yxT09Row==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1u5lcvuuwd4lk7f3xewjk70j75yuh68myr89qkd0e8d44zgyjleeqw03vqs
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-05-23T08:14:16Z"
+    mac: ENC[AES256_GCM,data:PMsWarSYianTYXbjpwz0HmU5DpSvRyN3dBjTlFBkAknNUhDMklK/x2AZT5F0h30/zBWsEyKw7bDs553hWbmFX6EdXPaVBeMzY6e5QkkZQvVwf3tsxfOP3VTjxJDlT4kBgWzBpdheJi58g6BlLk8myaj1YhoF4LtjhyiS3D6Za1o=,iv:SyTmx1CMdmjfzRCo5KgG/cmTMf0aWbkrrRCesDZ064c=,tag:6zv27LkLuGgg/rEx+GLb+w==,type:str]
+    version: 3.13.1

--- a/apps/overlays/main/cluster-config.yaml
+++ b/apps/overlays/main/cluster-config.yaml
@@ -46,7 +46,7 @@ data:
   # Staging on cluster wildcard before moving production DNS:
   host_authentik: authentik.cluster.f4mily.net
   host_homepage: home.f4mily.net
-  host_immich: immich.cluster.f4mily.net
+  host_immich: immich.f4mily.net
   host_jellyfin: jellyfin.f4mily.net
   host_kavita: books.f4mily.net
   host_paperless: paperless.f4mily.net

--- a/apps/overlays/main/kustomization.yaml
+++ b/apps/overlays/main/kustomization.yaml
@@ -302,6 +302,8 @@ replacements:
         fieldPaths: [spec.values.ingress.tls.0.secretName]
       - select: {kind: Ingress, name: searxng}
         fieldPaths: [spec.tls.0.secretName]
+      - select: {kind: Ingress, name: immich}
+        fieldPaths: [spec.tls.0.secretName]
 
   - source:
       kind: ConfigMap
@@ -309,8 +311,6 @@ replacements:
       fieldPath: data.clusterTlsSecret
     targets:
       - select: {kind: Ingress, name: authentik}
-        fieldPaths: [spec.tls.0.secretName]
-      - select: {kind: Ingress, name: immich}
         fieldPaths: [spec.tls.0.secretName]
       - select: {kind: Ingress, name: tandoor}
         fieldPaths: [spec.tls.0.secretName]

--- a/docs/integrations/teslamate-grafana-authentik.md
+++ b/docs/integrations/teslamate-grafana-authentik.md
@@ -1,0 +1,22 @@
+# TeslaMate Grafana ↔ Authentik
+
+OAuth for `teslamate-grafana` uses Authentik at `https://login.f4mily.net` (application slug **`tesla-grafana`**).
+
+## GitOps
+
+- Secret: `apps/base/teslamate/teslamate-grafana-oauth.secret.yaml` (`client-id`, `client-secret`)
+- ConfigMap: `apps/base/teslamate/teslamate-grafana-config.configmap.yaml`
+- Blueprint: `apps/base/authentik/blueprints/teslamate-grafana-oauth.configmap.yaml`
+
+After first Flux reconcile, set the **Provider for TeslaMate Grafana** client secret in Authentik to match `teslamate-grafana-oauth` (same value as production if you migrated the OAuth app).
+
+Redirect URI: `https://teslamate-grafana.cluster.f4mily.net/login/generic_oauth`
+
+## MQTT (Home Assistant)
+
+- In-cluster: `mosquitto.teslamate.svc:1883`
+- LAN (production-like): `192.168.10.245:1883` via `mosquitto-external` Service
+
+## DB migrations
+
+NodePort `homelab-postgres-restore` → port **30433** on any control-plane node (see `infrastructure/overlays/main/database-clusters/postgres-restore-nodeport.yaml`).

--- a/docs/migrations/immich-docker-to-kubernetes.md
+++ b/docs/migrations/immich-docker-to-kubernetes.md
@@ -12,7 +12,7 @@ PVCs).
 
 | Component | Docker (production) | Kubernetes (homelab) |
 |-----------|---------------------|----------------------|
-| App | `immich_server` — `ghcr.io/immich-app/immich-server:release` | Helm chart `immich` — image tag `v1.119.0` (pin in `helmrelease.yaml`) |
+| App | `immich_server` — `ghcr.io/immich-app/immich-server:release` (prod: **v2.7.5**) | Helm chart `immich` — shared `values.image.tag` (e.g. `v2.7.5` in `helmrelease.yaml`) |
 | ML | `immich_machine_learning` | Chart subchart `machine-learning` |
 | DB | `immich_postgres` — `ghcr.io/immich-app/postgres:14-vectorchord…` | CNPG `immich-postgres` — `ghcr.io/tensorchord/cloudnative-vectorchord:16.9-0.4.3` |
 | Redis | `immich_redis` (Valkey 8) | In-cluster Redis (Bitnami legacy image, **no persistence**) |
@@ -34,19 +34,18 @@ migrated; Redis is ephemeral.
 - [ ] NFS PVCs bound: `immich-library`, `immich-fotos` in namespace `immich`.
 - [ ] Dev shell: `nix develop` (provides `kubectl`, `pg_restore`, `flux`).
 - [ ] Maintenance window (Immich offline for DB export/import).
-- [ ] **Version check:** align production Immich tag with cluster `helmrelease.yaml`
-  (`server.image.tag`). Production uses `:release`; cluster pins `v1.119.0`.
-  Major version skew can break schema restore — note prod version before cutover:
+- [ ] **Version check:** align production Immich tag with cluster `values.image.tag` in
+  `helmrelease.yaml`. Production uses `:release` (currently **v2.7.5**); cluster should
+  match before DB restore. Note prod version before cutover:
 
 ```bash
 docker inspect immich_server --format '{{.Config.Image}}'
 docker exec immich_server immich-admin version 2>/dev/null || true
 ```
 
-- [ ] **Vector extension:** production Postgres image ships VectorChord; cluster
-  Helm sets `DB_VECTOR_EXTENSION: pgvector` for Immich **v1.119**. After restore,
-  verify `\dx` and Immich startup logs. Upgrading to Immich v2+ may require
-  `DB_VECTOR_EXTENSION` / chart changes — see
+- [ ] **Vector extension:** production and cluster use VectorChord on `immich-postgres`.
+  Do **not** set `DB_VECTOR_EXTENSION=pgvector` on v2.x — Immich auto-detects `vchord`.
+  Verify `\dx` and startup logs after restore — see
   [Immich: pre-existing Postgres](https://docs.immich.app/administration/postgres-standalone).
 
 ## Phase 1 — Stop writes on Docker (production host)

--- a/docs/migrations/immich-docker-to-kubernetes.md
+++ b/docs/migrations/immich-docker-to-kubernetes.md
@@ -18,7 +18,7 @@ PVCs).
 | Redis | `immich_redis` (Valkey 8) | In-cluster Redis (Bitnami legacy image, **no persistence**) |
 | Library | `/mnt/truenas/Media/Bilder` → `/usr/src/app/upload` | PVC `immich-library` → NFS `Media` + `subPath: Bilder` |
 | Fotos | `/mnt/truenas/Media/Fotos` → `/fotos` | PVC `immich-fotos` → NFS `Media` + `subPath: Fotos` |
-| Ingress | Traefik `immich.f4mily.net` | NGINX `immich.cluster.f4mily.net` (cutover → `immich.f4mily.net`) |
+| Ingress | Traefik `immich.f4mily.net` | NGINX `immich.f4mily.net` |
 | Power Tools | `immich-power-tools` (optional) | Not deployed on cluster yet |
 
 Photos and videos **do not need to be copied** if the cluster NFS PVs point at the
@@ -77,7 +77,8 @@ docker exec immich_postgres pg_isready -U "${DB_USERNAME:-postgres}"
 BACKUP_DIR="/backup/immich-migration-$(date +%Y%m%d)"
 mkdir -p "$BACKUP_DIR"
 
-docker exec -t immich_postgres pg_dump \
+# No "-t" on docker exec — a TTY corrupts binary custom-format dumps (pg_restore segfault / EOF).
+docker exec immich_postgres pg_dump \
   -U "${DB_USERNAME:-postgres}" \
   -Fc \
   --no-owner \
@@ -97,7 +98,7 @@ Using container names from `Migration/Immich/compose.yml`:
 ### Plain SQL (alternative)
 
 ```bash
-docker exec -t immich_postgres pg_dump \
+docker exec immich_postgres pg_dump \
   -U "${DB_USERNAME:-postgres}" \
   -Fp \
   --no-owner \
@@ -165,13 +166,35 @@ role `immich`.
 
 ## Phase 4 — Database import into CNPG
 
-Port-forward the primary:
+### Recommended: plain SQL (`immich.sql`)
+
+Avoids `pg_restore` segfaults on corrupted or cross-version custom dumps. From the
+repo workstation (NodePort `immich-postgres-restore` on control-plane LAN IP, port
+`30432` — remove after migration):
+
+```bash
+Migration/Immich/scripts/restore-to-cnpg.sh /backup/immich-migration-YYYYMMDD/immich.sql
+```
+
+Or manually:
+
+```bash
+export PGPASSWORD="$(kubectl get secret -n immich homelab-postgres-immich -o jsonpath='{.data.password}' | base64 -d)"
+nix shell nixpkgs#postgresql_16 --command psql \
+  -h 192.168.10.43 -p 30432 -U immich -d immich -v ON_ERROR_STOP=1 \
+  -f /backup/immich-migration-YYYYMMDD/immich.sql
+```
+
+### Alternative: custom format (`pg_restore`)
+
+Only if `pg_restore -l immich.dump | wc -l` reports **hundreds+** lines (not `0` or
+segfault). **Never** use `docker exec -t` when creating the dump (see Phase 2).
+
+Port-forward (if kubelet/exec from your machine works):
 
 ```bash
 kubectl port-forward -n cnpg-system svc/immich-postgres-rw 15432:5432
 ```
-
-In another terminal (credentials from cluster secret):
 
 ```bash
 export PGPASSWORD="$(
@@ -188,21 +211,14 @@ pg_restore \
   -p 15432 \
   -U "$PGUSER" \
   -d immich \
-  --clean \
-  --if-exists \
   --no-owner \
   --no-acl \
   /backup/immich-migration-YYYYMMDD/immich.dump
 ```
 
-**PG 14 → 16:** use a `pg_restore` client from PostgreSQL 16+ (included in
-`nix develop`). Harmless errors about missing roles or extensions often appear;
-fix missing extensions with:
-
-```bash
-kubectl exec -n cnpg-system immich-postgres-1 -- \
-  psql -U postgres -d immich -c '\dx'
-```
+**PG 14 → 16:** use a `pg_restore` client from PostgreSQL 16+ (e.g. `nix shell
+nixpkgs#postgresql_16`). Extensions on `immich-postgres` must already include
+`vector`, `vchord`, `cube`, `earthdistance` before import.
 
 Post-restore checks:
 
@@ -224,7 +240,7 @@ kubectl -n immich logs deployment/immich-server --tail=80
 
 Smoke test (before public DNS):
 
-- https://immich.cluster.f4mily.net — login with migrated users
+- https://immich.f4mily.net — login with migrated users
 - Library scan: Admin → Library → Scan (if assets exist on NFS but counts look wrong)
 
 ## Phase 6 — DNS cutover
@@ -255,6 +271,16 @@ docker compose down
 
 Production runs `immich-power-tools` with API key and DB access. Not part of the
 cluster Helm release. Re-deploy separately or omit until Immich on cluster is stable.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|--------|-----|
+| `pg_restore` exit **139** (segfault) | Corrupt `-Fc` dump (often `docker exec -t`) | Re-run Phase 2 **without** `-t`; prefer `immich.sql` + Phase 4 SQL import |
+| `pg_restore -l` → **0** lines | Same | New dump; verify `pg_restore -l … \| wc -l` ≫ 0 before upload |
+| Millions of `\r` / `\x1b` in dump | TTY on `docker exec -t` | Use `Migration/Immich/scripts/backup-db.sh` |
+| `kubectl logs` / `exec` fails | Kubelet on node IPs unreachable from laptop | Use NodePort + `psql` from LAN, or in-cluster Jobs writing status to table `_restore_status` |
+| Job `Pending` (memory) | Control-plane RAM full | Delete failed restore Jobs; import via workstation `psql` only |
 
 ## Related docs
 

--- a/docs/migrations/phase1-postgres.md
+++ b/docs/migrations/phase1-postgres.md
@@ -23,7 +23,7 @@ kubectl get secret -n paperless-ngx homelab-postgres-paperless
 Per app on the Docker host:
 
 ```bash
-docker exec -t <postgres_container> pg_dump -U <user> -Fc <dbname> > /backup/<app>.dump
+docker exec <postgres_container> pg_dump -U <user> -Fc <dbname> > /backup/<app>.dump
 ```
 
 ## 3. Data import into CNPG

--- a/infrastructure/overlays/main/database-clusters/kustomization.yaml
+++ b/infrastructure/overlays/main/database-clusters/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - credentials
   # Velero volume-level restore (optional, separate from Barman PITR)
   - restore.yaml
+  - postgres-restore-nodeport.yaml

--- a/infrastructure/overlays/main/database-clusters/postgres-restore-nodeport.yaml
+++ b/infrastructure/overlays/main/database-clusters/postgres-restore-nodeport.yaml
@@ -1,0 +1,20 @@
+# Temporary LAN access for pg_dump/psql migrations (workstation → CNPG).
+# homelab-postgres: 30433 — immich-postgres uses 30432 (separate Service if needed).
+# Remove or leave in place when not migrating; restrict via firewall if exposed beyond LAN.
+apiVersion: v1
+kind: Service
+metadata:
+  name: homelab-postgres-restore
+  namespace: cnpg-system
+  labels:
+    app.kubernetes.io/component: migration-restore
+spec:
+  type: NodePort
+  selector:
+    cnpg.io/cluster: homelab-postgres
+    cnpg.io/instanceRole: primary
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+      nodePort: 30433

--- a/renovate.json
+++ b/renovate.json
@@ -33,10 +33,23 @@
         "/\\.ya?ml$/"
       ],
       "matchStrings": [
-        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(?:\\s+versioning=(?<versioning>\\S+))?(?:\\s+extractVersion=(?<extractVersion>\\S+))?\\s*\\n[^\\n]*?[\"']?(?<currentValue>[A-Za-z0-9][^\\s\"':]*)[\"']?\\s*(?:#.*)?$",
+        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(?:\\s+versioning=(?<versioning>\\S+))?(?:\\s+extractVersion=(?<extractVersion>\\S+))?\\s*\\n(?:[^\\n]*\\n)*?\\s*tag:\\s*[\"']?(?<currentValue>[^\\s\"'#]+)[\"']?\\s*(?:#.*)?$",
         "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(?:\\s+versioning=(?<versioning>\\S+))?(?:\\s+extractVersion=(?<extractVersion>\\S+))?\\s*\\n[^\\n]*?:\\s*[\"']?[^:\\s\"']+:(?<currentValue>[^\"'\\s]+)[\"']?\\s*(?:#.*)?$"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    },
+    {
+      "customType": "regex",
+      "description": "Immich shared image.tag (values.image.tag — avoids false match on redis/bitnami tags)",
+      "managerFilePatterns": [
+        "/apps/base/immich/helmrelease\\.yaml$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=docker depName=ghcr\\.io/immich-app/immich-server[^\\n]*\\n\\s+tag:\\s*[\"']?(?<currentValue>v[^\\s\"']+)[\"']?"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "ghcr.io/immich-app/immich-server",
+      "versioningTemplate": "semver"
     },
     {
       "customType": "regex",


### PR DESCRIPTION
## Summary

- **Immich**: Cut over ingress to `immich.f4mily.net`, upgrade to v2.7.5, fix large uploads (`client-max-body-size`), migration docs and CNPG restore NodePort.
- **TeslaMate**: Production migration (ENCRYPTION_KEY via secret file mount, image pin `3.0.0`), Authentik Grafana OAuth, MQTT LAN service, restore NodePort `30433`, **nginx WebSocket** for Phoenix LiveView (`/live/websocket`).
- **Renovate**: Improve Helm/Docker image tag detection.
- **Homepage**: Disable eager K8s stats to prevent UI crash.

## Test plan

- [ ] Flux reconciles `apps` kustomization without errors
- [ ] `https://immich.f4mily.net` — login, photo upload (>10 MB)
- [ ] `https://teslamate.cluster.f4mily.net` — no encryption warning, car data loads, **LiveView pages update** (geo-fences, settings) without WebSocket errors in browser console
- [ ] `https://teslamate-grafana.cluster.f4mily.net` — Authentik OAuth login
- [ ] MQTT: Home Assistant receives TeslaMate topics via `192.168.10.245:1883` (if used)
- [ ] Forgejo CI (lint / validate / kind dry-run) green


Made with [Cursor](https://cursor.com)