### PR TITLE
feat(forgejo): PostgreSQL GitOps (post-migration)

### DIFF
--- a/apps/base/forgejo/deployment.yaml
+++ b/apps/base/forgejo/deployment.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: forgejo
   namespace: forgejo
+  annotations:
+    kustomize.toolkit.fluxcd.io/depends-on: postgresql.cnpg.io/Database/cnpg-system/homelab-postgres-forgejo
 spec:
   replicas: 1
   strategy:
@@ -44,9 +46,26 @@ spec:
               value: redis
             - name: GITEA__session__PROVIDER_CONFIG
               value: redis://forgejo-redis:6379/0
-            # Reduce SQLite lock waits under concurrent git/runner load
-            - name: GITEA__database__SQLITE_TIMEOUT
-              value: "5000"
+            - name: GITEA__database__DB_TYPE
+              value: postgres
+            - name: GITEA__database__HOST
+              value: homelab-postgres-rw.cnpg-system.svc.cluster.local
+            - name: GITEA__database__PORT
+              value: "5432"
+            - name: GITEA__database__NAME
+              value: forgejo
+            - name: GITEA__database__USER
+              valueFrom:
+                secretKeyRef:
+                  name: homelab-postgres-forgejo
+                  key: username
+            - name: GITEA__database__PASSWD
+              valueFrom:
+                secretKeyRef:
+                  name: homelab-postgres-forgejo
+                  key: password
+            - name: GITEA__database__SSL_MODE
+              value: disable
           # Do not set runAsUser/runAsGroup — the Forgejo image drops privileges via s6.
           securityContext:
             allowPrivilegeEscalation: false
@@ -57,7 +76,7 @@ spec:
             limits:
               cpu: 500m
               memory: 2Gi
-          # Liveness: TCP only — /api/healthz pings SQLite and can take 20s+ under load.
+          # Liveness: TCP only — /api/healthz can stall when Postgres is under load.
           startupProbe:
             httpGet:
               path: /api/healthz

--- a/apps/overlays/main/databases/forgejo.yaml
+++ b/apps/overlays/main/databases/forgejo.yaml
@@ -1,0 +1,10 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: homelab-postgres-forgejo
+  namespace: cnpg-system
+spec:
+  name: forgejo
+  owner: forgejo
+  cluster:
+    name: homelab-postgres

--- a/apps/overlays/main/databases/kustomization.yaml
+++ b/apps/overlays/main/databases/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - linkwarden.yaml
   - teslamate.yaml
   - goloom.yaml
+  - forgejo.yaml

