### PR TITLE
fix(sparkyfitness): trust Authentik for OIDC discovery

### DIFF
--- a/apps/base/sparkyfitness/helmrelease.yaml
+++ b/apps/base/sparkyfitness/helmrelease.yaml
@@ -91,6 +91,8 @@ spec:
     config:
       # Chart ingress is disabled; without this Better Auth defaults to localhost:3004 → Invalid origin.
       frontendUrl: https://fitness.f4mily.net
+      # Better Auth SSO: OIDC discovery host must be a trusted origin (discovery_untrusted_origin).
+      extraTrustedOrigins: https://login.f4mily.net
       timezone: Europe/Berlin
       # Chart default forceEmailLogin=true keeps email login even when OIDC is on — disable for SSO-only.
       forceEmailLogin: false

--- a/docs/integrations/sparkyfitness-authentik.md
+++ b/docs/integrations/sparkyfitness-authentik.md
@@ -13,6 +13,7 @@ GitOps sets server env via Helm (`apps/base/sparkyfitness/helmrelease.yaml`) and
 | Scope | `openid profile email` ([upstream docs](https://codewithcj.github.io/SparkyFitness/administration/oauth-authentication)) |
 | Provider slug / name | `authentik` / `Authentik` |
 | Public frontend URL | `https://fitness.f4mily.net` (`config.frontendUrl`) |
+| Extra trusted origins | `https://login.f4mily.net` (`config.extraTrustedOrigins` — required for OIDC discovery) |
 | OIDC logo | jsDelivr Authentik icon (`config.oidc.logoUrl`) |
 | Auto-register | `true` |
 | Email/password login | disabled (`disableEmailLogin`, `forceEmailLogin: false`) |


### PR DESCRIPTION
## Summary
- Set `config.extraTrustedOrigins` to `https://login.f4mily.net`
- Fixes Better Auth `discovery_untrusted_origin` on `POST /api/auth/sign-in/sso`

## Test plan
- [ ] SSO login redirects to Authentik without 400

Made with [Cursor](https://cursor.com)