### PR TITLE
fix(immich): enable Socket.IO websocket on nginx ingress

### DIFF
--- a/apps/base/immich/ingress.yaml
+++ b/apps/base/immich/ingress.yaml
@@ -13,6 +13,10 @@ metadata:
     nginx.org/ssl-redirect: "false"
     nginx.org/redirect-to-https: "true"
     nginx.org/client-max-body-size: "0"
+    # Socket.IO (/api/socket.io) for live server status and uploads
+    nginx.org/websocket-services: "immich-server"
+    nginx.org/proxy-read-timeout: "3600s"
+    nginx.org/proxy-send-timeout: "3600s"
 spec:
   ingressClassName: nginx
   tls:


### PR DESCRIPTION
## Summary

- Add nginx ingress WebSocket support for `immich-server` so Socket.IO at `/api/socket.io` works over `wss://`.
- Fixes Immich reporting server offline and Firefox WebSocket connection failures behind the ingress.

## Test plan

- [x] Flux reconciles `apps` without errors
- [x] `https://immich.f4mily.net` — server status green, no `wss://…/api/socket.io` errors in browser console
- [x] Upload / live updates work in the web UI and mobile app


Made with [Cursor](https://cursor.com)