### PR TITLE
fix(grafana): resolve CrashLoopBackOff in vm-k8s-stack

### DIFF
--- a/apps/base/monitoring/vm-k8s-stack/helmrelease.yaml
+++ b/apps/base/monitoring/vm-k8s-stack/helmrelease.yaml
@@ -225,11 +225,19 @@ spec:
         storageClassName: truenas-iscsi
         size: 2Gi
 
-      # Security context
+      # Align securityContext with podSecurityContext: chart init-chown uses
+      # securityContext.runAsUser (default 472), not podSecurityContext — mismatch
+      # caused CrashLoop (init chown 472, main container UID 1000).
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       podSecurityContext:
         runAsUser: 1000
         runAsGroup: 1000
         fsGroup: 1000
+      initChownData:
+        enabled: false
 
       containerSecurityContext:
         allowPrivilegeEscalation: false
@@ -244,12 +252,16 @@ spec:
           emptyDir: {}
         - name: plugins-dir
           emptyDir: {}
+        - name: logs
+          emptyDir: {}
 
       extraVolumeMounts:
         - name: tmp
           mountPath: /tmp
         - name: plugins-dir
           mountPath: /var/lib/grafana/plugins
+        - name: logs
+          mountPath: /var/log/grafana
 
       # Native VictoriaMetrics datasource plugin
       # Pin to 0.22.0 - 0.23.x requires Grafana >=11.6.11 (not yet available in charts)
@@ -316,13 +328,12 @@ spec:
       podAnnotations:
         backup.velero.io/backup-volumes: grafana-storage
 
-      # Sidecar watches for dashboard configmaps (chart handles datasource natively)
+      # Sidecar watches dashboard ConfigMaps only; defaultDatasources below
+      # provisions VM datasource — enabling the datasource sidecar duplicates
+      # provisioning and prevented Grafana from starting (exit 1 ~2s).
       sidecar:
         datasources:
-          enabled: true
-          initDatasources: false
-          label: grafana_datasource
-          labelValue: "1"
+          enabled: false
         dashboards:
           enabled: true
           label: grafana_dashboard


### PR DESCRIPTION
## Summary

- Align `securityContext` with `podSecurityContext` (UID 1000) and disable `initChownData` — the chart init container chowned the PVC to **472** while Grafana ran as **1000**.
- Disable the **datasource sidecar** — `defaultDatasources` already provisions VictoriaMetrics; both caused Grafana to exit immediately (exit 1).
- Add writable `emptyDir` for `/var/log/grafana` with `readOnlyRootFilesystem`.

## Root cause

The n8n remediation hint (missing env vars) was incorrect. The pod failed due to filesystem UID mismatch and duplicate datasource provisioning.

## Test plan

- [x] Cluster: Grafana pod `2/2 Running`, `/api/health` returns 200
- [ ] After merge: Flux reconciles `vm-k8s-stack` in `monitoring`
- [ ] Verify login via Authentik at `https://grafana.cluster.f4mily.net`
- [ ] Confirm dashboard sidecar still loads ConfigMaps (`grafana_dashboard=1`)


Made with [Cursor](https://cursor.com)