### PR TITLE
fix(sparkyfitness): Authentik issuer slug sparky-fitness

### DIFF
--- a/apps/base/sparkyfitness/helmrelease.yaml
+++ b/apps/base/sparkyfitness/helmrelease.yaml
@@ -101,8 +101,8 @@ spec:
         enabled: true
         providerSlug: authentik
         providerName: Authentik
-        # Authentik application slug must match path segment (discovery: …/application/o/sparkyfitness/).
-        issuerUrl: https://login.f4mily.net/application/o/sparkyfitness/
+        # Authentik application slug is sparky-fitness (hyphen) — not sparkyfitness.
+        issuerUrl: https://login.f4mily.net/application/o/sparky-fitness/
         # https://codewithcj.github.io/SparkyFitness/administration/oauth-authentication
         scope: openid profile email
         logoUrl: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/authentik.svg

--- a/docs/integrations/sparkyfitness-authentik.md
+++ b/docs/integrations/sparkyfitness-authentik.md
@@ -8,7 +8,7 @@ GitOps sets server env via Helm (`apps/base/sparkyfitness/helmrelease.yaml`) and
 
 | Setting | GitOps value |
 |---------|----------------|
-| Issuer URL | `https://login.f4mily.net/application/o/sparkyfitness/` |
+| Issuer URL | `https://login.f4mily.net/application/o/sparky-fitness/` (Authentik app slug) |
 | Client ID / secret | `sparkyfitness-app-values` → Helm `valuesFrom` |
 | Scope | `openid profile email` ([upstream docs](https://codewithcj.github.io/SparkyFitness/administration/oauth-authentication)) |
 | Provider slug / name | `authentik` / `Authentik` |
@@ -21,7 +21,7 @@ GitOps sets server env via Helm (`apps/base/sparkyfitness/helmrelease.yaml`) and
 
 ## Checklist (Authentik admin)
 
-1. **Application** slug `sparkyfitness`, provider type OAuth2/OIDC.
+1. **Application** slug **`sparky-fitness`** (with hyphen), provider type OAuth2/OIDC.
 2. **Redirect URI** (strict) — must match Better Auth, not the legacy `oidc-callback` path from older docs:
 
    ```text
@@ -38,7 +38,7 @@ GitOps sets server env via Helm (`apps/base/sparkyfitness/helmrelease.yaml`) and
 
 ```bash
 # Discovery (from a host that reaches login.f4mily.net)
-curl -sS https://login.f4mily.net/application/o/sparkyfitness/.well-known/openid-configuration | jq .issuer
+curl -sS https://login.f4mily.net/application/o/sparky-fitness/.well-known/openid-configuration | jq .issuer
 
 # Server env (after Flux reconcile)
 kubectl -n sparkyfitness exec deploy/sparkyfitness-server -- env | grep SPARKY_FITNESS_OIDC


### PR DESCRIPTION
## Summary
Authentik OIDC discovery is at `/application/o/sparky-fitness/`, not `sparkyfitness` (404 → discovery_not_found).

## Test plan
- [ ] `curl …/sparky-fitness/.well-known/openid-configuration` → 200
- [ ] SSO login on fitness.f4mily.net works

Made with [Cursor](https://cursor.com)