### PR TITLE
feat(authentik): production migration to login.f4mily.net

### DIFF
--- a/apps/base/authentik/helmrelease.yaml
+++ b/apps/base/authentik/helmrelease.yaml
@@ -11,7 +11,8 @@ spec:
   chart:
     spec:
       chart: authentik
-      version: "2024.10.5"
+      # renovate: datasource=helm registryUrl=https://charts.goauthentik.io depName=authentik
+      version: "2025.12.4"
       sourceRef:
         kind: HelmRepository
         name: authentik-repo
@@ -36,8 +37,6 @@ spec:
       architecture: standalone
       auth:
         enabled: false
-      # Bitnami moved their images off Docker Hub in 2025; pin to the legacy
-      # mirror to keep `bitnami/redis` references working.
       image:
         registry: docker.io
         repository: bitnamilegacy/redis
@@ -51,19 +50,49 @@ spec:
         port: 5432
         name: authentik
         user: authentik
+      email:
+        host: mail.f4mily.net
+        port: 465
+        username: authentik@f4mily.net
+        use_ssl: true
+        from: authentik@f4mily.net
+        timeout: 10
+      error_reporting:
+        enabled: true
+    # Production DB is authoritative — do not overlay GitOps OAuth blueprints.
     blueprints:
-      configMaps:
-        - authentik-grafana-blueprint
-        - authentik-teslamate-grafana-blueprint
+      configMaps: []
     server:
       ingress:
         enabled: false
+      securityContext:
+        fsGroup: 1000
+      initContainers:
+        - name: media-init
+          # renovate: datasource=docker depName=docker.io/library/busybox
+          image: docker.io/library/busybox:1.36
+          command:
+            - sh
+            - -c
+            - mkdir -p /media/public/application-icons && chown -R 1000:1000 /media
+          volumeMounts:
+            - name: media
+              mountPath: /media
+          securityContext:
+            runAsUser: 0
       resources:
         requests:
           cpu: 25m
           memory: 256Mi
         limits:
           memory: 1Gi
+      volumes:
+        - name: media
+          persistentVolumeClaim:
+            claimName: authentik-media
+      volumeMounts:
+        - name: media
+          mountPath: /media
     worker:
       resources:
         requests:

--- a/apps/base/authentik/ingress.yaml
+++ b/apps/base/authentik/ingress.yaml
@@ -15,10 +15,10 @@ spec:
   ingressClassName: nginx
   tls:
     - hosts:
-        - authentik.cluster.f4mily.net
-      secretName: wildcard-cluster-f4mily-net-tls
+        - login.f4mily.net
+      secretName: wildcard-f4mily-net-tls
   rules:
-    - host: authentik.cluster.f4mily.net
+    - host: login.f4mily.net
       http:
         paths:
           - path: /

--- a/apps/base/authentik/kustomization.yaml
+++ b/apps/base/authentik/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - authentik-secret-key.secret.yaml
-  - blueprints/grafana-oauth.configmap.yaml
-  - blueprints/teslamate-grafana-oauth.configmap.yaml
+  - media-pvc.yaml
   - helmrelease.yaml
   - ingress.yaml

--- a/apps/base/authentik/media-pvc.yaml
+++ b/apps/base/authentik/media-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: authentik-media
+  namespace: authentik
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn-1
+  resources:
+    requests:
+      storage: 1Gi

--- a/apps/overlays/main/cluster-config.yaml
+++ b/apps/overlays/main/cluster-config.yaml
@@ -44,7 +44,7 @@ data:
   # Public-facing apps (covered by *.f4mily.net wildcard):
   host_audiobookshelf: audible.f4mily.net
   # Staging on cluster wildcard before moving production DNS:
-  host_authentik: authentik.cluster.f4mily.net
+  host_authentik: login.f4mily.net
   host_homepage: home.f4mily.net
   host_immich: immich.f4mily.net
   host_jellyfin: jellyfin.f4mily.net

--- a/apps/overlays/main/kustomization.yaml
+++ b/apps/overlays/main/kustomization.yaml
@@ -321,14 +321,14 @@ replacements:
         fieldPaths: [spec.tls.0.secretName]
       - select: {kind: Ingress, name: teslamate}
         fieldPaths: [spec.tls.0.secretName]
+      - select: {kind: Ingress, name: authentik}
+        fieldPaths: [spec.tls.0.secretName]
 
   - source:
       kind: ConfigMap
       name: homelab-cluster-config
       fieldPath: data.clusterTlsSecret
     targets:
-      - select: {kind: Ingress, name: authentik}
-        fieldPaths: [spec.tls.0.secretName]
       - select: {kind: Ingress, name: tandoor}
         fieldPaths: [spec.tls.0.secretName]
       - select: {kind: Ingress, name: goloom}

