### PR TITLE
docs(storage): Longhorn staged upgrade runbook; enable Renovate secret

### DIFF
--- a/apps/base/forgejo/kustomization.yaml
+++ b/apps/base/forgejo/kustomization.yaml
@@ -11,5 +11,4 @@ resources:
   - transportserver.yaml
   - renovate-config.configmap.yaml
   - renovate-cronjob.yaml
-  # Enable after SOPS-encrypting renovate-credentials.secret.yaml (see migration runbook).
-  # - renovate-credentials.secret.yaml
+  - renovate-credentials.secret.yaml

--- a/apps/base/forgejo/renovate-credentials.secret.yaml
+++ b/apps/base/forgejo/renovate-credentials.secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+data:
+    RENOVATE_GITHUB_COM_TOKEN: ENC[AES256_GCM,data:racBbWb9WBAGqj9s7vJNm7Jy+l+X4r6c2hWc8/okFT+uhZ6AH9nMAwhfVVy79xCv9Mvfhs0TnGpHFltmyTaAdxai/+UEvYs0DJrJm1CnlAFRv/9GPIFrPvLL13pHJHSLNKhrE6x0i36hn6afx78ozxdjfT1M6dh459PIuQ==,iv:Yfhnp0em7jfVJbVzt+ZEdBDDrY3VoZlNqDxRWsHCYas=,tag:kqYypJJ+Lo/QfkUZHrZumA==,type:str]
+    RENOVATE_TOKEN: ENC[AES256_GCM,data:+ZEu4PjjL4z5e2UFIwoOAfO/rSFIIz0W+gXM3uOXMQ62Gpu6+Bx4rEuBBcabx1Jp5yWgn70BVNU=,iv:hoFnTHOr4diI6cIJp1G2bs+6T8fLVBoMi7A8bfuaOSo=,tag:8yMyhF/dLWHvU97lgB+tvw==,type:str]
+kind: Secret
+metadata:
+    name: renovate-credentials
+    namespace: forgejo
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGbVZaMmNRbnpXelZRZ0V5
+            ajBQSHBySnRpclhEejBkZVlwY0V1bzg1QWh3CjNQRm40SlNzdVBMODh4SERDM2tV
+            M1FYOHRQL281dmxRU2ZyaWF5ZTFZZ3MKLS0tIHlrdVlXMGo5ZnZaTlJmeHBTN21x
+            UmRFYkRtNjRRaGQyVm9MVmxzR1l4ZW8Ky+yVXuXT/rw4ZXI79xv0RnZwwqubtOzg
+            1Tn/ldVvV8jOtNTzz7jrWXPvR6smbOOs5X+6wxVoOV2v1XXrpL7blw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1u5lcvuuwd4lk7f3xewjk70j75yuh68myr89qkd0e8d44zgyjleeqw03vqs
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-05-24T12:56:36Z"
+    mac: ENC[AES256_GCM,data:JZ+7BXhHavdb5wgZXI7GHYoBVmvo91gWpExgWaXiSxmiu45yVwg46ymSZ6KzWZB5DsIRhaMd1M9Iwe6Ebcix0qXli2toPEATcde8NmlHy9S5m/9O76rFQuJYMpN4+8EV3Qt56XnE5DdMTQrOJuqyj2ChzRJS5Bj9jno67VwEHDM=,iv:2e2e9Iki4xB6rxBk76AFLfo4sgjE4zmmpVaq3kvOwQs=,tag:ZHwaK7oTr3WBT5aR/KE9zw==,type:str]
+    version: 3.13.1

--- a/docs/disaster-recovery/README.md
+++ b/docs/disaster-recovery/README.md
@@ -77,6 +77,8 @@ DR patches include `cnpg.io/skipEmptyWalArchiveCheck: enabled` when reusing the 
 | Paperless `secret paperless-ngx not found` | App secret not in Git | `apps/overlays/main/paperless-ngx.secret.yaml` (SOPS) |
 | UI unreachable via VIP `.245` | Ingress uses `hostNetwork` on node IPs | Use `https://<node-ip>` or DNS to `.41`/`.42`/`.43`, not API VIP |
 | `infra-storage` fails on StorageClass `longhorn` | Git must not redefine Helm-owned SC | Only `storageclass-longhorn-1.yaml` in kustomize |
+| Longhorn HelmRelease `FailedUpgradePreCheck` (1.6→1.11) | Longhorn allows one minor version per upgrade | [longhorn-upgrade.md](../runbooks/longhorn-upgrade.md) — staged `scripts/longhorn-staged-upgrade.sh` |
+| Longhorn/Velero pre-upgrade hook `no route to host` (10.96.0.1:443) on cp1/cp3 | Hook Job scheduled on node without working service CNI/API path | `kubectl cordon talos-cp1 talos-cp3`, delete failed hook Job, retry upgrade |
 
 ## Reach apps after rebuild
 

