### PR TITLE
fix(sparkyfitness): tune resources from cluster metrics

### DIFF
--- a/apps/base/sparkyfitness/helmrelease.yaml
+++ b/apps/base/sparkyfitness/helmrelease.yaml
@@ -67,12 +67,14 @@ spec:
         backup:
           storageClass: truenas-iscsi
           size: 5Gi
+      # Sized from cluster metrics (idle): ~2m CPU, ~260Mi RAM; headroom for sync/API bursts.
       resources:
         requests:
           cpu: 50m
-          memory: 256Mi
+          memory: 384Mi
         limits:
-          memory: 1Gi
+          cpu: 500m
+          memory: 768Mi
     frontend:
       image:
         # renovate: datasource=docker depName=codewithcj/sparkyfitness versioning=semver
@@ -84,10 +86,10 @@ spec:
         port: 8080
       resources:
         requests:
-          cpu: 25m
-          memory: 64Mi
+          cpu: 10m
+          memory: 32Mi
         limits:
-          memory: 256Mi
+          memory: 128Mi
     config:
       # Chart ingress is disabled; without this Better Auth defaults to localhost:3004 → Invalid origin.
       frontendUrl: https://fitness.f4mily.net
@@ -118,12 +120,14 @@ spec:
       image:
         repository: codewithcj/sparkyfitness_garmin
         tag: v0.16.6.3
+      # Sized from cluster metrics (idle): ~3m CPU, ~95Mi RAM.
       resources:
         requests:
-          cpu: 50m
+          cpu: 25m
           memory: 128Mi
         limits:
-          memory: 512Mi
+          cpu: 250m
+          memory: 256Mi
     ingress:
       enabled: false
     databaseBackup:

--- a/docs/integrations/sparkyfitness-garmin.md
+++ b/docs/integrations/sparkyfitness-garmin.md
@@ -15,7 +15,10 @@ After Flux reconcile, check:
 ```bash
 kubectl -n sparkyfitness get pods -l app.kubernetes.io/component=garmin
 kubectl -n sparkyfitness exec deploy/sparkyfitness-server -- printenv GARMIN_MICROSERVICE_URL
+kubectl -n sparkyfitness top pods
 ```
+
+Helm resources are tuned from `kubectl top` (homelab idle: server ~260Mi, garmin ~95Mi, frontend ~5Mi). Re-check after heavy Garmin sync.
 
 ## Connect in the app
 


### PR DESCRIPTION
## Summary
- **Server**: memory request 256Mi → 384Mi (idle usage ~260Mi), limit 1Gi → 768Mi, CPU limit 500m
- **Frontend**: requests 25m/64Mi → 10m/32Mi, limit 256Mi → 128Mi (idle ~4Mi)
- **Garmin**: CPU limit 250m, memory limit 512Mi → 256Mi (idle ~95Mi)
- Doc: note `kubectl top` baseline and re-check after Garmin sync

## Test plan
- [ ] Flux reconciles HelmRelease
- [ ] All three pods Ready; no OOMKilled
- [ ] `https://fitness.f4mily.net/api/health` → 200
- [ ] `GARMIN_MICROSERVICE_URL` set on server


Made with [Cursor](https://cursor.com)