### PR TITLE
feat(forgejo): deploy production Git server to cluster

### DIFF
--- a/apps/base/forgejo/deployment.yaml
+++ b/apps/base/forgejo/deployment.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: forgejo
+  namespace: forgejo
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: forgejo
+  template:
+    metadata:
+      labels:
+        app: forgejo
+        app.kubernetes.io/name: forgejo
+    spec:
+      enableServiceLinks: false
+      securityContext:
+        fsGroup: 1000
+      containers:
+        - name: forgejo
+          # renovate: datasource=docker depName=codeberg.org/forgejo/forgejo versioning=semver
+          image: codeberg.org/forgejo/forgejo:15
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 3000
+              name: http
+            - containerPort: 22
+              name: ssh
+          env:
+            - name: TZ
+              value: Europe/Berlin
+            - name: USER_UID
+              value: "1000"
+            - name: USER_GID
+              value: "1000"
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            allowPrivilegeEscalation: false
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+            limits:
+              memory: 2Gi
+          livenessProbe:
+            httpGet:
+              path: /api/healthz
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /api/healthz
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+          volumeMounts:
+            - name: data
+              mountPath: /data
+              subPath: docker/forgejo
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: forgejo-data

--- a/apps/base/forgejo/forgejo-runner-register.secret.yaml.template
+++ b/apps/base/forgejo/forgejo-runner-register.secret.yaml.template
@@ -1,0 +1,10 @@
+# One-time registration token from Forgejo Admin → Actions → Runners → Create new Runner.
+# sops -e forgejo-runner-register.secret.yaml.template > forgejo-runner-register.secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: forgejo-runner-register
+  namespace: forgejo
+type: Opaque
+stringData:
+  token: REPLACE_WITH_RUNNER_REGISTRATION_TOKEN

--- a/apps/base/forgejo/ingress.yaml
+++ b/apps/base/forgejo/ingress.yaml
@@ -1,0 +1,36 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: forgejo
+  namespace: forgejo
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: Forgejo
+    gethomepage.dev/description: Git hosting & CI
+    gethomepage.dev/group: Infrastructure
+    gethomepage.dev/icon: forgejo.png
+    gethomepage.dev/pod-selector: app=forgejo
+    nginx.org/ssl-redirect: "false"
+    nginx.org/redirect-to-https: "true"
+    nginx.org/websocket-services: "forgejo-app"
+    nginx.org/proxy-read-timeout: "3600s"
+    nginx.org/proxy-send-timeout: "3600s"
+    nginx.org/client-max-body-size: "0"
+    nginx.org/proxy-body-size: "0"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - git.f4mily.net
+      secretName: wildcard-f4mily-net-tls
+  rules:
+    - host: git.f4mily.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: forgejo-app
+                port:
+                  number: 3000

--- a/apps/base/forgejo/kustomization.yaml
+++ b/apps/base/forgejo/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - pvc.yaml
+  - deployment.yaml
+  # Runner: enable after SOPS-encrypting forgejo-runner-register.secret.yaml (see docs/migrations/forgejo-docker-to-kubernetes.md).
+  # - runner-deployment.yaml
+  - service.yaml
+  - ingress.yaml
+  - transportserver.yaml

--- a/apps/base/forgejo/namespace.yaml
+++ b/apps/base/forgejo/namespace.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: forgejo
+  labels:
+    # Runner uses Docker-in-Docker for Forgejo Actions (docker:// labels).
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/apps/base/forgejo/pvc.yaml
+++ b/apps/base/forgejo/pvc.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: forgejo-data
+  namespace: forgejo
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: nfs-media-static
+  volumeName: pv-nfs-forgejo-data
+  resources:
+    requests:
+      storage: 200Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: forgejo-runner-data
+  namespace: forgejo
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn-1
+  resources:
+    requests:
+      storage: 5Gi

