### PR TITLE
fix(cluster): reduce CPU limit overcommit

### DIFF
--- a/apps/base/forgejo/deployment.yaml
+++ b/apps/base/forgejo/deployment.yaml
@@ -49,11 +49,11 @@ spec:
             allowPrivilegeEscalation: false
           resources:
             requests:
-              cpu: 500m
-              memory: 1Gi
+              cpu: 100m
+              memory: 512Mi
             limits:
-              cpu: "2"
-              memory: 4Gi
+              cpu: 500m
+              memory: 2Gi
           livenessProbe:
             httpGet:
               path: /api/healthz

--- a/apps/base/forgejo/renovate-cronjob.yaml
+++ b/apps/base/forgejo/renovate-cronjob.yaml
@@ -7,7 +7,7 @@ spec:
   schedule: "0 */4 * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
-  failedJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
       backoffLimit: 1

--- a/apps/base/readeck/deployment.yaml
+++ b/apps/base/readeck/deployment.yaml
@@ -41,7 +41,7 @@ spec:
             - name: READECK_ALLOWED_HOSTS
               value: readeck.f4mily.net
             - name: READECK_DATABASE_SOURCE
-              value: /readeck/db.sqlite3
+              value: sqlite3:/readeck/db.sqlite3
           volumeMounts:
             - name: data
               mountPath: /readeck

--- a/clusters/main/flux-system/gotk-components.yaml
+++ b/clusters/main/flux-system/gotk-components.yaml
@@ -2583,10 +2583,10 @@ spec:
             port: http
         resources:
           limits:
-            cpu: 1000m
-            memory: 1Gi
+            cpu: 200m
+            memory: 512Mi
           requests:
-            cpu: 50m
+            cpu: 25m
             memory: 64Mi
         securityContext:
           allowPrivilegeEscalation: false
@@ -3407,10 +3407,10 @@ spec:
             port: healthz
         resources:
           limits:
-            cpu: 1000m
-            memory: 1Gi
+            cpu: 200m
+            memory: 512Mi
           requests:
-            cpu: 100m
+            cpu: 25m
             memory: 64Mi
         securityContext:
           allowPrivilegeEscalation: false
@@ -4963,10 +4963,10 @@ spec:
             port: healthz
         resources:
           limits:
-            cpu: 1000m
-            memory: 1Gi
+            cpu: 200m
+            memory: 512Mi
           requests:
-            cpu: 100m
+            cpu: 25m
             memory: 64Mi
         securityContext:
           allowPrivilegeEscalation: false
@@ -6409,10 +6409,10 @@ spec:
             port: healthz
         resources:
           limits:
-            cpu: 1000m
-            memory: 1Gi
+            cpu: 200m
+            memory: 512Mi
           requests:
-            cpu: 100m
+            cpu: 25m
             memory: 64Mi
         securityContext:
           allowPrivilegeEscalation: false
@@ -7716,10 +7716,10 @@ spec:
             port: healthz
         resources:
           limits:
-            cpu: 1000m
-            memory: 1Gi
+            cpu: 200m
+            memory: 512Mi
           requests:
-            cpu: 100m
+            cpu: 25m
             memory: 64Mi
         securityContext:
           allowPrivilegeEscalation: false
@@ -8654,10 +8654,10 @@ spec:
             port: healthz
         resources:
           limits:
-            cpu: 1000m
-            memory: 1Gi
+            cpu: 200m
+            memory: 512Mi
           requests:
-            cpu: 100m
+            cpu: 25m
             memory: 64Mi
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
- Forgejo: 500m/2 → 100m/500m request/limit, memory 512Mi/2Gi
- Flux controllers (6×): limit 1000m → 200m, request 25m, mem 512Mi
- Readeck: `READECK_DATABASE_SOURCE=sqlite3:/readeck/db.sqlite3`
- Renovate: `failedJobsHistoryLimit: 1`

## Problem
Node CPU limits at 114–135% allocatable; 5 pods not ready (Renovate errors, Readeck crash, n8n fin Pending).

## Test plan
- [x] Node limits cp1 ~12%, cp3 ~91% (was 135%)
- [x] Forgejo + Readeck Ready


Made with [Cursor](https://cursor.com)