### PR TITLE
fix(searxng): Recreate strategy SSA patch

### DIFF
--- a/apps/base/searxng/deployment.yaml
+++ b/apps/base/searxng/deployment.yaml
@@ -5,7 +5,9 @@ metadata:
   namespace: searxng
 spec:
   replicas: 1
+  # Recreate + RWO PVC; $patch: replace drops stale rollingUpdate after SSA merge.
   strategy:
+    $patch: replace
     type: Recreate
   selector:
     matchLabels:


### PR DESCRIPTION
## Summary
Flux dry-run failed: `rollingUpdate` forbidden when `strategy.type` is `Recreate` (stale field from SSA merge on existing Deployment).

Uses `$patch: replace` on `spec.strategy` (same pattern as `system-upgrade-controller`).

## Test plan
- [ ] `flux reconcile kustomization apps` succeeds
- [ ] `kubectl get deploy -n searxng searxng -o jsonpath='{.spec.strategy}'`

Made with [Cursor](https://cursor.com)