--- a/apps/base/forgejo/runner-deployment.yaml
+++ b/apps/base/forgejo/runner-deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: forgejo-runner
+  namespace: forgejo
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: forgejo-runner
+  template:
+    metadata:
+      labels:
+        app: forgejo-runner
+        app.kubernetes.io/name: forgejo-runner
+    spec:
+      enableServiceLinks: false
+      containers:
+        - name: runner
+          # renovate: datasource=docker depName=codeberg.org/forgejo/runner versioning=semver
+          image: codeberg.org/forgejo/runner:6.2.2
+          env:
+            - name: DOCKER_HOST
+              value: tcp://127.0.0.1:2375
+            - name: GITEA_INSTANCE_URL
+              value: http://forgejo-app.forgejo.svc.cluster.local:3000
+            - name: GITEA_RUNNER_REGISTRATION_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: forgejo-runner-register
+                  key: token
+          volumeMounts:
+            - name: runner-data
+              mountPath: /data
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              memory: 1Gi
+        - name: dind
+          # renovate: datasource=docker depName=docker.io/library/docker
+          image: docker.io/library/docker:27-dind
+          securityContext:
+            privileged: true
+          env:
+            - name: DOCKER_TLS_CERTDIR
+              value: ""
+          volumeMounts:
+            - name: dind-storage
+              mountPath: /var/lib/docker
+      volumes:
+        - name: runner-data
+          persistentVolumeClaim:
+            claimName: forgejo-runner-data
+        - name: dind-storage
+          emptyDir: {}

--- a/apps/base/forgejo/service.yaml
+++ b/apps/base/forgejo/service.yaml
@@ -1,0 +1,30 @@
+# HTTP service name avoids K8s env injection (FORGEJO_PORT) on the app pod.
+apiVersion: v1
+kind: Service
+metadata:
+  name: forgejo-app
+  namespace: forgejo
+spec:
+  type: ClusterIP
+  selector:
+    app: forgejo
+  ports:
+    - name: http
+      port: 3000
+      targetPort: http
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: forgejo-ssh
+  namespace: forgejo
+spec:
+  type: ClusterIP
+  selector:
+    app: forgejo
+  ports:
+    - name: ssh
+      port: 22
+      targetPort: ssh
+      protocol: TCP

--- a/apps/base/forgejo/transportserver.yaml
+++ b/apps/base/forgejo/transportserver.yaml
@@ -1,0 +1,35 @@
+# Git SSH on ingress nodes (hostNetwork NGINX): ports 22 and 2222 → forgejo built-in SSH.
+# Requires GlobalConfiguration listeners in infrastructure/base/network/ingress/helmrelease.yaml.
+apiVersion: k8s.nginx.org/v1
+kind: TransportServer
+metadata:
+  name: forgejo-ssh-22
+  namespace: forgejo
+spec:
+  ingressClassName: nginx
+  listener:
+    name: forgejo-ssh-22
+    protocol: TCP
+  upstreams:
+    - name: forgejo-ssh
+      service: forgejo-ssh
+      port: 22
+  action:
+    pass: forgejo-ssh
+---
+apiVersion: k8s.nginx.org/v1
+kind: TransportServer
+metadata:
+  name: forgejo-ssh-2222
+  namespace: forgejo
+spec:
+  ingressClassName: nginx
+  listener:
+    name: forgejo-ssh-2222
+    protocol: TCP
+  upstreams:
+    - name: forgejo-ssh
+      service: forgejo-ssh
+      port: 22
+  action:
+    pass: forgejo-ssh

--- a/apps/overlays/main/cluster-config.yaml
+++ b/apps/overlays/main/cluster-config.yaml
@@ -43,6 +43,7 @@ data:
   # ---------------------------------------------------------------------
   # Public-facing apps (covered by *.f4mily.net wildcard):
   host_audiobookshelf: audible.f4mily.net
+  host_forgejo: git.f4mily.net
   # Staging on cluster wildcard before moving production DNS:
   host_authentik: login.f4mily.net
   host_homepage: home.f4mily.net

