### PR TITLE
feat(storage): TrueNAS iSCSI replaces Longhorn as default block storage

### DIFF
--- a/apps/base/authentik/media-pvc.yaml
+++ b/apps/base/authentik/media-pvc.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: longhorn-1
+  storageClassName: truenas-iscsi
   resources:
     requests:
       storage: 1Gi

--- a/apps/base/forgejo/pvc.yaml
+++ b/apps/base/forgejo/pvc.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: longhorn-1
+  storageClassName: truenas-iscsi
   resources:
     requests:
       storage: 5Gi
@@ -33,7 +33,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: longhorn-1
+  storageClassName: truenas-iscsi
   resources:
     requests:
       storage: 2Gi

--- a/apps/base/kite/deployment.yaml
+++ b/apps/base/kite/deployment.yaml
@@ -70,7 +70,7 @@ spec:
           pvc:
             enabled: true
             # Must match existing PVC storageClassName (immutable after bind). New installs: longhorn-1 is fine.
-            storageClass: longhorn
+            storageClass: truenas-iscsi
             accessModes:
               - ReadWriteOnce
             size: 1Gi

--- a/apps/base/linkwarden/pvc.yaml
+++ b/apps/base/linkwarden/pvc.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: longhorn-1
+  storageClassName: truenas-iscsi
   resources:
     requests:
       storage: 10Gi
@@ -19,7 +19,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: longhorn-1
+  storageClassName: truenas-iscsi
   resources:
     requests:
       storage: 5Gi

--- a/apps/base/monitoring/vm-k8s-stack/helmrelease.yaml
+++ b/apps/base/monitoring/vm-k8s-stack/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
       spec:
         retentionPeriod: "1"
         storage:
-          storageClassName: longhorn
+          storageClassName: truenas-iscsi
           resources:
             requests:
               storage: 20Gi
@@ -222,7 +222,7 @@ spec:
       # Persistence - reuse existing PVC
       persistence:
         enabled: true
-        storageClassName: longhorn
+        storageClassName: truenas-iscsi
         size: 2Gi
 
       # Security context

--- a/apps/base/n8n/helmrelease.yaml
+++ b/apps/base/n8n/helmrelease.yaml
@@ -45,8 +45,8 @@ spec:
       persistence:
         enabled: true
         type: dynamic
-        # Cluster has longhorn (default longhorn-1); local-path is not installed.
-        storageClass: longhorn-1
+        # Default block storage: truenas-iscsi (TrueNAS iSCSI via democratic-csi).
+        storageClass: truenas-iscsi
         accessModes:
           - ReadWriteOnce
         size: 10Gi

--- a/apps/base/sterling-pdf/deployment.yaml
+++ b/apps/base/sterling-pdf/deployment.yaml
@@ -59,7 +59,7 @@ spec:
       externalPort: 8080
     persistence:
       enabled: true
-      storageClass: longhorn
+      storageClass: truenas-iscsi
       accessMode: ReadWriteOnce
       size: 8Gi
       path: /configs

--- a/apps/base/unifi-controller/pvc.yaml
+++ b/apps/base/unifi-controller/pvc.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: longhorn-1
+  storageClassName: truenas-iscsi
   resources:
     requests:
       storage: 10Gi
@@ -19,7 +19,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: longhorn-1
+  storageClassName: truenas-iscsi
   resources:
     requests:
       storage: 20Gi

--- a/apps/base/uptime-kuma/pvc.yaml
+++ b/apps/base/uptime-kuma/pvc.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: longhorn-1
+  storageClassName: truenas-iscsi
   resources:
     requests:
       storage: 5Gi

--- a/apps/base/watchyourlan/pvc.yaml
+++ b/apps/base/watchyourlan/pvc.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: longhorn-1
+  storageClassName: truenas-iscsi
   resources:
     requests:
       storage: 1Gi

--- a/clusters/main/infrastructure.yaml
+++ b/clusters/main/infrastructure.yaml
@@ -35,6 +35,10 @@ spec:
     name: flux-system
   wait: true
   timeout: 5m
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization

--- a/docs/applications.md
+++ b/docs/applications.md
@@ -164,12 +164,9 @@ Then `just validate` and commit.
 
 ## 4. Storage strategy reminder
 
