### PR TITLE
fix: increase memory limits for Authentik and Postgres

### DIFF
--- a/apps/base/authentik/helmrelease.yaml
+++ b/apps/base/authentik/helmrelease.yaml
@@ -86,9 +86,9 @@ spec:
       resources:
         requests:
           cpu: 25m
-          memory: 256Mi
+          memory: 768Mi
         limits:
-          memory: 1Gi
+          memory: 2Gi
       volumes:
         - name: data
           persistentVolumeClaim:
@@ -100,6 +100,6 @@ spec:
       resources:
         requests:
           cpu: 25m
-          memory: 256Mi
+          memory: 768Mi
         limits:
-          memory: 1Gi
+          memory: 2Gi

--- a/infrastructure/overlays/main/database-clusters/cluster.yaml
+++ b/infrastructure/overlays/main/database-clusters/cluster.yaml
@@ -28,9 +28,9 @@ spec:
   resources:
     requests:
       cpu: 50m
-      memory: 128Mi
-    limits:
       memory: 512Mi
+    limits:
+      memory: 1Gi
 
   monitoring:
     enablePodMonitor: true


### PR DESCRIPTION
Adjusted memory requests and limits for Authentik (768Mi/2Gi) and homelab-postgres (512Mi/1Gi) to address high usage.