### PR TITLE
fix(forgejo): migration follow-up (permissions, runbook)

### DIFF
--- a/apps/base/forgejo/deployment.yaml
+++ b/apps/base/forgejo/deployment.yaml
@@ -36,9 +36,8 @@ spec:
               value: "1000"
             - name: USER_GID
               value: "1000"
+          # Do not set runAsUser/runAsGroup — the Forgejo image drops privileges via s6.
           securityContext:
-            runAsUser: 1000
-            runAsGroup: 1000
             allowPrivilegeEscalation: false
           resources:
             requests:

--- a/apps/base/forgejo/fix-perms.job.yaml
+++ b/apps/base/forgejo/fix-perms.job.yaml
@@ -1,0 +1,32 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: forgejo-fix-perms
+  namespace: forgejo
+spec:
+  ttlSecondsAfterFinished: 120
+  template:
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: talos-cp2
+      restartPolicy: Never
+      containers:
+        - name: fix
+          image: busybox:1.37
+          securityContext:
+            runAsUser: 0
+          command:
+            - sh
+            - -c
+            - |
+              set -eux
+              rm -rf /mnt/docker/forgejo/.s6-svscan
+              chown -R 1000:1000 /mnt/docker/forgejo
+              chmod -R u+rwX,g+rwX /mnt/docker/forgejo
+          volumeMounts:
+            - name: media
+              mountPath: /mnt
+      volumes:
+        - name: media
+          persistentVolumeClaim:
+            claimName: forgejo-data

--- a/apps/base/forgejo/migrate-data.job.yaml
+++ b/apps/base/forgejo/migrate-data.job.yaml
@@ -1,0 +1,30 @@
+# One-shot Job: populate NFS subPath docker/forgejo before first Forgejo start.
+# Usage (from repo root, after scaling forgejo Deployment to 0):
+#   tar -C ../Migration/forgejo -czf /tmp/forgejo-data.tar.gz git gitea
+#   kubectl apply -f apps/base/forgejo/migrate-data.job.yaml
+#   kubectl wait -n forgejo job/forgejo-data-migrate --for=condition=complete --timeout=600s
+#   POD=$(kubectl get pod -n forgejo -l job-name=forgejo-data-migrate -o jsonpath='{.items[0].metadata.name}')
+#   kubectl cp /tmp/forgejo-data.tar.gz forgejo/$POD:/tmp/forgejo-data.tar.gz
+#   kubectl exec -n forgejo $POD -- sh -c 'mkdir -p /mnt/docker/forgejo && tar -xzf /tmp/forgejo-data.tar.gz -C /mnt/docker/forgejo'
+#   kubectl delete job -n forgejo forgejo-data-migrate
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: forgejo-data-migrate
+  namespace: forgejo
+spec:
+  ttlSecondsAfterFinished: 300
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: migrate
+          image: busybox:1.37
+          command: ["sleep", "3600"]
+          volumeMounts:
+            - name: media
+              mountPath: /mnt
+      volumes:
+        - name: media
+          persistentVolumeClaim:
+            claimName: forgejo-data

--- a/docs/migrations/forgejo-docker-to-kubernetes.md
+++ b/docs/migrations/forgejo-docker-to-kubernetes.md
@@ -39,6 +39,31 @@ On the NAS (or from a host with both CephFS and NFS access):
 rsync -avH --delete /mnt/cephfs/forgejo/ /mnt/truenas/Media/docker/forgejo/
 ```
 
+If CephFS is not mounted locally, use the repo export under `Migration/forgejo/`
+(`git/` + `gitea/` only) and copy via a cluster Job on **talos-cp2** (the only
+node reachable for `kubectl cp` / `exec` from the operator workstation in this
+setup):
+
+```bash
+tar -C Migration/forgejo -czf /tmp/forgejo-data.tar.gz git gitea
+split -b 100M /tmp/forgejo-data.tar.gz /tmp/forgejo-part-
+
+# Scale forgejo Deployment to 0, then run migrate-data.job.yaml (nodeSelector: cp2)
+kubectl apply -f apps/base/forgejo/migrate-data.job.yaml
+POD=$(kubectl get pod -n forgejo -l job-name=forgejo-data-migrate -o jsonpath='{.items[0].metadata.name}')
+for f in /tmp/forgejo-part-*; do kubectl cp "$f" forgejo/$POD:/tmp/$(basename "$f"); done
+kubectl exec -n forgejo "$POD" -- sh -c 'cat /tmp/forgejo-part-* > /tmp/forgejo-data.tar.gz && tar -xzf /tmp/forgejo-data.tar.gz -C /mnt/docker/forgejo'
+
+# Fix ownership (tar via root job leaves root-owned files → s6 lock error)
+kubectl apply -f apps/base/forgejo/fix-perms.job.yaml
+kubectl wait -n forgejo job/forgejo-fix-perms --for=condition=complete --timeout=600s
+kubectl delete job -n forgejo forgejo-data-migrate forgejo-fix-perms
+```
+
+**Important:** Do **not** set `runAsUser`/`runAsGroup` on the Forgejo container.
+The image drops privileges via s6; forcing UID 1000 causes
+`s6-svscan: unable to open .s6-svscan/lock: Permission denied`.
+
 Verify layout (must match container mount `/data`):
 
 ```text


### PR DESCRIPTION
## Summary
- Remove `runAsUser`/`runAsGroup` from Forgejo Deployment (fixes `s6-svscan` crash after NFS import).
- Add helper Jobs `migrate-data.job.yaml` and `fix-perms.job.yaml` for cutover.
- Extend migration runbook with tested cp2 `kubectl cp` workflow and permission fix.

## Test plan
- [x] Forgejo pod Running on cluster after manual cutover
- [x] `https://git.f4mily.net/api/healthz` → status pass
- [x] SSH auth on ports 22 and 2222
- [x] `git ls-remote ssh://git@git.f4mily.net:2222/Homelab/homelab-gitops.git HEAD`

Made with [Cursor](https://cursor.com)