### PR TITLE
Erhöhung der Speicherkapazität für reflector Pod

### DIFF
--- a/gitops-homelab/apps/base/reflector/patches/increase-memory-limits.yaml
+++ b/gitops-homelab/apps/base/reflector/patches/increase-memory-limits.yaml
@@ -1,0 +1,15 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reflector-system-reflector
+  namespace: reflector-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: reflector
+        resources:
+          requests:
+            memory: "256Mi"
+          limits:
+            memory: "512Mi"


### PR DESCRIPTION
## Hintergrund
Der reflector Pod im reflector-system Namespace wurde aufgrund von OOMKilled beendet. Dies deutet darauf hin, dass der Pod mehr Speicher benötigt.

## Änderungen
- Erhöhung der Speicherkapazität für den reflector Pod auf 256Mi (Request) und 512Mi (Limit).

## Auswirkungen
Diese Änderung sollte die Stabilität des Pods verbessern und das Risiko von OOMKilled-Fehlern verringern.

---
Auto-remediation for **KubePodOOMKilled** in `reflector-system/reflector-system-reflector-65f59458b7-7rj25`.