### PR TITLE
feat(forgejo): add Renovate CronJob

### DIFF
--- a/apps/base/forgejo/kustomization.yaml
+++ b/apps/base/forgejo/kustomization.yaml
@@ -9,3 +9,7 @@ resources:
   - service.yaml
   - ingress.yaml
   - transportserver.yaml
+  - renovate-config.configmap.yaml
+  - renovate-cronjob.yaml
+  # Enable after SOPS-encrypting renovate-credentials.secret.yaml (see migration runbook).
+  # - renovate-credentials.secret.yaml

--- a/apps/base/forgejo/pvc.yaml
+++ b/apps/base/forgejo/pvc.yaml
@@ -24,3 +24,16 @@ spec:
   resources:
     requests:
       storage: 5Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: renovate-data
+  namespace: forgejo
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn-1
+  resources:
+    requests:
+      storage: 2Gi

--- a/apps/base/forgejo/renovate-config.configmap.yaml
+++ b/apps/base/forgejo/renovate-config.configmap.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: renovate-config
+  namespace: forgejo
+data:
+  config.js: |
+    /** @type {import('renovate').RenovateConfig} */
+    module.exports = {
+      platform: 'forgejo',
+      endpoint: 'http://forgejo-app.forgejo.svc.cluster.local:3000/api/v1/',
+      token: process.env.RENOVATE_TOKEN,
+      hostRules: [
+        {
+          matchHost: 'github.com',
+          token: process.env.RENOVATE_GITHUB_COM_TOKEN,
+        },
+        {
+          matchHost: 'api.github.com',
+          token: process.env.RENOVATE_GITHUB_COM_TOKEN,
+        },
+      ],
+      autodiscover: true,
+      autodiscoverFilter: ['homelab/*', 'Homelab/*', 'kreativmonkey/*', 'diyon/*'],
+      gitAuthor: 'Renovate Bot <renovate@f4mily.net>',
+      onboarding: true,
+      onboardingConfig: {
+        extends: ['config:recommended', ':dependencyDashboard'],
+      },
+      timezone: 'Europe/Berlin',
+      persistRepoData: true,
+    };

--- a/apps/base/forgejo/renovate-credentials.secret.yaml.template
+++ b/apps/base/forgejo/renovate-credentials.secret.yaml.template
@@ -1,0 +1,12 @@
+# Forgejo bot PAT (repo+issue+organization scopes) and GitHub.com token for datasource lookups.
+# cp renovate-credentials.secret.yaml.template renovate-credentials.secret.yaml
+# fill values, then: sops -e -i renovate-credentials.secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: renovate-credentials
+  namespace: forgejo
+type: Opaque
+stringData:
+  RENOVATE_TOKEN: REPLACE_WITH_FORGEJO_PAT
+  RENOVATE_GITHUB_COM_TOKEN: REPLACE_WITH_GITHUB_PAT

--- a/apps/base/forgejo/renovate-cronjob.yaml
+++ b/apps/base/forgejo/renovate-cronjob.yaml
@@ -1,0 +1,63 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: renovate
+  namespace: forgejo
+spec:
+  schedule: "0 */4 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      ttlSecondsAfterFinished: 86400
+      template:
+        spec:
+          restartPolicy: Never
+          enableServiceLinks: false
+          containers:
+            - name: renovate
+              # renovate: datasource=docker depName=renovate/renovate versioning=semver
+              image: renovate/renovate:40.46.0
+              env:
+                - name: TZ
+                  value: Europe/Berlin
+                - name: LOG_LEVEL
+                  value: info
+                - name: RENOVATE_CONFIG_FILE
+                  value: /usr/src/app/config.js
+                - name: RENOVATE_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: renovate-credentials
+                      key: RENOVATE_TOKEN
+                - name: RENOVATE_GITHUB_COM_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: renovate-credentials
+                      key: RENOVATE_GITHUB_COM_TOKEN
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 512Mi
+                limits:
+                  memory: 2Gi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+              volumeMounts:
+                - name: config
+                  mountPath: /usr/src/app/config.js
+                  subPath: config.js
+                  readOnly: true
+                - name: data
+                  mountPath: /tmp/renovate
+          volumes:
+            - name: config
+              configMap:
+                name: renovate-config
+            - name: data
+              persistentVolumeClaim:
+                claimName: renovate-data

