### PR TITLE
fix(ingress): SearXNG probes, Homepage TeslaMate/Forgejo

### DIFF
--- a/apps/base/forgejo/ingress.yaml
+++ b/apps/base/forgejo/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/name: Forgejo
     gethomepage.dev/description: Git hosting & CI
-    gethomepage.dev/group: Infrastructure
+    gethomepage.dev/group: Tools
     gethomepage.dev/icon: forgejo.png
     gethomepage.dev/pod-selector: app=forgejo
     nginx.org/ssl-redirect: "false"

--- a/apps/base/searxng/deployment.yaml
+++ b/apps/base/searxng/deployment.yaml
@@ -76,13 +76,15 @@ spec:
             periodSeconds: 5
             failureThreshold: 60
           livenessProbe:
-            tcpSocket:
+            httpGet:
+              path: /
               port: http
             initialDelaySeconds: 90
             periodSeconds: 30
             failureThreshold: 5
           readinessProbe:
-            tcpSocket:
+            httpGet:
+              path: /
               port: http
             initialDelaySeconds: 10
             periodSeconds: 10

--- a/apps/base/searxng/ingress.yaml
+++ b/apps/base/searxng/ingress.yaml
@@ -9,6 +9,7 @@ metadata:
     gethomepage.dev/description: Privacy search
     gethomepage.dev/group: Tools
     gethomepage.dev/icon: searxng.png
+    gethomepage.dev/pod-selector: app=searxng
     nginx.org/ssl-redirect: "false"
     nginx.org/redirect-to-https: "true"
 spec:

--- a/apps/base/teslamate/ingress.yaml
+++ b/apps/base/teslamate/ingress.yaml
@@ -7,6 +7,7 @@ metadata:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/name: Teslamate
     gethomepage.dev/description: Tesla logging (Grafana at /grafana/)
+    gethomepage.dev/href: "https://teslamate.f4mily.net/"
     gethomepage.dev/group: Energy
     gethomepage.dev/icon: teslamate.png
     gethomepage.dev/app: teslamate


### PR DESCRIPTION
## Summary
- **Forgejo:** Homepage group `Tools` (was Infrastructure)
- **TeslaMate:** `gethomepage.dev/href` → `https://teslamate.f4mily.net/` (Ingress lists `/grafana` first; Homepage linked there)
- **SearXNG:** HTTP `/` readiness/liveness probes; Homepage `pod-selector`

## Related
DNS fix for `search.f4mily.net` is in homelab-infrastructure (move hostname to `module.talos_cluster`).

## Test plan
- [ ] Flux reconcile `apps`
- [ ] Homepage: TeslaMate opens main UI; Forgejo under Tools
- [ ] After DNS apply: `curl -sk https://search.f4mily.net/` → 200

Made with [Cursor](https://cursor.com)