--- a/docs/applications.md
+++ b/docs/applications.md
@@ -71,6 +71,7 @@ here so it is obvious what is **planned** but not deployed:
 | speedtest-tracker  | wip    | ingress only, missing Deployment          |
 | watchyourlan       | on     | DaemonSet (hostNetwork), scan via IFACES  |
 | teslamate          | on     | Deployment, Mosquitto, CNPG, teslamate.f4mily.net (/grafana/) |
+| authentik          | on     | HelmRelease, CNPG, login.f4mily.net (production IdP)            |
 | goloom             | on     | Deployment, CNPG PostgreSQL, goloom.cluster.f4mily.net |
 | pcm                | wip    | ingress only, missing HelmRelease         |
 

--- a/docs/migrations/authentik-docker-to-kubernetes.md
+++ b/docs/migrations/authentik-docker-to-kubernetes.md
@@ -1,0 +1,96 @@
+# Authentik: Docker (production) → Kubernetes
+
+Migrate production Authentik (`login.f4mily.net` on Docker Swarm / prod host) to the
+homelab cluster (HelmRelease, CloudNativePG `homelab-postgres`, NGINX ingress).
+
+**Source:** `Migration/authentik/` (PGDATA, media, compose-stack.yml).
+
+**Target:** `apps/base/authentik/`, Database `homelab-postgres-authentik`.
+
+## Architecture
+
+| Component | Docker (production) | Kubernetes |
+|-----------|---------------------|------------|
+| App | `ghcr.io/goauthentik/server:2025.12.4` | Helm chart `2025.12.4` |
+| DB | Postgres 16 (bind mount PGDATA) | CNPG `homelab-postgres` / DB `authentik` |
+| Redis | Docker volume | In-cluster Bitnami Redis (ephemeral) |
+| Media | `/mnt/cephfs/authentik/media` | PVC `authentik-media` |
+| Ingress | Traefik `login.f4mily.net` | NGINX `login.f4mily.net` |
+
+## Prerequisites
+
+- CNPG cluster Ready: `kubectl get cluster -n cnpg-system homelab-postgres`
+- NodePort restore: `homelab-postgres-restore` → **30433** (control-plane LAN IP)
+- Production `AUTHENTIK_SECRET_KEY` must match cluster secret (SOPS or live patch)
+- Maintenance window — Authentik offline during DB import
+
+## Phase 1 — Export from Migration PGDATA
+
+If you have a logical dump already, skip to Phase 2.
+
+```bash
+PGDATA=/path/to/Migration/authentik/database
+nix shell nixpkgs#postgresql_16 --command bash -c "
+  pg_ctl -D '$PGDATA' -o '-p 55432 -h 127.0.0.1 -k /tmp' -l /tmp/authentik-pg.log start
+  PGPASSWORD='<prod-db-password>' pg_dump -h 127.0.0.1 -p 55432 -U authentik \
+    -Fc --no-owner --no-acl authentik > /tmp/authentik.dump
+  pg_ctl -D '$PGDATA' stop
+"
+```
+
+## Phase 2 — Import into CNPG
+
+```bash
+export KUBECONFIG=homelab-infrastructure/talos/kubeconfig
+kubectl scale deployment -n authentik authentik-server authentik-worker --replicas=0
+
+CNPG_PASS=$(kubectl get secret -n authentik homelab-postgres-authentik -o jsonpath='{.data.password}' | base64 -d)
+NODE_IP=192.168.10.41   # any control-plane node
+
+# If DB was dropped: recreate via CNPG Database CR
+kubectl apply -f apps/overlays/main/databases/authentik.yaml
+
+pg_restore -h "$NODE_IP" -p 30433 -U authentik -d authentik \
+  --no-owner --no-acl --clean --if-exists /tmp/authentik.dump
+```
+
+Verify:
+
+```bash
+psql -h "$NODE_IP" -p 30433 -U authentik -d authentik \
+  -c "SELECT COUNT(*) FROM authentik_core_user;"
+```
+
+## Phase 3 — Secret key and media
+
+**Secret key** (required — decrypts stored credentials):
+
+```bash
+just sops-edit apps/base/authentik/authentik-secret-key.secret.yaml
+# Set secret-key to production AUTHENTIK_SECRET_KEY from compose-stack.yml
+```
+
+**Media** (icons, uploads):
+
+```bash
+POD=$(kubectl get pod -n authentik -l app.kubernetes.io/name=authentik,app.kubernetes.io/component=server -o jsonpath='{.items[0].metadata.name}')
+kubectl cp Migration/authentik/media/. authentik/"$POD":/media/
+```
+
+## Phase 4 — Production cutover (GitOps)
+
+1. `cluster-config.yaml`: `host_authentik: login.f4mily.net`
+2. Ingress TLS → `publicTlsSecret` (`wildcard-f4mily-net-tls`)
+3. DNS: `login.f4mily.net` → cluster VIP (`homelab-infrastructure/dns/servers.tf`)
+4. Remove GitOps OAuth blueprints (production DB is authoritative)
+5. `terraform apply` DNS + `flux reconcile kustomization apps`
+
+## Phase 5 — Validate
+
+- https://login.f4mily.net/ → login with existing production user
+- OAuth apps (Grafana, Immich, …) — redirect URIs unchanged if hostname stays `login.f4mily.net`
+- Outposts: Docker-based outposts from production need re-deployment (K8s/LDAP/proxy outposts)
+
+## Rollback
+
+Re-enable Docker stack on prod; restore AdGuard rewrite `login.f4mily.net` → `192.168.10.244`.

