### PR TITLE
fix(homepage): Authentik partial status pod-selector

### DIFF
--- a/apps/base/authentik/ingress.yaml
+++ b/apps/base/authentik/ingress.yaml
@@ -9,6 +9,8 @@ metadata:
     gethomepage.dev/description: Identity Provider
     gethomepage.dev/group: Tools
     gethomepage.dev/icon: authentik.png
+    # Only the server serves the Ingress; worker shares app.kubernetes.io/name=authentik.
+    gethomepage.dev/pod-selector: app.kubernetes.io/component=server
     nginx.org/ssl-redirect: "false"
     nginx.org/redirect-to-https: "true"
 spec:


### PR DESCRIPTION
## Summary
- Add `gethomepage.dev/pod-selector: app.kubernetes.io/component=server` on Authentik Ingress so Homepage does not count the worker Deployment in readiness.

## Context
Partial dots on Homepage were primarily from Longhorn/cp3 (pods not Ready). After volume recovery, Authentik would still show partial without this selector because the worker is also labeled `app.kubernetes.io/name=authentik`.

## Test plan
- [ ] After merge + Flux reconcile, Authentik tile on Homepage shows healthy when server pod is Ready

Made with [Cursor](https://cursor.com)