### PR TITLE
fix(forgejo): correct Redis image for cache/session

### DIFF
--- a/apps/base/forgejo/redis.yaml
+++ b/apps/base/forgejo/redis.yaml
@@ -15,7 +15,8 @@ spec:
     spec:
       containers:
         - name: redis
-          image: docker.io/bitnami/redis:7.4
+          # bitnami/redis moved to bitnamilegacy; tag must be full version (7.4 does not exist)
+          image: docker.io/bitnamilegacy/redis:8.2.1-debian-12-r0
           env:
             - name: ALLOW_EMPTY_PASSWORD
               value: "yes"


### PR DESCRIPTION
## Summary
- Replace non-existent `docker.io/bitnami/redis:7.4` with `bitnamilegacy/redis:8.2.1-debian-12-r0` (same as Nextcloud/Immich/Authentik).

## Problem
Forgejo CrashLoop: Redis `ImagePullBackOff`, Forgejo fatal `cache.Init` connection refused.

## Test plan
- [x] Redis pod Running in cluster
- [x] Forgejo pod Ready, `/api/healthz` OK


Made with [Cursor](https://cursor.com)