### PR TITLE
fix(cnpg): raise homelab-postgres max_connections to 100

### DIFF
--- a/infrastructure/overlays/main/database-clusters/cluster.yaml
+++ b/infrastructure/overlays/main/database-clusters/cluster.yaml
@@ -17,7 +17,9 @@ spec:
 
   postgresql:
     parameters:
-      max_connections: "50"
+      # Shared by many apps (Authentik, TeslaMate, SparkyFitness, …). 50 was exhausted
+      # (SparkyFitness alone: owner + app + Better Auth pools up to ~30 per replica).
+      max_connections: "100"
       shared_buffers: 64MB
       effective_cache_size: 256MB
 


### PR DESCRIPTION
## Summary
- Increase `homelab-postgres` `max_connections` from 50 to 100
- Fixes SparkyFitness API errors: `too many clients already` and `remaining connection slots are reserved for roles with the SUPERUSER attribute`

The shared CNPG cluster was at ~46/50 connections (Authentik, TeslaMate, etc.). SparkyFitness runs three `pg` pools (owner, app, Better Auth) with up to ~10 connections each.

## Test plan
- [ ] After CNPG rolling restart: `SELECT count(*) FROM pg_stat_activity` stays below 100 under normal use
- [ ] SparkyFitness `/api/adaptive-tdee` returns 200 instead of 500

Made with [Cursor](https://cursor.com)