### PR TITLE
feat: add cluster-reader RBAC for n8n AI agent

### DIFF
--- a/apps/base/n8n/helmrelease.yaml
+++ b/apps/base/n8n/helmrelease.yaml
@@ -30,6 +30,11 @@ spec:
     ingress:
       enabled: false
 
+    serviceAccount:
+      create: true
+      name: n8n-app
+      automountServiceAccountToken: true
+
     main:
       config:
         n8n:

--- a/apps/base/n8n/kustomization.yaml
+++ b/apps/base/n8n/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - n8n-integration-credentials.secret.yaml
   - helmrelease.yaml
   - ingress.yaml
+  - rbac.yaml

--- a/apps/base/n8n/rbac.yaml
+++ b/apps/base/n8n/rbac.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: n8n-cluster-tool
+  labels:
+    app.kubernetes.io/name: n8n
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "events", "services", "namespaces", "configmaps"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "statefulsets", "daemonsets", "replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: n8n-cluster-tool
+  labels:
+    app.kubernetes.io/name: n8n
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: n8n-cluster-tool
+subjects:
+  - kind: ServiceAccount
+    name: n8n-app
+    namespace: ai-ops


### PR DESCRIPTION
Added ClusterRole and ClusterRoleBinding for n8n-app ServiceAccount to allow reading pods, logs, and events. This enables n8n AI workflows to query cluster state for better remediation.