--- a/apps/overlays/main/kustomization.yaml
+++ b/apps/overlays/main/kustomization.yaml
@@ -37,6 +37,7 @@ resources:
   # - ../../base/unifi-controller    # disabled: dropped from catalog (DR test)
 
   # --- Cloud & Management -----------------------------------------------
+  - ../../base/forgejo
   - ../../base/nextcloud
   # - ../../base/linkwarden          # disabled: temporarily removed from catalog
   - ../../base/authentik
@@ -76,6 +77,16 @@ replacements:
       fieldPath: data.host_audiobookshelf
     targets:
       - select: {kind: Ingress, name: audiobookshelf}
+        fieldPaths:
+          - spec.rules.0.host
+          - spec.tls.0.hosts.0
+
+  - source:
+      kind: ConfigMap
+      name: homelab-cluster-config
+      fieldPath: data.host_forgejo
+    targets:
+      - select: {kind: Ingress, name: forgejo}
         fieldPaths:
           - spec.rules.0.host
           - spec.tls.0.hosts.0
@@ -304,6 +315,8 @@ replacements:
       fieldPath: data.publicTlsSecret
     targets:
       - select: {kind: Ingress, name: audiobookshelf}
+        fieldPaths: [spec.tls.0.secretName]
+      - select: {kind: Ingress, name: forgejo}
         fieldPaths: [spec.tls.0.secretName]
       - select: {kind: Ingress, name: homepage}
         fieldPaths: [spec.tls.0.secretName]

--- a/docs/applications.md
+++ b/docs/applications.md
@@ -72,6 +72,7 @@ here so it is obvious what is **planned** but not deployed:
 | watchyourlan       | on     | DaemonSet (hostNetwork), scan via IFACES  |
 | teslamate          | on     | Deployment, Mosquitto, CNPG, teslamate.f4mily.net (/grafana/) |
 | authentik          | on     | HelmRelease, CNPG, login.f4mily.net (production IdP)            |
+| forgejo            | on     | Deployment, NFS, git.f4mily.net (Git + CI), SSH :22/:2222       |
 | goloom             | on     | Deployment, CNPG PostgreSQL, goloom.cluster.f4mily.net |
 | pcm                | wip    | ingress only, missing HelmRelease         |
 
@@ -176,6 +177,9 @@ volumeName) are **immutable**. See `docs/migrations/nfs-migration.md`.
 
 **Immich (Docker → cluster):** `docs/migrations/immich-docker-to-kubernetes.md` — production
 compose reference in repo root `Migration/Immich/`.
+
+**Forgejo (Docker → cluster):** `docs/migrations/forgejo-docker-to-kubernetes.md` — production
+compose reference in repo root `Migration/forgejo/`.
 
 ## 5. Reconciliation cheat sheet
 

