### PR TITLE
fix(searxng): persistent instance settings

### DIFF
--- a/apps/base/searxng/configmap.yaml
+++ b/apps/base/searxng/configmap.yaml
@@ -4,8 +4,18 @@ metadata:
   name: searxng-settings
   namespace: searxng
 data:
+  # Instance config (GitOps). Applied on every pod start.
+  # UI preferences from /preferences are browser cookies (signed with SEARXNG_SECRET);
+  # put lasting defaults here or in settings.local.yml on the PVC (see deployment init).
   settings.yml: |
     use_default_settings: true
     server:
       limiter: false
       bind_address: "0.0.0.0"
+    general:
+      instance_name: "SearXNG"
+    ui:
+      default_theme: simple
+    search:
+      safe_search: 0
+      default_lang: "de-DE"

--- a/apps/base/searxng/deployment.yaml
+++ b/apps/base/searxng/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: searxng
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: searxng
@@ -30,8 +32,12 @@ spec:
             - /bin/sh
             - -ec
             - |
-              cp -a /etc/searxng/. /mnt/etc/searxng/
-              cp /config/settings.yml /mnt/etc/searxng/settings.yml
+              set -e
+              DEST=/mnt/etc/searxng
+              if [ ! -f "${DEST}/settings.yml" ]; then
+                cp -a /etc/searxng/. "${DEST}/"
+              fi
+              cp /config/settings.yml "${DEST}/settings.yml"
           securityContext:
             runAsUser: 977
             runAsGroup: 977
@@ -100,7 +106,8 @@ spec:
               mountPath: /etc/searxng
       volumes:
         - name: etc-searxng
-          emptyDir: {}
+          persistentVolumeClaim:
+            claimName: searxng-config
         - name: config-source
           configMap:
             name: searxng-settings

--- a/apps/base/searxng/kustomization.yaml
+++ b/apps/base/searxng/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yaml
+  - pvc.yaml
   - configmap.yaml
   - searxng-secret.secret.yaml
   - valkey-deployment.yaml

--- a/apps/base/searxng/pvc.yaml
+++ b/apps/base/searxng/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: searxng-config
+  namespace: searxng
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: truenas-iscsi
+  resources:
+    requests:
+      storage: 100Mi

--- a/apps/overlays/main/cluster-config.yaml
+++ b/apps/overlays/main/cluster-config.yaml
@@ -53,6 +53,7 @@ data:
   host_paperless: paperless.f4mily.net
   host_sterling_pdf: pdf.f4mily.net
   host_searxng: search.f4mily.net
+  url_searxng: https://search.f4mily.net/
   host_teslamate: teslamate.f4mily.net
   url_teslamate_grafana: https://teslamate.f4mily.net/grafana/
   host_tandoor: rezepte.f4mily.net

--- a/apps/overlays/main/kustomization.yaml
+++ b/apps/overlays/main/kustomization.yaml
@@ -203,6 +203,15 @@ replacements:
   - source:
       kind: ConfigMap
       name: homelab-cluster-config
+      fieldPath: data.url_searxng
+    targets:
+      - select: {kind: Deployment, name: searxng}
+        fieldPaths:
+          - spec.template.spec.containers.[name=searxng].env.[name=SEARXNG_BASE_URL].value
+
+  - source:
+      kind: ConfigMap
+      name: homelab-cluster-config
       fieldPath: data.host_tandoor
     targets:
       - select: {kind: Ingress, name: tandoor}


### PR DESCRIPTION
## Summary
- PVC `searxng-config` for `/etc/searxng` (replaces `emptyDir`)
- Init seeds once, reapplies `settings.yml` from ConfigMap on each start
- Instance defaults in ConfigMap (theme, `de-DE`, safe search)
- `url_searxng` replacement for `SEARXNG_BASE_URL`

## Note
UI preferences on `/preferences` remain browser cookies. Lasting instance settings belong in `configmap.yaml` or `settings.local.yml` on the PVC.

## Test plan
- [ ] Merge + `flux reconcile kustomization apps`
- [ ] Hard-refresh https://search.f4mily.net
- [ ] ConfigMap edits apply after rollout

Made with [Cursor](https://cursor.com)