### PR TITLE
feat(authentik): upgrade to 2026.2.3 with runbook and secret fix

### DIFF
--- a/apps/base/authentik/authentik-secret-key.secret.yaml
+++ b/apps/base/authentik/authentik-secret-key.secret.yaml
@@ -1,22 +1,22 @@
 apiVersion: v1
 data:
-    secret-key: ENC[AES256_GCM,data:ZR0SRpHqdcmk8aYQHWNWAYxo7ma7KJa7vkYRXBNFjAFVVqvyhhH2HsS31XuPch0HsCUa5Wf+928CxnnMRwqzLIz5lsodJPv07IaU3B2QQTM=,iv:GusNeTRpV68z5S8uXdPwpQF5rfqcwM9ZcBeG7y/peOg=,tag:MK4osQ8Vyr87BAPcPXw9hQ==,type:str]
+    secret-key: ENC[AES256_GCM,data:OLAhm1sKIEUvgMsGXs27+QlaS8f/oxqvuJcr/7S+gVPwtupCsBUxQLci7mOLPEx6ENRLi+PMPL8FmHXwXYul5pe4Ct88cWALv5WkCVhtBIhmZfpUDS5VEvPPNchTu2NTY3jt1aSgMtHd6P0N,iv:5JjDYGpdXO8UM5v8Vwe01hFHoU49+WFYbjfy+fnCzG8=,tag:Q0NJsWn8W0vHXOjvgLV0dQ==,type:str]
 kind: Secret
 metadata:
     name: authentik-secret-key
     namespace: authentik
 sops:
     age:
-        - recipient: age1u5lcvuuwd4lk7f3xewjk70j75yuh68myr89qkd0e8d44zgyjleeqw03vqs
-          enc: |
+        - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHZEdGcytWSnliQ21xQjFl
-            VXdiUTIyaFJqWE9sWnd1UkVoSzZzWUpDZG5BCnJwelRLcURCL2Mwa2hnYUU1MmVK
-            UFFEb2xkOHJLQlJnU1FGVHdDRTR3OHcKLS0tIHgvemY3OG1pRVdML0dIa1RvQStv
-            OXNpTzBRVDZYZ3hRaUF3TVZIT0FmM1UKdIS3NphcQhwRLJuYZzsSmJjPpyL3dn95
-            fyS6jgR5nKyrhizsrJl/G18z9O2FgxISmcM4Qe8oNNIsREQWkO0erQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHSVNJa0ZDbURtd2diK05j
+            elY4TW5EblpDQmcydVR6ZlB3L0dxamQ2REVFCjAzRHRHaW96anJMMUthTEhZS3VI
+            eW9OSHloOFVEcGNkRmRlOUpHZ2h6UlkKLS0tIExJWWJPdzJ3QzF2LzUxTThvZXRh
+            NFdCVmRJclhTek5NMmxIQ3FjQ0FrM0UKs6VONzC7gasDfN5P4+kKV3jd/z98IJTy
+            /oThFxNWTNBBOa453riExUtCqMMNaC6BZMV8H2jdApCXRYwOgJSqRQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-17T20:14:53Z"
-    mac: ENC[AES256_GCM,data:srzJ+3SCWDk3NKKjhpYLOzZhW/VYyNg5t/AZqbekJZtkQvAJLVF+a9Xyen7DLN7wMnDCU4ji/TYXmcCTYyAhU3+E8QxqiwbipAVeR176+0ZPhn3+rZ3yv9gzgtb3SCp9IA+baJ+bPNnhBNHg+OYKgS2r47/W/sTk/CAENsMG9m8=,iv:sN+3RHyyUVgUVQMRaW1Ty6pVMHJWVTOKnGLWq0U75rE=,tag:snHPiMdiQfeK1+3sNsv9Rg==,type:str]
+          recipient: age1u5lcvuuwd4lk7f3xewjk70j75yuh68myr89qkd0e8d44zgyjleeqw03vqs
     encrypted_regex: ^(data|stringData)$
