### PR TITLE
Fix CrashLoopBackOff for authentik-worker

### DIFF
--- a/gitops-homelab/apps/base/authentik/patches/crashloopbackoff-fix.yaml
+++ b/gitops-homelab/apps/base/authentik/patches/crashloopbackoff-fix.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: authentik-worker
+  namespace: authentik
+spec:
+  template:
+    spec:
+      containers:
+        - name: worker
+          image: authentik/worker:2026.2.2 # Downgrade to a stable version


### PR DESCRIPTION
## Problem
Der Pod `authentik-worker` ist in einem `CrashLoopBackOff`-Zustand, was auf eine mögliche Versionsinkompatibilität mit der Produktionsdatenbank hinweist.

## Lösung
Dieser PR downgrades das Image des `authentik-worker`-Pods auf eine stabilere Version (`2026.2.2`), um die Stabilität wiederherzustellen.

Bitte überprüfen und mergen.

---
Auto-remediation for **KubePodCrashLoopBackOff** in `authentik/authentik-worker-7dc95c8798-86b29`.