-- `longhorn` / `longhorn-1` — RWO block storage for databases, configs,
-  small state. `longhorn-1` is the cluster default (single replica).
-- `nfs-media-static` — RWX network storage backed by TrueNAS at
-  192.168.10.94. **Manually-defined PVs** in
-  `infrastructure/base/storage/pv-nfs.yaml` with a `claimRef` to the
-  intended app namespace.
+- `truenas-iscsi` — default **RWO block** on TrueNAS M.2 (democratic-csi). Replaces Longhorn for DBs and app state.
+- `longhorn` / `longhorn-1` — **deprecated**; remove after `docs/migrations/longhorn-to-truenas-iscsi.md`.
+- `nfs-media-static` — RWX on TrueNAS (`192.168.10.94`). Static PVs in `infrastructure/base/storage/pv-nfs.yaml`.
 
 When migrating an app from Longhorn → NFS, you must first delete the
 existing `Bound` PVC. PVC specs (storageClassName, accessModes,

--- a/docs/migrations/longhorn-to-truenas-iscsi.md
+++ b/docs/migrations/longhorn-to-truenas-iscsi.md
@@ -1,0 +1,122 @@
+# Longhorn → TrueNAS iSCSI (democratic-csi)
+
+Replace distributed Longhorn on Talos CP local disks with **block storage on TrueNAS M.2** via iSCSI. **NFS (`nfs-media-static`) stays** for media/RWX.
+
+## Prerequisites
+
+### TrueNAS (192.168.10.94)
+
+1. **User `k8sadmin`** — Credentials → Users → Add  
+   - Shell: `nologin`, group privilege: **Local Administrator**
+2. **API key** — Credentials → Users → `k8sadmin` → **API Keys** → Add → copy key
+3. **iSCSI service** — System → Services → iSCSI → enable, start on boot
+4. **Initiator group** — Sharing → Block (iSCSI) → Initiator Groups → Add  
+   - *Allow all initiators* (or restrict to Talos IQNs later) → note **id**
+5. **Portal** — Portals tab → Add → listen on **192.168.10.94** → note **id**
+6. **Datasets** (siblings under M.2 pool — API paths without `/mnt/`):
+   - **Volumes:** `FastStorage/ClusterStorage/k8s-volumes` (FILESYSTEM parent; CSI creates zvols)
+   - **Snapshots:** `FastStorage/ClusterStorage/k8s-snapshots`
+   Do **not** use the existing `k8s-storage` **zvol** as `datasetParentName`.
+
+Discover IDs:
+
+```bash
+export TRUENAS_API_KEY='...'
+./scripts/truenas-discover-iscsi.sh
+```
+
+**TrueNAS 25.04+:** use democratic-csi image tag `next` in the HelmRelease (not `v1.0.6`). Omit `zvolDedup` in the driver config (API rejects it). `VolumeSnapshotClass` needs the CSI snapshot CRDs — leave disabled until installed.
+
+### Cluster
+
+- Talos image includes **`iscsi_tools`** (see `cluster.auto.tfvars` schematic).
+- SOPS age key for Flux (`sops-age` in `flux-system`).
+
+## GitOps setup
+
+```bash
+cd gitops-homelab/infrastructure/base/storage/democratic-csi
+cp truenas-iscsi-driver.secret.yaml.template truenas-iscsi-driver.secret.yaml
+# Edit: apiKey, datasetParentName, detachedSnapshotsDatasetParentName, targetGroup* IDs
+export SOPS_AGE_KEY_FILE=~/.config/sops/age/keys.txt
+sops -e -i truenas-iscsi-driver.secret.yaml
+```
+
+Enable secret in `democratic-csi/kustomization.yaml`, commit, push GitHub `main`.
+
+```bash
+flux reconcile kustomization infra-storage -n flux-system --with-source
+kubectl get sc truenas-iscsi
+kubectl get pods -n democratic-csi
+```
+
+Test:
+
+```yaml
+# test-iscsi-pvc.yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: test-iscsi
+  namespace: default
+spec:
+  accessModes: [ReadWriteOnce]
+  storageClassName: truenas-iscsi
+  resources:
+    requests:
+      storage: 1Gi
+```
+
+## Migration order (live cluster)
+
+PVC `storageClassName` is **immutable**. Each workload: backup → stop → delete PVC → apply Git with `truenas-iscsi` → restore data.
+
+| Phase | Workload | PVC / notes |
+|-------|----------|-------------|
+| 1 | Test | ad-hoc 1Gi PVC — **done** (`default/truenas-iscsi-test`) |
+| 2 | `renovate-data`, `forgejo-runner-data` | small, low risk |
+| 3 | `kite-kite-storage`, `sterling-pdf`, `authentik-media` | stop app, copy or accept empty |
+| 4 | `vm-k8s-stack` (Grafana + VMSingle) | metrics gap OK briefly; no longhorn snapshots |
+| 5 | `pgadmin` | after DB stable |
+| 6 | **`homelab-postgres`** | Barman backup → new cluster/PVC on `truenas-iscsi` or pg_dump restore |
+| 7 | **`immich-postgres`** | same as CNPG DR runbook |
+| 8 | Remaining `longhorn-1` apps (n8n, linkwarden, …) | per `docs/migrations/nfs-migration.md` pattern |
+
+### Example: generic RWO app PVC
+
+```bash
+export KUBECONFIG=homelab-infrastructure/talos/kubeconfig
+NS=forgejo
+APP=renovate
+PVC=renovate-data
+
+flux suspend helmrelease -n "$NS" "$APP" 2>/dev/null || kubectl -n "$NS" scale deploy --all --replicas=0
+kubectl -n "$NS" delete pvc "$PVC" --wait=false
+# Flux applies new PVC with truenas-iscsi (or create manually)
+flux resume helmrelease -n "$NS" "$APP" 2>/dev/null || kubectl -n "$NS" scale deploy --all --replicas=1
+```
+
+### CNPG (homelab-postgres / immich-postgres)
+
+Do **not** only change `storageClass` in Git on a running cluster.
+
+1. Verify Barman backups: `kubectl get backup -n cnpg-system`
+2. `flux suspend kustomization apps -n flux-system`
+3. Scale down consumers (authentik, paperless, …)
+4. Backup / export or use CNPG recovery to new PVC on `truenas-iscsi`
+5. See `docs/disaster-recovery/cnpg-s3-dr.md`
+
+## Decommission Longhorn
+
+When no PVCs use `longhorn` / `longhorn-1`:
+
+```bash
+kubectl get pvc -A -o custom-columns=NS:.metadata.namespace,NAME:.metadata.name,SC:.spec.storageClassName | grep longhorn || true
+flux suspend helmrelease longhorn -n longhorn-system
+```
+
+Remove from Git: `longhorn.yaml`, `storageclass-longhorn-1.yaml`, Longhorn ingress; optional: drop Talos `/var/lib/longhorn` disk in OpenTofu (separate change).
+
+## Rollback
+
+Keep Longhorn HelmRelease in Git (unsuspended) until all PVCs migrated. Old PVCs on Longhorn remain readable until volumes are deleted.

--- a/docs/migrations/longhorn-to-truenas-iscsi.md
+++ b/docs/migrations/longhorn-to-truenas-iscsi.md
@@ -74,13 +74,13 @@ PVC `storageClassName` is **immutable**. Each workload: backup → stop → dele
 | Phase | Workload | PVC / notes |
 |-------|----------|-------------|
 | 1 | Test | ad-hoc 1Gi PVC — **done** (`default/truenas-iscsi-test`) |
-| 2 | `renovate-data`, `forgejo-runner-data` | small, low risk |
-| 3 | `kite-kite-storage`, `sterling-pdf`, `authentik-media` | stop app, copy or accept empty |
-| 4 | `vm-k8s-stack` (Grafana + VMSingle) | metrics gap OK briefly; no longhorn snapshots |
-| 5 | `pgadmin` | after DB stable |
-| 6 | **`homelab-postgres`** | Barman backup → new cluster/PVC on `truenas-iscsi` or pg_dump restore |
-| 7 | **`immich-postgres`** | same as CNPG DR runbook |
-| 8 | Remaining `longhorn-1` apps (n8n, linkwarden, …) | per `docs/migrations/nfs-migration.md` pattern |
+| 2 | `renovate-data`, `forgejo-runner-data` | **done** (renovate was faulted → empty volume) |
+| 3 | `kite-kite-storage`, `sterling-pdf`, `authentik-media` | **done** (rsync via migrate job) |
+| 4 | `vm-k8s-stack` (Grafana + VMSingle) | **done** |
+| 5 | `pgadmin` | **done** |
+| 6 | **`homelab-postgres`** | **done** (Barman recovery → `truenas-iscsi`) |
+| 7 | **`immich-postgres`** | **done** (Barman recovery) |
+| 8 | `n8n-app`, orphan `immich-restore-work` | **done** |
 
 ### Example: generic RWO app PVC
 
@@ -100,11 +100,16 @@ flux resume helmrelease -n "$NS" "$APP" 2>/dev/null || kubectl -n "$NS" scale de
 
 Do **not** only change `storageClass` in Git on a running cluster.
 
-1. Verify Barman backups: `kubectl get backup -n cnpg-system`
-2. `flux suspend kustomization apps -n flux-system`
-3. Scale down consumers (authentik, paperless, …)
-4. Backup / export or use CNPG recovery to new PVC on `truenas-iscsi`
-5. See `docs/disaster-recovery/cnpg-s3-dr.md`
+1. Verify Barman backups: `kubectl get backup.postgresql.cnpg.io -n cnpg-system`
+2. `flux suspend kustomization apps infra-main -n flux-system`
+3. On-demand backup: `Backup` CR per cluster (optional if daily backup is recent)
+4. Scale down consumers (authentik, immich, paperless, …)
+5. `kubectl delete cluster <name> -n cnpg-system --wait`
+6. `./scripts/force-delete-pvc.sh cnpg-system <name>-1`
+7. Merge main `cluster.yaml` + DR `patches/cluster-recovery*.yaml` (see `scripts/` — `kubectl patch --local` fails on Cluster CR) and `kubectl apply`
+8. `kubectl wait --for=condition=Ready cluster/<name> -n cnpg-system --timeout=45m`
+9. `flux resume kustomization apps infra-main -n flux-system`
+10. See `docs/disaster-recovery/cnpg-s3-dr.md`
 
 ## Decommission Longhorn
 

--- a/infrastructure/base/backup/helmrelease.yaml
+++ b/infrastructure/base/backup/helmrelease.yaml
@@ -4,7 +4,7 @@ metadata:
   name: velero
   namespace: velero
   annotations:
-    kustomize.toolkit.fluxcd.io/depends-on: helm.toolkit.fluxcd.io/HelmRelease/longhorn-system/longhorn
+    kustomize.toolkit.fluxcd.io/depends-on: helm.toolkit.fluxcd.io/HelmRelease/democratic-csi/democratic-csi-iscsi
 spec:
   interval: 1h
   targetNamespace: velero

--- a/infrastructure/base/database/cnpg/helmrelease.yaml
+++ b/infrastructure/base/database/cnpg/helmrelease.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cnpg
   namespace: cnpg-system
   annotations:
-    kustomize.toolkit.fluxcd.io/depends-on: helm.toolkit.fluxcd.io/HelmRelease/longhorn-system/longhorn
+    kustomize.toolkit.fluxcd.io/depends-on: helm.toolkit.fluxcd.io/HelmRelease/democratic-csi/democratic-csi-iscsi
 spec:
   interval: 1h
   targetNamespace: cnpg-system

--- a/infrastructure/base/sources/helm-repositories.yaml
+++ b/infrastructure/base/sources/helm-repositories.yaml
@@ -20,6 +20,15 @@ spec:
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
+  name: democratic-csi-repo
+  namespace: flux-system
+spec:
+  interval: 24h
+  url: https://democratic-csi.github.io/charts
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
   name: longhorn-repo
   namespace: flux-system
 spec:

--- a/infrastructure/base/storage/democratic-csi/helmrelease.yaml
+++ b/infrastructure/base/storage/democratic-csi/helmrelease.yaml
@@ -1,0 +1,56 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: democratic-csi-iscsi
+  namespace: democratic-csi
+spec:
+  interval: 1h
+  timeout: 15m
+  targetNamespace: democratic-csi
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: democratic-csi
+      version: "0.15.1"
+      sourceRef:
+        kind: HelmRepository
+        name: democratic-csi-repo
+        namespace: flux-system
+  values:
+    csiDriver:
+      name: truenas-iscsi
+    driver:
+      config:
+        driver: freenas-api-iscsi
+      existingConfigSecret: truenas-iscsi-driver-config
+    controller:
+      driver:
+        image:
+          tag: next
+    node:
+      hostPID: true
+      driver:
+        image:
+          tag: next
+        extraEnv:
+          - name: ISCSIADM_HOST_STRATEGY
+            value: nsenter
+          - name: ISCSIADM_HOST_PATH
+            value: /usr/local/sbin/iscsiadm
+        iscsiDirHostPath: /var/iscsi
+        iscsiDirHostPathType: ""
+    storageClasses:
+      - name: truenas-iscsi
+        defaultClass: true
+        reclaimPolicy: Delete
+        volumeBindingMode: Immediate
+        allowVolumeExpansion: true
+        parameters:
+          detachedVolumesFromSnapshots: "false"
+          fsType: ext4
+    # VolumeSnapshotClass requires snapshot.storage.k8s.io CRDs (not installed yet).

--- a/infrastructure/base/storage/democratic-csi/kustomization.yaml
+++ b/infrastructure/base/storage/democratic-csi/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helmrelease.yaml
+  - truenas-iscsi-driver.secret.yaml

--- a/infrastructure/base/storage/democratic-csi/namespace.yaml
+++ b/infrastructure/base/storage/democratic-csi/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: democratic-csi
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/infrastructure/base/storage/democratic-csi/truenas-iscsi-driver.secret.yaml
+++ b/infrastructure/base/storage/democratic-csi/truenas-iscsi-driver.secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: truenas-iscsi-driver-config
+    namespace: democratic-csi
+type: Opaque
+stringData:
+    driver-config-file.yaml: ENC[AES256_GCM,data:QjHzKRNJIGIYCXkJGVXl/FPJc7e2bhfKRtfnL5hdVqMMwjttquGCEjoyBQjwjXWLWrdEoWISr2v+yZMCOL1MID/lw3yV1OVbJKQCwV0ogC3GUiRY0YJpCmemwClWJ0S3GYVXIlHP7rLYg8rdZ/DthImm7aijjyq92KfB66HU0eHWoDYe/2EXYHB4QDCZ/XXItbNoYRUNIn4Qk+Zs/w428rNeGERLb+et/V/BErY6u7kP+Ezv2I9aqX3cOaEtiwoZaMgrbH32hoL0/9VsExt+bOVzew+NB5W0nd8qW+ctZGQvkPJcfxnoeh+EpmStte3rnW7arw8DXsqbJRQd2JgUSAxg2UGTYQtOc+LhkKpZV5i922NXVjuwYrycbNZ0n9jfNJlHKNUrrwLpNTm8bplDcPnwT7FhFVbtg6gGclFzc43eq+GhN3Yo2Z3vz6hjlIRfFmtfWCMweQVxyuooAJktnF/P/C6/3JXyh81rST6wsp8BHldiBhXE4CSbj8v6/oRQ/1hlVS5yO3PJg5ywtia+Fhybue7zzwnDHhB3DAv0sX8k4eRePX/6LCqXUb5eXovwkeYZbTgs+HHStfAPxga4EFBOxp9UHtjkfoTGVn+WkGe9lmjP+sJMTMEu7m/V5Slnyv7Fh7uwgZ/NV0FTLUFhCub/ciD6COKzcn+2NuqSZ8B4tl800Y0bc+mur+wWpyYiGyx93sL3mtCF/Zfgw6dCr62KJUUACxwvkkb3+uK+8uYwkU+z2kRzgvQsXIJXLosyCiBEYzRfYXmY9DIOeOAJr2dRH1r9jMX86WPLGfrG4gH+7MYiOLc01R1g1nuezliS1T74Eyj/+c77MwEmywZxaIjnZBAoHANeUzNf5/8Nxd46T/cn0uCCm5WTt20x3Gmo/sDqEccdXfStdoId3CgX/U0e6Yawuf9QLs8cd0zTPe3M8sfGt4fN7g4ZAUV+0d10tPwuExww3rmKJftXntxQaqmuZykiNeuR9BLW5ltoXSTROeQNUgnftExwFynWvXocEN38YuSo+ePByB2xPQpftAe1Wtc1KN4LMCE/JplC8Ml37idrJRWOCcKw5A40rL4b/a1zGrojbyzzvxD/EcGYmzq7INKY1q9SvJg5Nin5eIlD/wy9Bv2L0Bp+ITAKSR4LaYXqxnNUxUjWXKrt/kGF7SAdPHuO7pFiovK+/EU7b2K2PSenMR3exQpSeE9SswvGpNMaL1soprULqHc1HpWv6MSJMzD6DAlKpwRZpGIno41xWLDlPWRbjD+wLuXQUX/q8oxMgkBRVyk6ETqjP9Qf1PurrZENjz/SqFoJ/FA/zttTBbaFBEOP13UV4zllaz2fDIyOHXFetPWo0/u8Kkcl4RIx3Eiogpz2N5kHrowm3XPhnU1ALxDHpeTMumBylJMfxQKDUi03mmjobI6B8FA5Ha5xlUw9Xl5Es6A5xfTMgZk2jiuxHsJQMPGuVHxEUdVxOUdWXU4q2XBbRsncrm34YV+KlEQWjwUnpGzcDjMbtCLUF4BiLpXfDaA6TYF2E+PE4d2SS7oN7GPgub/5E7kzSAo+Yjpp7B2boFMG3OOeclT4UXHoBa4hWX/cGe7a9Rml+TC18Nshd+Uzdg==,iv:c1yu09mptox+3AUezqGS/BgCinIbi/11B3XcyFgqG1c=,tag:rHl0I6mXjp59yKt0GOVIeQ==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjTk9abzc0VVBacXppSnZL
+            WiszcGZlbUtOZTB2dzVwd24rYUUreVBHWVgwCkhNYTBqRUI0alFuTEc3QVFJem8y
+            TUhlVldNaXdvTGltVnhLT0RwZUhqL0kKLS0tIGdLalFDc0FGOGFmOVErbG5SMXFW
+            eUtCeGU3MVkvUnF0SWExcFduMGRPK00KDoiSuSLwLzvUZatEKMevad7zBYgkDSk1
+            63s9AzC4ltPje7BIjq+KhQ9zzDJdYK8kUEOqk5/DanG5WfEfDuTCTQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1u5lcvuuwd4lk7f3xewjk70j75yuh68myr89qkd0e8d44zgyjleeqw03vqs
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-05-24T14:56:14Z"
+    mac: ENC[AES256_GCM,data:xC4EBCONT+HVcTfiM9dbbIsM7VITILUTMuVU1bBnGqZjj3OyLn+gS2Ib2z7p+LngviVs2KAevnYd3QhFcUnKMxnkXVS9w1bpLZJfhpk1ohLtr1WYuf2D4qHHt+3ZmsKxYhok51PIGH4KnUU7xBm6Rys6z5LyRx5Ue3YeBZ8SFXM=,iv:32qJw6LDn7b5jiM3j8xW1D+kig+5yeqF9GHydFfvbnU=,tag:GWYGPDOEKiBBF3IxQONNiQ==,type:str]
+    version: 3.13.1

--- a/infrastructure/base/storage/democratic-csi/truenas-iscsi-driver.secret.yaml.template
+++ b/infrastructure/base/storage/democratic-csi/truenas-iscsi-driver.secret.yaml.template
@@ -1,0 +1,51 @@
+# TrueNAS API driver config for democratic-csi (freenas-api-iscsi).
+#
+# 1. TrueNAS UI: Credentials → Users → k8sadmin (Local Administrator) → API Keys → Add
+# 2. Sharing → Block (iSCSI): Initiator Group (allow all or Talos IQNs), Portal on 192.168.10.94
+# 3. Datasets: sibling datasets for volumes + snapshots (not nested in each other)
+# 4. scripts/truenas-discover-iscsi.sh — portal/initiator IDs and dataset paths
+# 5. cp this file → truenas-iscsi-driver.secret.yaml, fill apiKey + paths, then:
+#    export SOPS_AGE_KEY_FILE=~/.config/sops/age/keys.txt
+#    sops -e -i truenas-iscsi-driver.secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: truenas-iscsi-driver-config
+  namespace: democratic-csi
+type: Opaque
+stringData:
+  driver-config-file.yaml: |
+    driver: freenas-api-iscsi
+    instance_id: homelab-kube
+    httpConnection:
+      protocol: http
+      host: 192.168.10.94
+      port: 80
+      allowInsecure: true
+      apiKey: REPLACE_WITH_TRUENAS_API_KEY
+    iscsi:
+      targetPortal: "192.168.10.94:3260"
+      targetPortals: []
+      interface: ""
+      namePrefix: csi-
+      nameSuffix: "-homelab"
+      targetGroups:
+        - targetGroupPortalGroup: 1
+          targetGroupInitiatorGroup: 1
+          targetGroupAuthType: None
+          targetGroupAuthGroup: null
+      extentCommentTemplate: "{{ parameters.[csi.storage.k8s.io/pvc/namespace] }}/{{ parameters.[csi.storage.k8s.io/pvc/name] }}"
+      extentInsecureTpc: true
+      extentXenCompat: false
+      extentDisablePhysicalBlocksize: true
+      extentBlocksize: 512
+      extentRpm: "SSD"
+      extentAvailThreshold: 0
+    zfs:
+      # TrueNAS UI: /mnt/FastStorage/ClusterStorage/k8s-volumes (+ k8s-snapshots sibling)
+      datasetParentName: FastStorage/ClusterStorage/k8s-volumes
+      detachedSnapshotsDatasetParentName: FastStorage/ClusterStorage/k8s-snapshots
+      zvolCompression: lz4
+      zvolEnableReservation: false
+      datasetProperties:
+        "org.freenas:description": "{{ parameters.[csi.storage.k8s.io/pvc/namespace] }}/{{ parameters.[csi.storage.k8s.io/pvc/name] }}"

--- a/infrastructure/base/storage/kustomization.yaml
+++ b/infrastructure/base/storage/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - longhorn.yaml
   - storageclass-longhorn-1.yaml
+  - democratic-csi
   - ingress.yaml
   - nfs-storageclass.yaml
   - pv-nfs.yaml

--- a/infrastructure/base/storage/storageclass-longhorn-1.yaml
+++ b/infrastructure/base/storage/storageclass-longhorn-1.yaml
@@ -1,11 +1,9 @@
-# Single-replica Longhorn class (homelab disk limits). Do not redefine `longhorn` here —
-# that StorageClass is owned by the Longhorn Helm chart and its parameters are immutable.
+# Legacy single-replica Longhorn class — remove after longhorn-to-truenas-iscsi migration.
+# Default StorageClass is truenas-iscsi (democratic-csi HelmRelease).
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: longhorn-1
-  annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
 provisioner: driver.longhorn.io
 allowVolumeExpansion: true
 reclaimPolicy: Delete

--- a/infrastructure/overlays/main/database-clusters/cluster.yaml
+++ b/infrastructure/overlays/main/database-clusters/cluster.yaml
@@ -22,7 +22,7 @@ spec:
       effective_cache_size: 256MB
 
   storage:
-    storageClass: longhorn
+    storageClass: truenas-iscsi
     size: 10Gi
 
   resources:

--- a/infrastructure/overlays/main/database-clusters/immich-postgres/cluster.yaml
+++ b/infrastructure/overlays/main/database-clusters/immich-postgres/cluster.yaml
@@ -26,7 +26,7 @@ spec:
       effective_cache_size: 512MB
 
   storage:
-    storageClass: longhorn
+    storageClass: truenas-iscsi
     size: 10Gi
 
   resources:

--- a/infrastructure/overlays/main/pgadmin/helmrelease.yaml
+++ b/infrastructure/overlays/main/pgadmin/helmrelease.yaml
@@ -55,4 +55,4 @@ spec:
     persistentVolume:
       enabled: true
       size: 1Gi
-      storageClass: longhorn
+      storageClass: truenas-iscsi

--- a/scripts/force-delete-pvc.sh
+++ b/scripts/force-delete-pvc.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Force-delete a PVC stuck in Terminating (Longhorn finalizers).
+set -euo pipefail
+NS="${1:?namespace}"; PVC="${2:?pvc name}"
+kubectl patch pvc "$PVC" -n "$NS" -p '{"metadata":{"finalizers":null}}' --type=merge 2>/dev/null || true
+kubectl delete pvc "$PVC" -n "$NS" --force --grace-period=0 2>/dev/null || true

--- a/scripts/migrate-pvc-to-truenas.sh
+++ b/scripts/migrate-pvc-to-truenas.sh
@@ -7,8 +7,9 @@ NS="${1:?namespace}"
 PVC="${2:?pvc name}"
 SIZE="${3:-}"
 SC="truenas-iscsi"
-MIG="${PVC}-migrate-${MIG_ID:-$(date +%s)}"
-JOB_ID="${MIG_ID:-$(date +%s)}"
+MIG_ID="${MIG_ID:-$(date +%s)}"
+MIG="${PVC}-m-${MIG_ID}"
+JOB_ID="${MIG_ID}"
 
 if [[ -z "${KUBECONFIG:-}" ]]; then
   echo "Set KUBECONFIG" >&2
@@ -82,7 +83,7 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: migrate-${PVC}-${JOB_ID}
+  name: mig-${JOB_ID}
   namespace: ${NS}
 spec:
   ttlSecondsAfterFinished: 600
@@ -115,10 +116,22 @@ spec:
             claimName: ${MIG}
 EOF
 
-kubectl wait --for=condition=complete "job/migrate-${PVC}-${JOB_ID}" -n "$NS" --timeout=30m
+kubectl wait --for=condition=complete "job/mig-${JOB_ID}" -n "$NS" --timeout=30m
 
 echo "==> [$NS/$PVC] replace PVC"
-kubectl delete pvc -n "$NS" "$PVC" --wait=true
+kubectl delete pvc -n "$NS" "$PVC" --wait=false
+for _ in $(seq 1 90); do
+  if ! kubectl get pvc -n "$NS" "$PVC" &>/dev/null; then
+    break
+  fi
+  phase="$(kubectl get pvc -n "$NS" "$PVC" -o jsonpath='{.status.phase}' 2>/dev/null || echo gone)"
+  [[ "$phase" == "Terminating" ]] && bash "$(dirname "$0")/force-delete-pvc.sh" "$NS" "$PVC"
+  sleep 5
+done
+if kubectl get pvc -n "$NS" "$PVC" &>/dev/null; then
+  echo "ERROR: PVC $NS/$PVC still exists after delete" >&2
+  exit 1
+fi
 kubectl apply -f - <<EOF
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -140,7 +153,7 @@ kubectl apply -f - <<EOF
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: migrate-${PVC}-restore-${JOB_ID}
+  name: mig-r-${JOB_ID}
   namespace: ${NS}
 spec:
   ttlSecondsAfterFinished: 600
@@ -172,9 +185,9 @@ spec:
             claimName: ${PVC}
 EOF
 
-kubectl wait --for=condition=complete "job/migrate-${PVC}-restore-${JOB_ID}" -n "$NS" --timeout=30m
+kubectl wait --for=condition=complete "job/mig-r-${JOB_ID}" -n "$NS" --timeout=30m
 kubectl delete pvc -n "$NS" "$MIG" --wait=false
-kubectl delete job -n "$NS" "migrate-${PVC}-${JOB_ID}" "migrate-${PVC}-restore-${JOB_ID}" --ignore-not-found
+kubectl delete job -n "$NS" "mig-${JOB_ID}" "mig-r-${JOB_ID}" --ignore-not-found
 
 echo "==> [$NS/$PVC] scale up"
 kubectl get cronjob -n "$NS" -o name 2>/dev/null | while read -r cj; do

--- a/scripts/migrate-pvc-to-truenas.sh
+++ b/scripts/migrate-pvc-to-truenas.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# Copy data from an existing Longhorn PVC to a new PVC on truenas-iscsi (same name).
+# Usage: migrate-pvc-to-truenas.sh <namespace> <pvc-name> [size e.g. 5Gi]
+set -euo pipefail
+
+NS="${1:?namespace}"
+PVC="${2:?pvc name}"
+SIZE="${3:-}"
+SC="truenas-iscsi"
+MIG="${PVC}-migrate-${MIG_ID:-$(date +%s)}"
+JOB_ID="${MIG_ID:-$(date +%s)}"
+
+if [[ -z "${KUBECONFIG:-}" ]]; then
+  echo "Set KUBECONFIG" >&2
+  exit 1
+fi
+
+if [[ -z "$SIZE" ]]; then
+  SIZE="$(kubectl get pvc -n "$NS" "$PVC" -o jsonpath='{.spec.resources.requests.storage}')"
+fi
+
+echo "==> [$NS/$PVC] scale down consumers"
+kubectl get pods -A -o json | python3 -c "
+import json, sys
+ns, pvc = '$NS', '$PVC'
+for p in json.load(sys.stdin)['items']:
+  vols = p.get('spec', {}).get('volumes', [])
+  if p['metadata']['namespace'] != ns:
+    continue
+  if any(v.get('persistentVolumeClaim', {}).get('claimName') == pvc for v in vols):
+    kind = p['metadata'].get('ownerReferences', [{}])[0].get('kind', '')
+    print(p['metadata']['name'])
+" | while read -r pod; do
+  [[ -z "$pod" ]] && continue
+  echo "    deleting pod $pod"
+  kubectl delete pod -n "$NS" "$pod" --wait=false 2>/dev/null || true
+done
+
+# CronJobs / Deployments: suspend cronjob, scale deployments
+kubectl get cronjob -n "$NS" -o name 2>/dev/null | while read -r cj; do
+  kubectl patch -n "$NS" "$cj" -p '{"spec":{"suspend":true}}' --type=merge 2>/dev/null || true
+done
+kubectl get deploy -n "$NS" -o json 2>/dev/null | python3 -c "
+import json, sys
+ns, pvc = '$NS', '$PVC'
+for d in json.load(sys.stdin)['items']:
+  spec = d.get('spec', {}).get('template', {}).get('spec', {})
+  vols = spec.get('volumes', [])
+  if any(v.get('persistentVolumeClaim', {}).get('claimName') == pvc for v in vols):
+    print(d['metadata']['name'])
+" | while read -r dep; do
+  kubectl scale deploy -n "$NS" "$dep" --replicas=0
+done
+
+kubectl get statefulset -n "$NS" -o json 2>/dev/null | python3 -c "
+import json, sys
+ns, pvc = '$NS', '$PVC'
+for s in json.load(sys.stdin)['items']:
+  vols = s.get('spec', {}).get('template', {}).get('spec', {}).get('volumes', [])
+  if any(v.get('persistentVolumeClaim', {}).get('claimName') == pvc for v in vols):
+    print(s['metadata']['name'])
+" | while read -r sts; do
+  kubectl scale sts -n "$NS" "$sts" --replicas=0
+done
+
+sleep 5
+
+echo "==> [$NS/$PVC] rsync longhorn -> temp $MIG"
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ${MIG}
+  namespace: ${NS}
+spec:
+  accessModes: [ReadWriteOnce]
+  storageClassName: ${SC}
+  resources:
+    requests:
+      storage: ${SIZE}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: migrate-${PVC}-${JOB_ID}
+  namespace: ${NS}
+spec:
+  ttlSecondsAfterFinished: 600
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: rsync
+          image: alpine:3.21
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+              apk add --no-cache rsync
+              mkdir -p /dst
+              rsync -aHAX /src/ /dst/ || [ -z "\$(ls -A /src 2>/dev/null)" ]
+              echo done
+          volumeMounts:
+            - name: src
+              mountPath: /src
+            - name: dst
+              mountPath: /dst
+      volumes:
+        - name: src
+          persistentVolumeClaim:
+            claimName: ${PVC}
+        - name: dst
+          persistentVolumeClaim:
+            claimName: ${MIG}
+EOF
+
+kubectl wait --for=condition=complete "job/migrate-${PVC}-${JOB_ID}" -n "$NS" --timeout=30m
+
+echo "==> [$NS/$PVC] replace PVC"
+kubectl delete pvc -n "$NS" "$PVC" --wait=true
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ${PVC}
+  namespace: ${NS}
+spec:
+  accessModes: [ReadWriteOnce]
+  storageClassName: ${SC}
+  resources:
+    requests:
+      storage: ${SIZE}
+EOF
+
+kubectl wait --for=jsonpath='{.status.phase}'=Bound "pvc/${PVC}" -n "$NS" --timeout=10m
+
+echo "==> [$NS/$PVC] rsync temp -> new"
+kubectl apply -f - <<EOF
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: migrate-${PVC}-restore-${JOB_ID}
+  namespace: ${NS}
+spec:
+  ttlSecondsAfterFinished: 600
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: rsync
+          image: alpine:3.21
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+              apk add --no-cache rsync
+              rsync -aHAX /src/ /dst/
+              echo done
+          volumeMounts:
+            - name: src
+              mountPath: /src
+            - name: dst
+              mountPath: /dst
+      volumes:
+        - name: src
+          persistentVolumeClaim:
+            claimName: ${MIG}
+        - name: dst
+          persistentVolumeClaim:
+            claimName: ${PVC}
+EOF
+
+kubectl wait --for=condition=complete "job/migrate-${PVC}-restore-${JOB_ID}" -n "$NS" --timeout=30m
+kubectl delete pvc -n "$NS" "$MIG" --wait=false
+kubectl delete job -n "$NS" "migrate-${PVC}-${JOB_ID}" "migrate-${PVC}-restore-${JOB_ID}" --ignore-not-found
+
+echo "==> [$NS/$PVC] scale up"
+kubectl get cronjob -n "$NS" -o name 2>/dev/null | while read -r cj; do
+  kubectl patch -n "$NS" "$cj" -p '{"spec":{"suspend":false}}' --type=merge 2>/dev/null || true
+done
+kubectl get deploy -n "$NS" -o json 2>/dev/null | python3 -c "
+import json, sys
+ns, pvc = '$NS', '$PVC'
+for d in json.load(sys.stdin)['items']:
+  spec = d.get('spec', {}).get('template', {}).get('spec', {})
+  vols = spec.get('volumes', [])
+  if any(v.get('persistentVolumeClaim', {}).get('claimName') == pvc for v in vols):
+    print(d['metadata']['name'])
+" | while read -r dep; do
+  kubectl scale deploy -n "$NS" "$dep" --replicas=1
+done
+kubectl get statefulset -n "$NS" -o json 2>/dev/null | python3 -c "
+import json, sys
+ns, pvc = '$NS', '$PVC'
+for s in json.load(sys.stdin)['items']:
+  vols = s.get('spec', {}).get('template', {}).get('spec', {}).get('volumes', [])
+  if any(v.get('persistentVolumeClaim', {}).get('claimName') == pvc for v in vols):
+    print(s['metadata']['name'])
+" | while read -r sts; do
+  kubectl scale sts -n "$NS" "$sts" --replicas=1
+done
+
+echo "==> [$NS/$PVC] done"

--- a/scripts/truenas-discover-iscsi.sh
+++ b/scripts/truenas-discover-iscsi.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Query TrueNAS iSCSI portal/initiator IDs and list datasets (needs API key).
+# Usage: TRUENAS_API_KEY=... ./scripts/truenas-discover-iscsi.sh
+set -euo pipefail
+
+HOST="${TRUENAS_HOST:-192.168.10.94}"
+API_KEY="${TRUENAS_API_KEY:?Set TRUENAS_API_KEY}"
+
+api() {
+  curl -sS -H "Authorization: Bearer ${API_KEY}" "http://${HOST}/api/v2.0/$1"
+}
+
+echo "=== iSCSI portals (use id for targetGroupPortalGroup) ==="
+api iscsi/portal | python3 -m json.tool 2>/dev/null || api iscsi/portal
+
+echo
+echo "=== iSCSI initiator groups (use id for targetGroupInitiatorGroup) ==="
+api iscsi/initiator | python3 -m json.tool 2>/dev/null || api iscsi/initiator
+
+echo
+echo "=== iSCSI targets (CSI creates extents dynamically; manual target optional) ==="
+api iscsi/target | python3 -m json.tool 2>/dev/null || api iscsi/target
+
+echo
+echo "=== ZFS pools / datasets (pick sibling parents for volumes + snapshots) ==="
+api pool/dataset | python3 -c "
+import json,sys
+data=json.load(sys.stdin)
+for d in sorted(data, key=lambda x: x.get('name','')):
+    if d.get('type') in ('FILESYSTEM','VOLUME'):
+        print(d.get('name'), d.get('type'), d.get('mountpoint',''))
+" 2>/dev/null || api pool/dataset | head -c 4000
+
+echo
+echo "Paste portal id, initiator id, and dataset paths into:"
+echo "  infrastructure/base/storage/democratic-csi/truenas-iscsi-driver.secret.yaml.template"


### PR DESCRIPTION
## Summary
- Deploy **democratic-csi** (`freenas-api-iscsi`) with StorageClass `truenas-iscsi` as the default block provisioner on TrueNAS M.2
- Switch app PVCs, CNPG clusters, pgAdmin, Velero/CNPG depends-on, and monitoring stack manifests from `longhorn`/`longhorn-1` to `truenas-iscsi`
- Add migration runbook, TrueNAS discovery script, and `migrate-pvc-to-truenas.sh` for live PVC cutover (immutable storageClass)

## Cluster state (pre-merge)
- democratic-csi already deployed manually; test PVC `default/truenas-iscsi-test` is **Bound**
- Image tag `next` required for TrueNAS 25.04; `zvolDedup` omitted; VolumeSnapshotClass disabled (no snapshot CRDs)
- 12 Longhorn PVCs remain — migration in progress on branch deploy

## Test plan
- [ ] `kubectl get sc truenas-iscsi` — default class
- [ ] `kubectl get pods -n democratic-csi` — controller + node Running
- [ ] Flux `infra-storage` reconciles with SOPS secret
- [ ] After PVC migration: `kubectl get pvc -A | grep longhorn` returns empty
- [ ] CNPG clusters healthy post Barman recovery
- [ ] Homepage / Grafana / Immich smoke test


Made with [Cursor](https://cursor.com)