### PR TITLE
fix: GitHub Actions nix-action download error

### DIFF
--- a/.forgejo/workflows/pr-validation.yaml
+++ b/.forgejo/workflows/pr-validation.yaml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Install Nix
-        uses: https://github.com/cachix/install-nix-action@v31.10.6
+        uses: https://github.com/cachix/install-nix-action@v31
 
       - name: Run validation (includes Renovate audit)
         run: nix develop -c just validate

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v6.0.2
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v31.10.6
+        uses: cachix/install-nix-action@v31
 
       - name: Run validation (includes Renovate audit)
         run: nix develop -c just validate


### PR DESCRIPTION
Updated 'cachix/install-nix-action' to major version tag 'v31' to resolve download/SHA resolution errors in GitHub Actions and Forgejo workflows.