### PR TITLE
fix(nextcloud): cronjob UID 1000

### DIFF
--- a/apps/base/nextcloud/helmrelease.yaml
+++ b/apps/base/nextcloud/helmrelease.yaml
@@ -256,7 +256,8 @@ spec:
       enabled: true
       # crond sidecar requires root; use CronJob with same UID as the app pod.
       type: cronjob
-      securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
-        runAsNonRoot: true
+      cronjob:
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+          runAsNonRoot: true


### PR DESCRIPTION
Fix securityContext nesting for chart 9.1.0 cronjob type.

Made with [Cursor](https://cursor.com)