-    version: 3.12.1
+    lastmodified: "2026-05-23T22:32:50Z"
+    mac: ENC[AES256_GCM,data:AyCnd2IuZjqgU6NpFpPfTPl65VELzFC2p1UGSznTsjKycD9LGdtoMSmjuP4nB6WT/edIi+Y9uGrzFC67bUXhmG37+yvZLmAKOxhgF+LCf6W+Uy7K/e+wNu0GNMaYGGNOpU3M1fqbZUoOtOr+bX92rlr1JvOubuq/q67QFoJIp5A=,iv:J8Awk0AA4oPzZr9DAnW81Q6I0GTR/B7AIYXGabr/Gzw=,tag:1QF7WZzmpfyDLmOm6sb06g==,type:str]
+    version: 3.13.0

--- a/apps/base/authentik/helmrelease.yaml
+++ b/apps/base/authentik/helmrelease.yaml
@@ -11,8 +11,9 @@ spec:
   chart:
     spec:
       chart: authentik
+      # Upgrade path: 2025.12.4 → 2026.2.x (see docs/migrations/authentik-upgrade-2026.md)
       # renovate: datasource=helm registryUrl=https://charts.goauthentik.io depName=authentik
-      version: "2026.5.0"
+      version: "2026.2.3"
       sourceRef:
         kind: HelmRepository
         name: authentik-repo
@@ -65,6 +66,8 @@ spec:
     server:
       ingress:
         enabled: false
+      deploymentStrategy:
+        type: Recreate
       securityContext:
         fsGroup: 1000
       initContainers:
@@ -74,10 +77,10 @@ spec:
           command:
             - sh
             - -c
-            - mkdir -p /media/public/application-icons && chown -R 1000:1000 /media
+            - mkdir -p /data/media/public/application-icons && chown -R 1000:1000 /data
           volumeMounts:
-            - name: media
-              mountPath: /media
+            - name: data
+              mountPath: /data
           securityContext:
             runAsUser: 0
       resources:
@@ -87,12 +90,12 @@ spec:
         limits:
           memory: 1Gi
       volumes:
-        - name: media
+        - name: data
           persistentVolumeClaim:
             claimName: authentik-media
       volumeMounts:
-        - name: media
-          mountPath: /media
+        - name: data
+          mountPath: /data
     worker:
       resources:
         requests:

