### PR TITLE
feat(readeck): add read-it-later bookmark app

### DIFF
--- a/apps/base/readeck/deployment.yaml
+++ b/apps/base/readeck/deployment.yaml
@@ -1,0 +1,100 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: readeck
+  namespace: readeck
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: readeck
+  template:
+    metadata:
+      labels:
+        app: readeck
+        app.kubernetes.io/name: readeck
+    spec:
+      enableServiceLinks: false
+      containers:
+        - name: readeck
+          # renovate: datasource=docker depName=codeberg.org/readeck/readeck
+          image: codeberg.org/readeck/readeck:0.22.3
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8000
+              name: http
+          env:
+            - name: TZ
+              value: Europe/Berlin
+            - name: READECK_LOG_LEVEL
+              value: info
+            - name: READECK_LOG_FORMAT
+              value: text
+            - name: READECK_SERVER_HOST
+              value: "0.0.0.0"
+            - name: READECK_SERVER_PORT
+              value: "8000"
+            - name: READECK_SERVER_BASE_URL
+              value: https://readeck.f4mily.net
+            - name: READECK_ALLOWED_HOSTS
+              value: readeck.f4mily.net
+            - name: READECK_DATABASE_SOURCE
+              value: /readeck/db.sqlite3
+          volumeMounts:
+            - name: data
+              mountPath: /readeck
+          startupProbe:
+            exec:
+              command:
+                - /bin/readeck
+                - healthcheck
+                - -config
+                - /readeck/config.toml
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            failureThreshold: 30
+          livenessProbe:
+            exec:
+              command:
+                - /bin/readeck
+                - healthcheck
+                - -config
+                - /readeck/config.toml
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 25m
+              memory: 512Mi
+            limits:
+              memory: 1Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: readeck-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: readeck
+  namespace: readeck
+spec:
+  ports:
+    - port: 8000
+      targetPort: http
+      name: http
+  selector:
+    app: readeck

--- a/apps/base/readeck/ingress.yaml
+++ b/apps/base/readeck/ingress.yaml
@@ -1,0 +1,32 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: readeck
+  namespace: readeck
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: Readeck
+    gethomepage.dev/description: Read-it-later bookmarks
+    gethomepage.dev/group: Office
+    gethomepage.dev/icon: readeck.png
+    gethomepage.dev/app: readeck
+    gethomepage.dev/pod-selector: app=readeck
+    nginx.org/ssl-redirect: "false"
+    nginx.org/redirect-to-https: "true"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - readeck.f4mily.net
+      secretName: wildcard-f4mily-net-tls
+  rules:
+    - host: readeck.f4mily.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: readeck
+                port:
+                  number: 8000

--- a/apps/base/readeck/kustomization.yaml
+++ b/apps/base/readeck/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - pvc.yaml
+  - deployment.yaml
+  - ingress.yaml

--- a/apps/base/readeck/namespace.yaml
+++ b/apps/base/readeck/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: readeck
+  labels:
+    app.kubernetes.io/name: readeck
+    app.kubernetes.io/part-of: homelab-apps

--- a/apps/base/readeck/pvc.yaml
+++ b/apps/base/readeck/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: readeck-data
+  namespace: readeck
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: truenas-iscsi
+  resources:
+    requests:
+      storage: 5Gi

--- a/apps/overlays/main/cluster-config.yaml
+++ b/apps/overlays/main/cluster-config.yaml
@@ -59,6 +59,8 @@ data:
   # Comma-separated Django ALLOWED_HOSTS (host + local debugging).
   tandoor_allowed_hosts: tandoor.cluster.f4mily.net,localhost,127.0.0.1
   host_linkwarden: linkwarden.f4mily.net
+  host_readeck: readeck.f4mily.net
+  url_readeck: https://readeck.f4mily.net
 
   # Cluster-internal apps (covered by *.cluster.f4mily.net wildcard):
   host_goloom: goloom.cluster.f4mily.net