--- a/docs/runbooks/longhorn-upgrade.md
+++ b/docs/runbooks/longhorn-upgrade.md
@@ -1,0 +1,75 @@
+# Longhorn staged upgrade
+
+## Symptom
+
+- Flux `HelmRelease/longhorn` **Failed** / **Stalled** with `FailedUpgradePreCheck: upgrading from vX.Y to vA.B for minor version is not supported`
+- PVCs stay **Pending** (`longhorn-1` / `longhorn` provisioner unavailable)
+- `infra-storage` → `infra-base` → `infra-main` → `apps` kustomizations not Ready
+
+Longhorn only supports **one minor version step** per upgrade (e.g. 1.6 → 1.7, not 1.6 → 1.11).
+
+## Preconditions
+
+- `KUBECONFIG` pointing at the cluster (`homelab-infrastructure/talos/kubeconfig`)
+- Helm values match `infrastructure/base/storage/longhorn.yaml` (see script usage below)
+- If pre-upgrade hook jobs fail with `dial tcp 10.96.0.1:443: connect: no route to host` on **cp1/cp3**, cordon those nodes so hooks schedule on **cp2** (known Talos/CNI quirk on this cluster)
+
+## Staged upgrade (manual)
+
+```bash
+cd homelab-infrastructure && nix develop .#talos
+
+export KUBECONFIG=$PWD/talos/kubeconfig
+
+# Optional: keep hook jobs off broken nodes
+kubectl cordon talos-cp1 talos-cp3
+
+flux suspend helmrelease longhorn -n longhorn-system
+kubectl -n longhorn-system delete job longhorn-pre-upgrade --ignore-not-found
+
+# Values file must mirror Git HelmRelease values
+cat >/tmp/longhorn-upgrade-values.yaml <<'EOF'
+global:
+  priorityClassName: homelab-infrastructure
+persistence:
+  defaultClass: false
+  defaultDataPath: /var/lib/longhorn
+defaultSettings:
+  createDefaultDiskLabeledNodes: false
+  replicaCount: 1
+longhornManager:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+EOF
+
+./scripts/longhorn-staged-upgrade.sh /tmp/longhorn-upgrade-values.yaml
+
+flux resume helmrelease longhorn -n longhorn-system
+flux reconcile helmrelease longhorn -n longhorn-system --with-source
+flux reconcile kustomization infra-storage -n flux-system --with-source
+
+kubectl uncordon talos-cp1 talos-cp3
+```
+
+The script steps through chart versions **1.7.3 → 1.8.2 → 1.9.2 → 1.10.2 → 1.11.2** (adjust the `VERSIONS` array in `scripts/longhorn-staged-upgrade.sh` if the cluster starts from a different release).
+
+## Verify
+
+```bash
+kubectl -n longhorn-system get ds longhorn-manager
+helm list -n longhorn-system
+flux get helmrelease longhorn -n longhorn-system
+kubectl get sc longhorn longhorn-1
+kubectl get pvc -A | rg Pending
+```
+
+All manager pods should run `longhorn-manager:v1.11.2` (or target version). Test provisioning with a small PVC on `longhorn-1`.
+
+## GitOps note
+
+After a manual staged upgrade, Flux `HelmRelease` chart version in Git should match the live Helm release (`1.11.2` in `infrastructure/base/storage/longhorn.yaml`). Do not redefine the `longhorn` StorageClass in kustomize — only `storageclass-longhorn-1.yaml` is managed in Git.

--- a/scripts/longhorn-staged-upgrade.sh
+++ b/scripts/longhorn-staged-upgrade.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Staged Longhorn Helm upgrade (one minor version at a time).
+# Required when jumping more than one minor release — see
+# https://longhorn.io/docs/1.11.2/deploy/upgrade/
+set -euo pipefail
+
+NAMESPACE="${LONGHORN_NAMESPACE:-longhorn-system}"
+RELEASE="${LONGHORN_RELEASE:-longhorn-system-longhorn}"
+VALUES_FILE="${1:-}"
+
+if [[ -z "${VALUES_FILE}" || ! -f "${VALUES_FILE}" ]]; then
+  echo "Usage: $0 <helm-values.yaml>" >&2
+  exit 1
+fi
+
+VERSIONS=(1.7.3 1.8.2 1.9.2 1.10.2 1.11.2)
+
+helm repo add longhorn https://charts.longhorn.io >/dev/null 2>&1 || true
+helm repo update longhorn >/dev/null
+
+for version in "${VERSIONS[@]}"; do
+  echo "==> Upgrading ${RELEASE} to chart ${version} ..."
+  helm upgrade "${RELEASE}" longhorn/longhorn \
+    --namespace "${NAMESPACE}" \
+    --version "${version}" \
+    --values "${VALUES_FILE}" \
+    --wait \
+    --timeout 20m
+  kubectl -n "${NAMESPACE}" rollout status daemonset/longhorn-manager --timeout=300s
+  echo "==> ${version} OK"
+done
+
+echo "Done. Reconcile Flux: flux reconcile helmrelease longhorn -n ${NAMESPACE}"


### PR DESCRIPTION
Reflect cluster state after 1.6→1.11.2 Longhorn upgrade and Forgejo migration: add staged-upgrade script and runbook, document pre-upgrade hook cordon workaround, and commit SOPS renovate-credentials for Flux-managed CronJob.