--- a/apps/overlays/main/db-secrets/forgejo-db-credentials.secret.yaml
+++ b/apps/overlays/main/db-secrets/forgejo-db-credentials.secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: forgejo-db-credentials
+    namespace: cnpg-system
+stringData:
+    username: ENC[AES256_GCM,data:OUmeg24v1A==,iv:kOVHKJ4a7IAynepC2S8am8gByBhdpbn/bd1lHbBtrMI=,tag:ho2h0wImg+32QUOW6otxww==,type:str]
+    password: ENC[AES256_GCM,data:UijD8U3H0yT1PHQh1ejTG/kvhmtwicpa6efmSxegfYs=,iv:4HyLucwbS3GNvvTeZOL7cD0RAd3arKAhS9kzf4TF3FU=,tag:JquOuzz/6prbY0lpflAjjA==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA3NmNCYkdWckJsWGlJRG9s
+            aHZNMFFMMmRDaXF1amMrdlB2N0hJU1pXajA0CllNQ0hYdXc0bTlsZlRKbUo0bXVy
+            bUVIbHNldlNyNEtYZ3dROWFCUnhQZ0kKLS0tIE5kTThWTTFvK0xKUGlmQUZJWGx1
+            RmN6L3JMQ0luU3dlOHZSbmRaUStIYUEKLhSRQDCgfDmHoLAkZKpdDDCp+BD9jkIl
+            KyPwx+LSWRtJ5jrv+6FdEBlVS6dr2a6l9aGmMR9W5TEn9dO/vZgpcQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1u5lcvuuwd4lk7f3xewjk70j75yuh68myr89qkd0e8d44zgyjleeqw03vqs
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-05-26T07:13:58Z"
+    mac: ENC[AES256_GCM,data:vnCQYM8bO2AyDg0XVSXb1A3qjlOPRegphL0aPteYXtDgigM2Xps9Ke/pE5E6BUhMOpG0MR/gvpqz+V3tPQVobyKeP/crzojw7Q8sk835a1a8+lMfL1TQiK9CWXco5pYH9N4XEQf7chebZWJNZvBpHdsgei6S+3C4a+//vd32on0=,iv:zqxzAKsLcQkbPyLbUhRLfrj4Q+UUM93xxy5R0Qod+nc=,tag:oR5l06wJecGfxMiZG/k72Q==,type:str]
+    version: 3.13.1

--- a/apps/overlays/main/db-secrets/kustomization.yaml
+++ b/apps/overlays/main/db-secrets/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - nextcloud-db-credentials.secret.yaml
   - paperless-db-credentials.secret.yaml
   - goloom-db-credentials.secret.yaml
+  - forgejo-db-credentials.secret.yaml
   - teslamate-db-credentials.secret.yaml
   # linkwarden disabled in apps catalog — no linkwarden namespace
   # - linkwarden-db-credentials.secret.yaml
@@ -81,3 +82,13 @@ patches:
       - op: replace
         path: /metadata/namespace
         value: tandoor
+  - target:
+      kind: Secret
+      name: forgejo-db-credentials
+    patch: |
+      - op: replace
+        path: /metadata/name
+        value: homelab-postgres-forgejo
+      - op: replace
+        path: /metadata/namespace
+        value: forgejo

--- a/docs/migrations/forgejo-docker-to-kubernetes.md
+++ b/docs/migrations/forgejo-docker-to-kubernetes.md
@@ -15,7 +15,7 @@ TransportServer).
 | Component | Docker (production) | Kubernetes (homelab) |
 |-----------|---------------------|----------------------|
 | App | `codeberg.org/forgejo/forgejo:15` | Deployment `forgejo` — pin in `deployment.yaml` |
-| DB | SQLite (`/data/gitea/gitea.db`) | Same file on NFS PVC (no CNPG) |
+| DB | SQLite (`/data/gitea/gitea.db`) | **PostgreSQL** on `homelab-postgres` (DB `forgejo`, CNPG role `forgejo`) |
 | Data | `/mnt/cephfs/forgejo` → `/data` | PVC `forgejo-data` → NFS `Media` + `subPath: docker/forgejo` |
 | HTTP | Traefik `git.f4mily.net:443` | Ingress `git.f4mily.net` (NGINX, wildcard TLS) |
 | Git SSH | Host port `2222` → container `:22` | TransportServer on ingress nodes `:22` and `:2222` → `forgejo-ssh:22` |

--- a/infrastructure/overlays/main/database-clusters/credentials/forgejo-db-credentials.secret.yaml
+++ b/infrastructure/overlays/main/database-clusters/credentials/forgejo-db-credentials.secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: forgejo-db-credentials
+    namespace: cnpg-system
+stringData:
+    username: ENC[AES256_GCM,data:OUmeg24v1A==,iv:kOVHKJ4a7IAynepC2S8am8gByBhdpbn/bd1lHbBtrMI=,tag:ho2h0wImg+32QUOW6otxww==,type:str]
+    password: ENC[AES256_GCM,data:UijD8U3H0yT1PHQh1ejTG/kvhmtwicpa6efmSxegfYs=,iv:4HyLucwbS3GNvvTeZOL7cD0RAd3arKAhS9kzf4TF3FU=,tag:JquOuzz/6prbY0lpflAjjA==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA3NmNCYkdWckJsWGlJRG9s
+            aHZNMFFMMmRDaXF1amMrdlB2N0hJU1pXajA0CllNQ0hYdXc0bTlsZlRKbUo0bXVy
+            bUVIbHNldlNyNEtYZ3dROWFCUnhQZ0kKLS0tIE5kTThWTTFvK0xKUGlmQUZJWGx1
+            RmN6L3JMQ0luU3dlOHZSbmRaUStIYUEKLhSRQDCgfDmHoLAkZKpdDDCp+BD9jkIl
+            KyPwx+LSWRtJ5jrv+6FdEBlVS6dr2a6l9aGmMR9W5TEn9dO/vZgpcQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1u5lcvuuwd4lk7f3xewjk70j75yuh68myr89qkd0e8d44zgyjleeqw03vqs
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-05-26T07:13:58Z"
+    mac: ENC[AES256_GCM,data:vnCQYM8bO2AyDg0XVSXb1A3qjlOPRegphL0aPteYXtDgigM2Xps9Ke/pE5E6BUhMOpG0MR/gvpqz+V3tPQVobyKeP/crzojw7Q8sk835a1a8+lMfL1TQiK9CWXco5pYH9N4XEQf7chebZWJNZvBpHdsgei6S+3C4a+//vd32on0=,iv:zqxzAKsLcQkbPyLbUhRLfrj4Q+UUM93xxy5R0Qod+nc=,tag:oR5l06wJecGfxMiZG/k72Q==,type:str]
+    version: 3.13.1

--- a/infrastructure/overlays/main/database-clusters/credentials/kustomization.yaml
+++ b/infrastructure/overlays/main/database-clusters/credentials/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - linkwarden-db-credentials.secret.yaml
   - teslamate-db-credentials.secret.yaml
   - goloom-db-credentials.secret.yaml
+  - forgejo-db-credentials.secret.yaml


### PR DESCRIPTION
## Summary
- Forgejo `Deployment`: `GITEA__database__*` → CNPG (`homelab-postgres-forgejo`), Flux `depends-on` Database CR, drop `SQLITE_TIMEOUT`
- CNPG: `Database` `homelab-postgres-forgejo`, SOPS `forgejo-db-credentials` (infra + apps `db-secrets` patch → `homelab-postgres-forgejo` in namespace `forgejo`)
- Docs: `forgejo-docker-to-kubernetes.md` architecture table updated (no migration runbook/job in repo)

## Context
SQLite → Postgres migration was completed manually on the cluster. This PR aligns Git with the running state only.

## Test plan
- [ ] `just validate` (local)
- [ ] After merge: `flux reconcile kustomization infra-main` and `apps`
- [ ] Confirm `kubectl get database -n cnpg-system homelab-postgres-forgejo`
- [ ] Confirm `kubectl get secret -n forgejo homelab-postgres-forgejo`
- [ ] `curl -s https://git.f4mily.net/api/healthz` → `database:ping` pass
- [ ] SOPS decrypt works in CI / Flux (credentials encrypted with repo age recipient + live cluster password)

Made with [Cursor](https://cursor.com)