### PR TITLE
feat(authentik): upgrade to 2026.5.0

### DIFF
--- a/apps/base/authentik/helmrelease.yaml
+++ b/apps/base/authentik/helmrelease.yaml
@@ -11,9 +11,9 @@ spec:
   chart:
     spec:
       chart: authentik
-      # Upgrade path: 2025.12.4 → 2026.2.x (see docs/migrations/authentik-upgrade-2026.md)
+      # Upgrade path: 2026.2.3 → 2026.5.x (see docs/migrations/authentik-upgrade-2026.md)
       # renovate: datasource=helm registryUrl=https://charts.goauthentik.io depName=authentik
-      version: "2026.2.3"
+      version: "2026.5.0"
       sourceRef:
         kind: HelmRepository
         name: authentik-repo

--- a/docs/migrations/authentik-upgrade-2026.md
+++ b/docs/migrations/authentik-upgrade-2026.md
@@ -8,11 +8,8 @@ releases** (e.g. do not jump 2025.12 → 2026.5 without passing 2026.2).
 
 | Step | Chart / image | Notes |
 |------|---------------|-------|
-| Current | `2025.12.4` | Stable baseline after Docker→K8s migration |
-| Next | `2026.2.x` (latest patch) | Required intermediate major; read [2026.2 release notes](https://docs.goauthentik.io/releases/2026.2/) |
-| Later | `2026.4.x` / `2026.5.x` | Only after 2026.2.x is healthy |
-
-Renovate is limited to `2026.2.x` until 2026.2 is verified; then bump allowedVersions for 2026.4+ separately.
+| Current | `2026.2.3` | Stable after 2025.12 → 2026.2 upgrade |
+| Next | `2026.5.x` (latest patch) | Required next major; read [2026.5 release notes](https://docs.goauthentik.io/releases/2026.5/) |
 
 ## Pre-flight checklist
 

--- a/renovate.json
+++ b/renovate.json
@@ -163,7 +163,7 @@
       "groupName": "authentik",
       "groupSlug": "authentik",
       "minimumReleaseAge": "7 days",
-      "allowedVersions": "2026.2.*",
+      "allowedVersions": "2026.5.*",
       "automerge": false
     },
     {


### PR DESCRIPTION
## Summary

- Bump Authentik Helm chart from **2026.2.3** to **2026.5.0** (next supported major after 2026.2).
- Update migration runbook target version table.
- Limit Renovate to `2026.5.*`.

## Pre-upgrade backups (completed on cluster)

| Backup | Status |
|--------|--------|
| CNPG Barman | `backup-20260523225316` (`authentik-pre-upgrade-20260524-0053`) |
| Logical pg_dump | `Migration/authentik/backups/authentik-pre-upgrade-20260524-0053.dump` |

## Test plan

- [x] CNPG backup completed
- [x] Helm upgrade to 2026.5.0 applied on cluster
- [ ] Verify login.f4mily.net + OAuth flows after merge


Made with [Cursor](https://cursor.com)