--- a/renovate.json
+++ b/renovate.json
@@ -140,6 +140,7 @@
         "!apps/base/kite/**",
         "!apps/base/authentik/**"
       ],
+      "groupName": "flux helm releases",
       "groupSlug": "flux-helm-releases",
       "minimumReleaseAge": "7 days",
       "automerge": false

--- a/renovate.json
+++ b/renovate.json
@@ -65,6 +65,20 @@
     },
     {
       "customType": "regex",
+      "description": "Authentik Helm chart (CalVer YYYY.MM.P on charts.goauthentik.io)",
+      "managerFilePatterns": [
+        "/apps/base/authentik/helmrelease\\.yaml$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=helm registryUrl=https://charts\\.goauthentik\\.io depName=authentik\\s*\\n\\s+version:\\s*[\"']?(?<currentValue>[^\"'\\s]+)[\"']?"
+      ],
+      "datasourceTemplate": "helm",
+      "depNameTemplate": "authentik",
+      "registryUrlTemplate": "https://charts.goauthentik.io",
+      "versioningTemplate": "loose"
+    },
+    {
+      "customType": "regex",
       "description": "CI workflow action versions (Forgejo and GitHub)",
       "managerFilePatterns": [
         "/^\\.(forgejo|github)/workflows/.*\\.ya?ml$/"
@@ -100,14 +114,32 @@
       "enabled": false
     },
     {
+      "description": "Authentik Helm chart uses CalVer (YYYY.MM.P) — dedicated PRs",
+      "matchManagers": [
+        "custom.regex",
+        "flux"
+      ],
+      "matchDepNames": [
+        "authentik"
+      ],
+      "matchFileNames": [
+        "apps/base/authentik/**"
+      ],
+      "versioning": "loose",
+      "groupName": "authentik",
+      "groupSlug": "authentik",
+      "minimumReleaseAge": "7 days",
+      "automerge": false
+    },
+    {
       "description": "Group all flux Helm chart bumps (except kite)",
       "matchManagers": [
         "flux"
       ],
       "matchFileNames": [
-        "!apps/base/kite/**"
+        "!apps/base/kite/**",
+        "!apps/base/authentik/**"
       ],
-      "groupName": "flux helm releases",
       "groupSlug": "flux-helm-releases",
       "minimumReleaseAge": "7 days",
       "automerge": false


### PR DESCRIPTION
## Summary

- Cut over Authentik to **`login.f4mily.net`** (public TLS, cluster ingress)
- Upgrade Helm chart **2024.10.5 → 2025.12.4** (matches production Docker image)
- Add media PVC + init container for application icons
- Remove GitOps OAuth blueprints — production DB restored to CNPG is authoritative
- **Fix Renovate**: custom regex manager + package rule for Authentik CalVer helm chart (`charts.goauthentik.io`)

## Renovate

Authentik was not tracked because the chart uses **CalVer** (`YYYY.MM.P`) and lacked an explicit Renovate marker. Added:

- `# renovate: datasource=helm registryUrl=https://charts.goauthentik.io depName=authentik` on chart version
- `custom.regex` manager in `renovate.json`
- Dedicated `authentik` package rule with `versioning: loose`

## Related

- DNS cutover (separate repo): `homelab-infrastructure` branch `feat/authentik-login-dns`
- Migration runbook: `docs/migrations/authentik-docker-to-kubernetes.md`
- DB import was done live; ensure `authentik-secret-key` SOPS matches production before merge

## Test plan

- [ ] `just validate`
- [ ] Flux reconciles `apps` kustomization
- [ ] `https://login.f4mily.net/` → Authentik login (after DNS apply)
- [ ] Existing OAuth apps (Grafana, Immich, …) still authenticate
- [ ] Renovate dashboard shows `authentik` helm dependency


Made with [Cursor](https://cursor.com)