### PR TITLE
feat(linkding): add bookmark manager

### DIFF
--- a/apps/base/linkding/helmrelease.yaml
+++ b/apps/base/linkding/helmrelease.yaml
@@ -1,0 +1,37 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: linkding
+  namespace: linkding
+spec:
+  interval: 1h
+  timeout: 15m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: linkding
+      # renovate: datasource=helm registryUrl=https://rubxkube.github.io/charts depName=linkding
+      version: "1.1.21"
+      sourceRef:
+        kind: HelmRepository
+        name: rubxkube-repo
+        namespace: flux-system
+  values:
+    common:
+      ingress:
+        enabled: false
+      persistence:
+        enabled: true
+        volumes:
+          - name: data
+            containerMount: /etc/linkding/data
+            size: 5Gi
+            storageClassName: truenas-iscsi
+      variables:
+        nonSecret:
+          TZ: Europe/Berlin

--- a/apps/base/linkding/ingress.yaml
+++ b/apps/base/linkding/ingress.yaml
@@ -1,0 +1,31 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: linkding
+  namespace: linkding
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: Linkding
+    gethomepage.dev/description: Bookmark Manager
+    gethomepage.dev/group: Office
+    gethomepage.dev/icon: linkding.png
+    gethomepage.dev/pod-selector: app.kubernetes.io/instance=linkding
+    nginx.org/ssl-redirect: "false"
+    nginx.org/redirect-to-https: "true"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - bookmarks.f4mily.net
+      secretName: wildcard-f4mily-net-tls
+  rules:
+    - host: bookmarks.f4mily.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: linkding
+                port:
+                  number: 80

--- a/apps/base/linkding/kustomization.yaml
+++ b/apps/base/linkding/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helmrelease.yaml
+  - ingress.yaml

--- a/apps/base/linkding/namespace.yaml
+++ b/apps/base/linkding/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: linkding
+  labels:
+    app.kubernetes.io/name: linkding
+    app.kubernetes.io/part-of: homelab-apps

--- a/apps/overlays/main/cluster-config.yaml
+++ b/apps/overlays/main/cluster-config.yaml
@@ -46,6 +46,7 @@ data:
   host_forgejo: git.f4mily.net
   # Staging on cluster wildcard before moving production DNS:
   host_authentik: login.f4mily.net
+  host_linkding: bookmarks.f4mily.net
   host_homepage: home.f4mily.net
   host_immich: immich.f4mily.net
   host_jellyfin: jellyfin.f4mily.net

--- a/apps/overlays/main/kustomization.yaml
+++ b/apps/overlays/main/kustomization.yaml
@@ -41,6 +41,7 @@ resources:
   - ../../base/renovate
   - ../../base/nextcloud
   # - ../../base/linkwarden          # disabled: temporarily removed from catalog
+  - ../../base/linkding
   - ../../base/readeck
   - ../../base/sparkyfitness
   - ../../base/authentik
@@ -150,6 +151,16 @@ replacements:
       fieldPath: data.host_paperless
     targets:
       - select: {kind: Ingress, name: paperless}
+        fieldPaths:
+          - spec.rules.0.host
+          - spec.tls.0.hosts.0
+
+  - source:
+      kind: ConfigMap
+      name: homelab-cluster-config
+      fieldPath: data.host_linkding
+    targets:
+      - select: {kind: Ingress, name: linkding}
         fieldPaths:
           - spec.rules.0.host
           - spec.tls.0.hosts.0
@@ -398,6 +409,8 @@ replacements:
       - select: {kind: Ingress, name: kavita}
         fieldPaths: [spec.tls.0.secretName]
       - select: {kind: Ingress, name: paperless}
+        fieldPaths: [spec.tls.0.secretName]
+      - select: {kind: Ingress, name: linkding}
         fieldPaths: [spec.tls.0.secretName]
       - select: {kind: Ingress, name: readeck}
         fieldPaths: [spec.tls.0.secretName]

--- a/infrastructure/base/sources/helm-repositories.yaml
+++ b/infrastructure/base/sources/helm-repositories.yaml
@@ -142,4 +142,13 @@ metadata:
 spec:
   interval: 24h
   url: https://docs.renovatebot.com/helm-charts
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: rubxkube-repo
+  namespace: flux-system
+spec:
+  interval: 24h
+  url: https://rubxkube.github.io/charts
 


### PR DESCRIPTION
Deploy linkding via rubxkube helm chart.

- HelmRelease from rubxkube/linkding chart v1.1.21
- bookmarks.f4mily.net via separate NGINX Ingress
- 5Gi truenas-iscsi PVC for SQLite data
- rubxkube HelmRepository added to sources
- Homepage integration enabled