### PR TITLE
fix(homepage): force rollout when ConfigMap changes

### DIFF
--- a/apps/base/homepage/configmap.yaml
+++ b/apps/base/homepage/configmap.yaml
@@ -40,12 +40,12 @@ data:
     - Develope:
         - Gitops Homelab:
             - abbr: GH
-            href: https://github.com/kreativmonkey/homelab-gitops
+              href: https://github.com/kreativmonkey/homelab-gitops
     - Social:
         - Jit.social:
             - icon: mastodon.png
-            href: https://jit.social
-            description: Radiotux und Binärgewitter
+              href: https://jit.social
+              description: Radiotux und Binärgewitter
   services.yaml: |
     ---
     - Infrastructure:

--- a/apps/base/homepage/deployment.yaml
+++ b/apps/base/homepage/deployment.yaml
@@ -14,7 +14,7 @@ spec:
         app: homepage
       annotations:
         # Bump to force rollout when only ConfigMap content changes.
-        config-version: "2026-05-23a"
+        config-version: "2026-05-26a"
     spec:
       serviceAccountName: homepage
       automountServiceAccountToken: true


### PR DESCRIPTION
## Summary
Homepage copies ConfigMap files into `emptyDir` once at pod start. Flux updated `homepage-config` but `config-version` was unchanged, so the running pod kept stale YAML (e.g. 3245 vs 3909 bytes in `services.yaml`).

Bump `config-version` to trigger rollout on sync.

## Test plan
- [x] `kubectl rollout restart` — pod now has 3909-byte `services.yaml` and bookmarks
- [ ] After merge: hard-refresh https://home.f4mily.net

Made with [Cursor](https://cursor.com)