--- a/docs/migrations/forgejo-docker-to-kubernetes.md
+++ b/docs/migrations/forgejo-docker-to-kubernetes.md
@@ -1,0 +1,130 @@
+# Forgejo: Docker (production) → Kubernetes
+
+Migrate the production Forgejo instance (Docker Compose + Traefik on CephFS) to the
+homelab cluster (Flux Kustomize base, NGINX Ingress, NFS data PVC, TCP SSH via
+TransportServer).
+
+**Source reference:** `Migration/forgejo/compose.yml`, `Migration/forgejo/gitea/conf/app.ini`.
+
+**Target:** `apps/base/forgejo/`, `infrastructure/base/storage/pv-nfs.yaml` (PV
+`pv-nfs-forgejo-data`), `infrastructure/base/network/ingress/helmrelease.yaml`
+(GlobalConfiguration TCP listeners on ports **22** and **2222**).
+
+## Architecture comparison
+
+| Component | Docker (production) | Kubernetes (homelab) |
+|-----------|---------------------|----------------------|
+| App | `codeberg.org/forgejo/forgejo:15` | Deployment `forgejo` — pin in `deployment.yaml` |
+| DB | SQLite (`/data/gitea/gitea.db`) | Same file on NFS PVC (no CNPG) |
+| Data | `/mnt/cephfs/forgejo` → `/data` | PVC `forgejo-data` → NFS `Media` + `subPath: docker/forgejo` |
+| HTTP | Traefik `git.f4mily.net:443` | Ingress `git.f4mily.net` (NGINX, wildcard TLS) |
+| Git SSH | Host port `2222` → container `:22` | TransportServer on ingress nodes `:22` and `:2222` → `forgejo-ssh:22` |
+| Runner | Docker Swarm `act-runner` | Optional Deployment `forgejo-runner` + DinD (enable after SOPS secret) |
+| Renovate | Sidecar container | Not deployed on cluster (keep external or add later) |
+
+## Prerequisites
+
+- [ ] TrueNAS export reachable from cluster (`192.168.10.94:/mnt/Storagepool/Media`).
+- [ ] Directory `Media/docker/forgejo` on NAS (create if missing).
+- [ ] DNS `git.f4mily.net` → ingress node LAN IPs (**192.168.10.41–43**), not the old Docker host.
+- [ ] Maintenance window (Forgejo offline during data rsync).
+- [ ] Dev shell: `nix develop` (`kubectl`, `rsync`, `flux`).
+
+## Phase 1 — Prepare NFS data
+
+On the NAS (or from a host with both CephFS and NFS access):
+
+```bash
+# Example: rsync production data to TrueNAS path backing pv-nfs-forgejo-data
+rsync -avH --delete /mnt/cephfs/forgejo/ /mnt/truenas/Media/docker/forgejo/
+```
+
+Verify layout (must match container mount `/data`):
+
+```text
+docker/forgejo/gitea/conf/app.ini
+docker/forgejo/git/repositories/…
+```
+
+## Phase 2 — Deploy manifests (GitOps)
+
+Merge the Forgejo PR, then reconcile:
+
+```bash
+flux reconcile source git flux-system
+flux reconcile kustomization infrastructure --with-source
+flux reconcile kustomization apps --with-source
+```
+
+Check:
+
+```bash
+kubectl get pv pv-nfs-forgejo-data
+kubectl get pvc -n forgejo
+kubectl get pods,ingress,transportserver -n forgejo
+kubectl get globalconfiguration -n ingress-nginx
+```
+
+## Phase 3 — Verify HTTP & SSH
+
+**HTTPS**
+
+```bash
+curl -sI https://git.f4mily.net/api/healthz
+```
+
+**SSH (both ports should accept git@git.f4mily.net)**
+
+```bash
+ssh -p 2222 -T git@git.f4mily.net
+ssh -p 22   -T git@git.f4mily.net
+git ls-remote ssh://git@git.f4mily.net:2222/Homelab/homelab-gitops.git HEAD
+```
+
+`app.ini` already sets `SSH_DOMAIN = git.f4mily.net:2222`; port **22** is an
+additional entry point via NGINX TCP passthrough (no Forgejo config change needed).
+
+## Phase 4 — Forgejo Actions runner (optional)
+
+1. Forgejo UI → **Administration → Actions → Runners → Create new runner** — copy registration token.
+2. Encrypt secret:
+
+```bash
+cp apps/base/forgejo/forgejo-runner-register.secret.yaml.template \
+   apps/base/forgejo/forgejo-runner-register.secret.yaml
+# edit token, then:
+sops -e -i apps/base/forgejo/forgejo-runner-register.secret.yaml
+```
+
+3. Uncomment in `apps/base/forgejo/kustomization.yaml`:
+
+```yaml
+  - runner-deployment.yaml
+  - forgejo-runner-register.secret.yaml
+```
+
+4. Commit, push, reconcile. Re-register if the old Swarm runner UUID should be retired.
+
+Alternatively copy existing runner state from `Migration/forgejo/runner/data/.runner`
+into the runner PVC before first start (skip registration token).
+
+## Phase 5 — Cutover & decommission Docker
+
+1. Stop Docker Compose stack on the old host.
+2. Confirm CI (`/.forgejo/workflows/`) and `git push` via SSH work against cluster.
+3. Update any hard-coded runner labels if executor changed (DinD vs Swarm).
+
+## Rollback
+
+- Re-point DNS to the Docker host and start Compose.
+- Cluster PVC uses `Retain` — data remains on NFS if the Deployment is removed.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| PVC Pending | PV `claimRef` / NAS path | Create `Media/docker/forgejo`, check PV name |
+| 502 on HTTPS | Service name / probes | Service must be `forgejo-app`, not `forgejo` |
+| SSH timeout | DNS or firewall | Confirm `:22`/`:2222` reach **41–43**, GlobalConfiguration listeners exist |
+| TransportServer Rejected | Custom resources off | `controller.enableCustomResources: true` in ingress HelmRelease |
+| LFS push fails | Upload limit | Ingress annotations `client-max-body-size: "0"` already set |