--- a/docs/applications.md
+++ b/docs/applications.md
@@ -72,7 +72,7 @@ here so it is obvious what is **planned** but not deployed:
 | watchyourlan       | on     | DaemonSet (hostNetwork), scan via IFACES  |
 | teslamate          | on     | Deployment, Mosquitto, CNPG, teslamate.f4mily.net (/grafana/) |
 | authentik          | on     | HelmRelease, CNPG, login.f4mily.net (production IdP)            |
-| forgejo            | on     | Deployment, NFS, git.f4mily.net (Git + CI), SSH :22/:2222       |
+| forgejo            | on     | Deployment, NFS, git.f4mily.net (Git + CI + Renovate CronJob), SSH :22/:2222 |
 | goloom             | on     | Deployment, CNPG PostgreSQL, goloom.cluster.f4mily.net |
 | pcm                | wip    | ingress only, missing HelmRelease         |
 

--- a/docs/migrations/forgejo-docker-to-kubernetes.md
+++ b/docs/migrations/forgejo-docker-to-kubernetes.md
@@ -20,7 +20,7 @@ TransportServer).
 | HTTP | Traefik `git.f4mily.net:443` | Ingress `git.f4mily.net` (NGINX, wildcard TLS) |
 | Git SSH | Host port `2222` → container `:22` | TransportServer on ingress nodes `:22` and `:2222` → `forgejo-ssh:22` |
 | Runner | Docker Swarm `act-runner` | Optional Deployment `forgejo-runner` + DinD (enable after SOPS secret) |
-| Renovate | Sidecar container | Not deployed on cluster (keep external or add later) |
+| Renovate | Sidecar `renovate/renovate` + `renovate-config.js` | CronJob `renovate` (every 4h), ConfigMap + SOPS credentials |
 
 ## Prerequisites
 
@@ -133,7 +133,34 @@ sops -e -i apps/base/forgejo/forgejo-runner-register.secret.yaml
 Alternatively copy existing runner state from `Migration/forgejo/runner/data/.runner`
 into the runner PVC before first start (skip registration token).
 
-## Phase 5 — Cutover & decommission Docker
+## Phase 5 — Renovate bot
+
+Production Compose sidecar (`renovate/renovate`) used:
+
+- `RENOVATE_PLATFORM=forgejo`
+- `RENOVATE_ENDPOINT=http://server:3000/api/v1`
+- Forgejo PAT + GitHub.com PAT (for datasource lookups)
+- `/mnt/cephfs/renovate/renovate-config.js` → replaced by `renovate-config` ConfigMap
+- `/mnt/cephfs/renovate/data` → PVC `renovate-data` (Longhorn, cache only — optional to migrate)
+
+1. Copy tokens from `Migration/forgejo/.env` (never commit):
+   ```bash
+   cp apps/base/forgejo/renovate-credentials.secret.yaml.template \
+      apps/base/forgejo/renovate-credentials.secret.yaml
+   # edit RENOVATE_TOKEN + RENOVATE_GITHUB_COM_TOKEN
+   sops -e -i apps/base/forgejo/renovate-credentials.secret.yaml
+   ```
+2. Uncomment in `apps/base/forgejo/kustomization.yaml`:
+   ```yaml
+   - renovate-credentials.secret.yaml
+   ```
+3. Commit, reconcile, trigger a run:
+   ```bash
+   kubectl create job -n forgejo renovate-manual --from=cronjob/renovate
+   kubectl logs -n forgejo job/renovate-manual -f
+   ```
+
+## Phase 6 — Cutover & decommission Docker
 
 1. Stop Docker Compose stack on the old host.
 2. Confirm CI (`/.forgejo/workflows/`) and `git push` via SSH work against cluster.


### PR DESCRIPTION
## Summary
- Add Renovate `CronJob` (every 4h) in `forgejo` namespace, talking to `forgejo-app:3000/api/v1`.
- ConfigMap replaces Docker `renovate-config.js`; autodiscover for `homelab/*`, `Homelab/*`, `kreativmonkey/*`, `diyon/*`.
- Longhorn PVC `renovate-data` for bot cache; SOPS template for Forgejo PAT + GitHub.com token.

## Test plan
- [ ] `just validate`
- [ ] SOPS-encrypt `renovate-credentials.secret.yaml`, uncomment in kustomization
- [ ] `kubectl create job -n forgejo renovate-manual --from=cronjob/renovate`
- [ ] Verify Renovate opens/updates dependency PRs on Forgejo repos

Made with [Cursor](https://cursor.com)