--- a/apps/overlays/main/kustomization.yaml
+++ b/apps/overlays/main/kustomization.yaml
@@ -40,6 +40,7 @@ resources:
   - ../../base/forgejo
   - ../../base/nextcloud
   # - ../../base/linkwarden          # disabled: temporarily removed from catalog
+  - ../../base/readeck
   - ../../base/authentik
   - ../../base/homepage
 
@@ -150,6 +151,34 @@ replacements:
         fieldPaths:
           - spec.rules.0.host
           - spec.tls.0.hosts.0
+
+  - source:
+      kind: ConfigMap
+      name: homelab-cluster-config
+      fieldPath: data.host_readeck
+    targets:
+      - select: {kind: Ingress, name: readeck}
+        fieldPaths:
+          - spec.rules.0.host
+          - spec.tls.0.hosts.0
+
+  - source:
+      kind: ConfigMap
+      name: homelab-cluster-config
+      fieldPath: data.url_readeck
+    targets:
+      - select: {kind: Deployment, name: readeck}
+        fieldPaths:
+          - spec.template.spec.containers.[name=readeck].env.[name=READECK_SERVER_BASE_URL].value
+
+  - source:
+      kind: ConfigMap
+      name: homelab-cluster-config
+      fieldPath: data.host_readeck
+    targets:
+      - select: {kind: Deployment, name: readeck}
+        fieldPaths:
+          - spec.template.spec.containers.[name=readeck].env.[name=READECK_ALLOWED_HOSTS].value
 
   - source:
       kind: ConfigMap
@@ -325,6 +354,8 @@ replacements:
       - select: {kind: Ingress, name: kavita}
         fieldPaths: [spec.tls.0.secretName]
       - select: {kind: Ingress, name: paperless}
+        fieldPaths: [spec.tls.0.secretName]
+      - select: {kind: Ingress, name: readeck}
         fieldPaths: [spec.tls.0.secretName]
       - select: {kind: HelmRelease, name: sterling-pdf}
         fieldPaths: [spec.values.ingress.tls.0.secretName]

--- a/docs/applications.md
+++ b/docs/applications.md
@@ -68,6 +68,7 @@ here so it is obvious what is **planned** but not deployed:
 | unifi-controller   | off    | removed from catalog (DR test)            |
 | nextcloud          | on     | HelmRelease + CNPG + NFS at cluster domain  |
 | linkwarden         | off    | temporarily removed from catalog          |
+| readeck            | on     | Deployment, SQLite on iSCSI, readeck.f4mily.net |
 | speedtest-tracker  | wip    | ingress only, missing Deployment          |
 | watchyourlan       | on     | DaemonSet (hostNetwork), scan via IFACES  |
 | teslamate          | on     | Deployment, Mosquitto, CNPG, teslamate.f4mily.net (/grafana/) |


### PR DESCRIPTION
## Summary

- Add Readeck ([docs](https://readeck.org/en/docs/#installation)) as a standalone Deployment with SQLite on `truenas-iscsi` (5 Gi PVC at `/readeck`).
- Expose via NGINX Ingress at `readeck.f4mily.net` with Homepage annotations (Office group).
- Wire hostname and base URL through `cluster-config.yaml` replacements.

## Resources

| Resource | Purpose |
|----------|---------|
| `apps/base/readeck/` | Namespace, PVC, Deployment, Service, Ingress |
| `cluster-config.yaml` | `host_readeck`, `url_readeck` |
| Overlay `kustomization.yaml` | Catalog entry + replacements + TLS |

## Post-merge

1. **DNS:** Add AdGuard rewrite for `readeck.f4mily.net` → ingress VIP (e.g. in `homelab-infrastructure/dns/servers.tf` under `talos_cluster.service_domains`, then `just dns::plan && just dns::apply`).
2. **Flux:** `flux reconcile kustomization apps --with-source`
3. **First visit:** Create admin account at https://readeck.f4mily.net

## Test plan

- [ ] `just validate` passes
- [ ] Pod `readeck` becomes Ready; PVC bound on `truenas-iscsi`
- [x] https://readeck.f4mily.net loads Readeck setup/login
- [ ] Homepage shows Readeck tile under Office


Made with [Cursor](https://cursor.com)