### PR TITLE
fix(flux): restore nextcloud HelmRepository

### DIFF
--- a/infrastructure/base/sources/helm-repositories.yaml
+++ b/infrastructure/base/sources/helm-repositories.yaml
@@ -151,4 +151,13 @@ metadata:
 spec:
   interval: 24h
   url: https://rubxkube.github.io/charts
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: nextcloud-repo
+  namespace: flux-system
+spec:
+  interval: 24h
+  url: https://nextcloud.github.io/helm/
 


### PR DESCRIPTION
## Summary
- Add missing `nextcloud-repo` HelmRepository so Flux can build the Nextcloud Helm chart artifact

## Test plan
- [ ] HelmRepository Ready in flux-system
- [ ] Nextcloud HelmRelease reconciles


Made with [Cursor](https://cursor.com)