### PR TITLE
fix(teslamate): restore teslamate.f4mily.net ingress

### DIFF
--- a/apps/base/immich/ingress.yaml
+++ b/apps/base/immich/ingress.yaml
@@ -13,6 +13,10 @@ metadata:
     nginx.org/ssl-redirect: "false"
     nginx.org/redirect-to-https: "true"
     nginx.org/client-max-body-size: "0"
+    # Socket.IO (/api/socket.io) for live server status and uploads
+    nginx.org/websocket-services: "immich-server"
+    nginx.org/proxy-read-timeout: "3600s"
+    nginx.org/proxy-send-timeout: "3600s"
 spec:
   ingressClassName: nginx
   tls:

--- a/apps/base/teslamate/ingress.yaml
+++ b/apps/base/teslamate/ingress.yaml
@@ -17,9 +17,6 @@ metadata:
     nginx.org/websocket-services: "teslamate,teslamate-grafana"
     nginx.org/proxy-read-timeout: "3600s"
     nginx.org/proxy-send-timeout: "3600s"
-    # Strip /grafana prefix before forwarding to teslamate-grafana (GF_SERVER_SERVE_FROM_SUB_PATH).
-    nginx.org/path-regex: case_insensitive
-    nginx.org/rewrites: serviceName=teslamate-grafana rewrite=/$1
 spec:
   ingressClassName: nginx
   tls:
@@ -30,7 +27,7 @@ spec:
     - host: teslamate.f4mily.net
       http:
         paths:
-          - path: /grafana(/|$)(.*)
+          - path: /grafana
             pathType: Prefix
             backend:
               service:


### PR DESCRIPTION
## Summary

- Remove broken `nginx.org/path-regex` + `nginx.org/rewrites` on the TeslaMate ingress (PR #75 regression)
- Use a plain `/grafana` prefix path instead — Grafana already runs with `GF_SERVER_SERVE_FROM_SUB_PATH=true`, so no URI rewrite is needed

Fixes `teslamate.f4mily.net` returning nginx 404 (HTTP) and TLS `unrecognized name` / Firefox `SSL_ERROR_INTERNAL_ERROR_ALERT` (HTTPS).

Note: Immich websocket fix from this branch was already merged via #76.

## Test plan

- [ ] Flux reconciles `apps` kustomization
- [ ] `curl -I https://teslamate.f4mily.net/` → 200
- [ ] `curl -I https://teslamate.f4mily.net/grafana/` → 302 to login
- [ ] TeslaMate LiveView websocket connects
- [ ] Grafana OAuth login via Authentik works


Made with [Cursor](https://cursor.com)