### PR TITLE
feat(sparkyfitness): OIDC-only login

### DIFF
--- a/apps/base/sparkyfitness/helmrelease.yaml
+++ b/apps/base/sparkyfitness/helmrelease.yaml
@@ -92,12 +92,16 @@ spec:
       # Chart ingress is disabled; without this Better Auth defaults to localhost:3004 → Invalid origin.
       frontendUrl: https://fitness.f4mily.net
       timezone: Europe/Berlin
+      # Chart default forceEmailLogin=true keeps email login even when OIDC is on — disable for SSO-only.
+      forceEmailLogin: false
+      disableEmailLogin: true
       oidc:
         enabled: true
         providerSlug: authentik
         providerName: Authentik
         issuerUrl: https://login.f4mily.net/application/o/sparkyfitness/
         autoRegister: true
+        autoRedirect: true
     ingress:
       enabled: false
     databaseBackup:


### PR DESCRIPTION
## Summary
- Disable email/password login (`disableEmailLogin: true`, `forceEmailLogin: false` — chart default would keep email enabled)
- Enable OIDC auto-redirect to Authentik when only SSO is configured (`autoRedirect: true`)

Maps to `SPARKY_FITNESS_DISABLE_EMAIL_LOGIN`, `SPARKY_FITNESS_FORCE_EMAIL_LOGIN`, and `SPARKY_FITNESS_OIDC_AUTO_REDIRECT` via Helm chart ConfigMap.

## Test plan
- [ ] After Flux reconcile: `fitness.f4mily.net` redirects to Authentik, no email/password form
- [ ] Successful OIDC login returns to SparkyFitness

Made with [Cursor](https://cursor.com)