--- a/infrastructure/base/network/ingress/helmrelease.yaml
+++ b/infrastructure/base/network/ingress/helmrelease.yaml
@@ -18,6 +18,17 @@ spec:
         namespace: flux-system
   values:
     controller:
+      enableCustomResources: true
+      globalConfiguration:
+        create: true
+        spec:
+          listeners:
+            - name: forgejo-ssh-22
+              port: 22
+              protocol: TCP
+            - name: forgejo-ssh-2222
+              port: 2222
+              protocol: TCP
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       kind: daemonset

--- a/infrastructure/base/storage/pv-nfs.yaml
+++ b/infrastructure/base/storage/pv-nfs.yaml
@@ -444,3 +444,27 @@ spec:
   claimRef:
     name: tandoor-media
     namespace: tandoor
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-nfs-forgejo-data
+  labels:
+    app: forgejo
+    storage.type: nfs-media
+spec:
+  capacity:
+    storage: 200Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: nfs-media-static
+  mountOptions:
+    - nfsvers=4.1
+  nfs:
+    path: /mnt/Storagepool/Media
+    server: 192.168.10.94
+  claimRef:
+    name: forgejo-data
+    namespace: forgejo


### PR DESCRIPTION
## Summary
- Deploy Forgejo (`git.f4mily.net`) as a first-class app: Deployment, NFS PVC (`Media/docker/forgejo`), HTTPS Ingress with LFS-friendly upload limits and WebSocket support.
- Expose Git SSH on **both port 22 and 2222** via F5 NGINX `GlobalConfiguration` TCP listeners and `TransportServer` resources routing to `forgejo-ssh`.
- Add migration runbook (`docs/migrations/forgejo-docker-to-kubernetes.md`) covering CephFS → NFS rsync, DNS cutover, and optional Forgejo Actions runner (DinD) enablement.

## Test plan
- [x] `just validate` passes in CI
- [ ] After merge: rsync `Migration/forgejo/` data to TrueNAS `Media/docker/forgejo`
- [ ] `flux reconcile kustomization infrastructure --with-source` (GlobalConfiguration listeners)
- [ ] `flux reconcile kustomization apps --with-source`
- [ ] `kubectl get pv pv-nfs-forgejo-data` / PVC bound in `forgejo`
- [ ] `curl -sI https://git.f4mily.net/api/healthz`
- [ ] `ssh -p 2222 -T git@git.f4mily.net` and `ssh -p 22 -T git@git.f4mily.net`
- [ ] `git ls-remote ssh://git@git.f4mily.net:2222/Homelab/homelab-gitops.git HEAD`
- [ ] Point DNS `git.f4mily.net` to ingress nodes (192.168.10.41–43) before cutover


Made with [Cursor](https://cursor.com)