--- a/apps/base/authentik/media-migrate-job.yaml
+++ b/apps/base/authentik/media-migrate-job.yaml
@@ -1,0 +1,61 @@
+# One-shot Job: move legacy /media layout → /data/media (Authentik 2026.2+).
+# Apply BEFORE upgrading Helm chart to 2026.2.x (server scaled to 0):
+#
+#   kubectl scale deploy -n authentik authentik-server authentik-worker --replicas=0
+#   kubectl apply -f apps/base/authentik/media-migrate-job.yaml
+#   kubectl wait -n authentik --for=condition=complete job/authentik-media-migrate --timeout=300s
+#   kubectl delete job -n authentik authentik-media-migrate --ignore-not-found
+#
+# Not in kustomization.yaml — manual pre-upgrade step only.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: authentik-media-migrate
+  namespace: authentik
+spec:
+  ttlSecondsAfterFinished: 3600
+  backoffLimit: 1
+  template:
+    spec:
+      restartPolicy: Never
+      securityContext:
+        fsGroup: 1000
+      containers:
+        - name: migrate
+          image: docker.io/library/busybox:1.36
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+              echo "Checking PVC layout on /data (authentik-media)..."
+              if [ -d /data/media/public ] || [ -f /data/media/.keep ]; then
+                echo "Already migrated (/data/media exists)."
+                exit 0
+              fi
+              if [ -d /data/public ] || [ -d /data/private ]; then
+                echo "Legacy root layout detected — moving to /data/media/"
+                mkdir -p /data/media
+                for item in /data/*; do
+                  base=$(basename "$item")
+                  case "$base" in
+                    media|lost+found) continue ;;
+                  esac
+                  mv "$item" /data/media/
+                done
+                chown -R 1000:1000 /data/media
+                echo "Done."
+                exit 0
+              fi
+              echo "Fresh PVC — creating /data/media/public/application-icons"
+              mkdir -p /data/media/public/application-icons
+              chown -R 1000:1000 /data/media
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: authentik-media

--- a/docs/migrations/authentik-docker-to-kubernetes.md
+++ b/docs/migrations/authentik-docker-to-kubernetes.md
@@ -63,12 +63,15 @@ psql -h "$NODE_IP" -p 30433 -U authentik -d authentik \
 
 ## Phase 3 — Secret key and media
 
-**Secret key** (required — decrypts stored credentials):
+**Secret key** (required — decrypts stored credentials; must be ASCII, same as Docker production):
 
 ```bash
-just sops-edit apps/base/authentik/authentik-secret-key.secret.yaml
-# Set secret-key to production AUTHENTIK_SECRET_KEY from compose-stack.yml
+cd apps/base/authentik
+just sops-create authentik-secret-key authentik \
+  secret-key='<AUTHENTIK_SECRET_KEY from Migration/authentik/compose-stack.yml>'
 ```
+
+See also: [authentik-upgrade-2026.md](./authentik-upgrade-2026.md) for version upgrades.
 
 **Media** (icons, uploads):
 

--- a/docs/migrations/authentik-upgrade-2026.md
+++ b/docs/migrations/authentik-upgrade-2026.md
@@ -1,0 +1,129 @@
+# Authentik Upgrade: 2025.12.4 → 2026.x
+
+Production DB was migrated from Docker at **2025.12.4**. Upgrades must follow Authentik’s
+[supported sequence](https://docs.goauthentik.io/install-config/upgrade/) — **no skipping major.minor
+releases** (e.g. do not jump 2025.12 → 2026.5 without passing 2026.2).
+
+## Target version
+
+| Step | Chart / image | Notes |
+|------|---------------|-------|
+| Current | `2025.12.4` | Stable baseline after Docker→K8s migration |
+| Next | `2026.2.x` (latest patch) | Required intermediate major; read [2026.2 release notes](https://docs.goauthentik.io/releases/2026.2/) |
+| Later | `2026.4.x` / `2026.5.x` | Only after 2026.2.x is healthy |
+
+Renovate is limited to `2026.2.x` until 2026.2 is verified; then bump allowedVersions for 2026.4+ separately.
+
+## Pre-flight checklist
+
+1. **Maintenance window** — login flows offline for several minutes during migrations.
+2. **CNPG backup** — on-demand before upgrade:
+   ```bash
+   kubectl apply -f - <<EOF
+   apiVersion: postgresql.cnpg.io/v1
+   kind: Backup
+   metadata:
+     name: authentik-pre-upgrade-$(date +%Y%m%d)
+     namespace: cnpg-system
+   spec:
+     cluster:
+       name: homelab-postgres
+     method: barmanObjectStore
+   EOF
+   kubectl wait -n cnpg-system --for=jsonpath='{.status.phase}'=completed \
+     backup/authentik-pre-upgrade-$(date +%Y%m%d) --timeout=600s
+   ```
+   Optional logical dump (authentik DB only, restore via NodePort 30433):
+   ```bash
+   pg_dump -h 192.168.10.41 -p 30433 -U authentik -d authentik -Fc --no-owner --no-acl \
+     -f Migration/authentik/backups/authentik-pre-upgrade.dump
+   ```
+   Requires PostgreSQL **18** client (`nix shell nixpkgs#postgresql_18`).
+3. **Secret key** — `authentik-secret-key` SOPS must hold the production ASCII key (same as Docker).
+4. **Disk headroom** — Talos root ~20 GiB; ensure nodes are not in `DiskPressure` (see runbook below).
+5. **HelmRelease** — `server.deploymentStrategy: Recreate` (RWO media PVC).
+6. **Outposts** — embedded proxy outposts upgrade with server/worker (same image tag).
+
+## Breaking changes (2025.12 → 2026.2)
+
+- **File storage path**: local files move from `/media` → `/data/media` (mount parent `/data`).
+  Update Helm values before upgrading to 2026.2 (see Phase 2).
+- **Outpost version skew**: server and outposts must run the same version.
+- **RBAC migrations**: if a prior failed upgrade left the DB half-migrated, restore from backup
+  before retrying ([issue #20734](https://github.com/goauthentik/authentik/issues/20734)).
+
+## Phase 1 — GitOps prep (no cluster change)
+
+1. Update `apps/base/authentik/helmrelease.yaml`:
+   - `version: "2026.2.x"` (latest patch from `helm search repo authentik --versions`).
+   - Add volume mount changes for `/data` (example):
+
+   ```yaml
+   server:
+     deploymentStrategy:
+       type: Recreate
+     volumes:
+       - name: data
+         persistentVolumeClaim:
+           claimName: authentik-media   # reuse PVC; mount as /data
+     volumeMounts:
+       - name: data
+         mountPath: /data
+   ```
+
+   Move existing PVC content once: `media/*` → `data/media/` (Job or `kubectl cp`).
+
+2. Remove Renovate pin `allowedVersions: "<2026"` in `renovate.json` after successful upgrade.
+
+3. PR + CI (`just validate-full`).
+
+## Phase 2 — Staged upgrade (cluster)
+
+```bash
+export KUBECONFIG=homelab-infrastructure/talos/kubeconfig
+
+# 1. Suspend auto-reconcile during manual steps
+flux suspend helmrelease authentik -n authentik
+
+# 2. Scale down
+kubectl scale deploy -n authentik authentik-server authentik-worker --replicas=0
+
+# 3. Migrate media PVC layout (2026.2 requires /data/media)
+kubectl apply -f apps/base/authentik/media-migrate-job.yaml
+kubectl wait -n authentik --for=condition=complete job/authentik-media-migrate --timeout=300s
+kubectl delete job -n authentik authentik-media-migrate --ignore-not-found
+
+# 4. Merge GitOps PR → flux reconcile OR helm upgrade --version 2026.2.x
+
+# 5. Watch migrations
+kubectl logs -n authentik -l app.kubernetes.io/component=server -c server -f
+
+# 6. Verify
+curl -skI --resolve login.f4mily.net:443:192.168.10.245 https://login.f4mily.net/
+# Admin → Outposts → health green; test Grafana/Forgejo OAuth
+
+flux resume helmrelease authentik -n authentik
+```
+
+## Phase 3 — Post-upgrade
+
+- Bump to latest **2026.2.x** patch via Renovate.
+- Only after 2026.2 stable: plan **2026.4** / **2026.5** as separate maintenance (same sequence rules).
+- Update `docs/migrations/authentik-docker-to-kubernetes.md` target version table.
+
+## Rollback
+
+Authentik **does not support downgrades**. On migration failure:
+
+1. Scale deployments to 0.
+2. Restore CNPG DB from backup taken in pre-flight.
+3. Re-deploy chart `2025.12.4`.
+4. Investigate logs for `migration inconsistency` before retry.
+
+## Estimated effort
+
+| Scenario | Effort |
+|----------|--------|
+| Clean 2025.12.4 DB, no failed 2026 attempts | ~1–2 h (GitOps + PVC path + verify OAuth) |
+| Prior failed 2026.x upgrade on this DB | Half day+ (restore + possible manual SQL per upstream issues) |
+| Skip sequence (2025.12 → 2026.5 direct) | **Not supported** — high risk of broken RBAC schema |

--- a/renovate.json
+++ b/renovate.json
@@ -163,6 +163,7 @@
       "groupName": "authentik",
       "groupSlug": "authentik",
       "minimumReleaseAge": "7 days",
+      "allowedVersions": "2026.2.*",
       "automerge": false
     },
     {


### PR DESCRIPTION
## Summary

- Upgrade Authentik Helm chart from **2025.12.4** to **2026.2.3** (required intermediate step before 2026.4+).
- Fix SOPS `authentik-secret-key` to the production ASCII key (resolves server/worker crash loop from invalid secret).
- Migrate server PVC mount from `/media` to `/data` (2026.2 breaking change) with init container + one-shot `media-migrate-job.yaml`.
- Set `server.deploymentStrategy: Recreate` for RWO PVC compatibility.
- Add runbook: `docs/migrations/authentik-upgrade-2026.md`.
- Limit Renovate to `2026.2.*` until 2026.2 is verified in production.

## Pre-upgrade backups (completed)

| Backup | Status |
|--------|--------|
| CNPG Barman → S3 | `backup-20260523223918` (`authentik-pre-upgrade-20260523`) |
| Logical pg_dump (authentik DB) | `Migration/authentik/backups/authentik-pre-upgrade-20260524-004201.dump` |

## Test plan

- [ ] Review runbook `docs/migrations/authentik-upgrade-2026.md`
- [ ] `flux suspend helmrelease authentik -n authentik`
- [ ] Scale server/worker to 0, apply `media-migrate-job.yaml`, wait for completion
- [ ] Merge PR → Flux reconcile
- [ ] Verify Django migrations in server logs
- [ ] Verify `https://login.f4mily.net` + OAuth apps / outposts
- [ ] `flux resume helmrelease authentik`

## Rollback

Authentik does not support chart downgrade. Restore from Barman backup or logical pg_dump (see runbook).


Made with [Cursor](https://cursor.com)