### PR TITLE
feat(nextcloud): Authentik OIDC login

### DIFF
--- a/apps/base/nextcloud/helmrelease.yaml
+++ b/apps/base/nextcloud/helmrelease.yaml
@@ -104,6 +104,7 @@ spec:
           $CONFIG = array(
             'overwritehost' => 'nextcloud.cluster.f4mily.net',
             'overwriteprotocol' => 'https',
+            'allow_local_remote_servers' => true,
           );
       # Shared TrueNAS export: files are UID 1000 from Docker (PUID). Run non-root as 1000 so
       # rsync skips --chown (nextcloud/docker#1344) and writes match existing ownership.
@@ -226,8 +227,59 @@ spec:
               mountPath: /var/www/html/data
               subPath: docker/nextcloud/data
             - name: nextcloud-main
-              mountPath: /var/www/custom_apps
+              mountPath: /var/www/html/custom_apps
               subPath: docker/nextcloud/custom_apps
+        - name: occ-oidc-setup
+          image: docker.io/library/nextcloud:33.0.3-apache
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+          env:
+            - name: OIDC_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: nextcloud-authentik-oauth
+                  key: client-id
+                  optional: true
+            - name: OIDC_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: nextcloud-authentik-oauth
+                  key: client-secret
+                  optional: true
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              set -e
+              cd /var/www/html
+              test -f config/config.php || exit 0
+              php occ app:install user_oidc 2>/dev/null || true
+              php occ app:enable user_oidc
+              php occ config:system:set allow_local_remote_servers --value=true --type=boolean
+              if [ -z "${OIDC_CLIENT_ID:-}" ] || [ -z "${OIDC_CLIENT_SECRET:-}" ]; then
+                echo "occ-oidc-setup: skip provider (secret nextcloud-authentik-oauth missing — run just nextcloud-authentik-oauth)"
+                exit 0
+              fi
+              php occ user_oidc:provider authentik \
+                --clientid="${OIDC_CLIENT_ID}" \
+                --clientsecret="${OIDC_CLIENT_SECRET}" \
+                --discoveryuri="https://login.f4mily.net/application/o/nextcloud/.well-known/openid-configuration" \
+                --scope="openid profile email" \
+                --mapping-uid=sub \
+                --mapping-display-name=name \
+                --mapping-email=email \
+                --unique-uid=0
+              php occ config:app:set --value=0 user_oidc allow_multiple_user_backends
+              php occ config:app:set user_oidc login_button_text --value="Authentik"
+              echo "occ-oidc-setup: Authentik provider configured"
+          volumeMounts:
+            - name: nextcloud-main
+              mountPath: /var/www/html
+              subPath: docker/nextcloud/html
+            - name: nextcloud-main
+              mountPath: /var/www/html/config
+              subPath: docker/nextcloud/config
       extraEnv:
         - name: TZ
           value: Europe/Berlin

--- a/apps/base/nextcloud/kustomization.yaml
+++ b/apps/base/nextcloud/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - nextcloud-admin.secret.yaml
+  - nextcloud-authentik-oauth.secret.yaml
   - pvc.yaml
   - helmrelease.yaml
   - ingress.yaml

--- a/apps/base/nextcloud/nextcloud-authentik-oauth.secret.yaml
+++ b/apps/base/nextcloud/nextcloud-authentik-oauth.secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+data:
+    client-id: ENC[AES256_GCM,data:FpQ2zGf5tvf+udPv6dPhqYJyUdvG10rE,iv:j3dutqLNEoHwD7efK/aSTFzr5KDI/GvWCOyB7BrBe00=,tag:JbpjMXVjOEWNtmKByyWkHg==,type:str]
+    client-secret: ENC[AES256_GCM,data:P8tTHOZ9zYMYFW4RM3YjOCYZAOVAgjvza4gGcdqD1ejuyJVZ9NTQAPYZ2Tx4XXhb/7ElSBheBtVM/axT,iv:rVuHds52ELIPN5UeIjLLS1Oyz1PqS9zgWd6v+6zptco=,tag:uyAuno2JT5ioLT287Jt2sg==,type:str]
+kind: Secret
+metadata:
+    name: nextcloud-authentik-oauth
+    namespace: nextcloud
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBoTHRBWlhDMHNlMTBOWGZC
+            SWhUbW1qc3lnQUJTY3lTTGpRYXJya2YvaGhjCjVPNTlMU1J3NGgyN1NaNDJKYWhS
+            OVlFZlFoRWxzMVZWUUdUUXRValM3WFEKLS0tIFpVelNJYUhmTmFNbzdIc1dHZVky
+            T2FCY1VWbExVMDd3QW5FQVV4SHBlRDgK3mBVAxTaTjiF/nBXRyWtSupMBrhZgbFj
+            Gx8EvI7bNr8idYOrgEbv1io/TQ9k2DqPQalTLFbWm7c3EgFW+ywofQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1u5lcvuuwd4lk7f3xewjk70j75yuh68myr89qkd0e8d44zgyjleeqw03vqs
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-05-29T14:37:25Z"
+    mac: ENC[AES256_GCM,data:VqQoXJPx5oH0/7eJnWEfFD+lZYBrfA7ibsi3j7FKKuHfBXqXpg8fR95bRxfhv/5p5UxX/yzwFwA66ACKa4YyQ0tXCmm8snczDyHQUqIPjiteD4N7y481vKO/PiSpqyO2cdUsEtRu+CVwjqMNHXtcj0zJ44cCjexv5ZYbJj+Cp8g=,iv:XjC73Tq8spxI4KkCdek/fwVSeVX3Hks4a/afGTHD9SY=,tag:ELDwWQ1B3W0e28agQMnEsg==,type:str]
+    version: 3.13.1

--- a/apps/base/nextcloud/nextcloud-authentik-oauth.secret.yaml.template
+++ b/apps/base/nextcloud/nextcloud-authentik-oauth.secret.yaml.template
@@ -1,0 +1,6 @@
+# OAuth credentials for Nextcloud ↔ Authentik (application slug: nextcloud)
+#
+# From gitops-homelab/ with SOPS_AGE_KEY_FILE set:
+#   just nextcloud-authentik-oauth
+#
+# Then create the Authentik provider (see docs/integrations/nextcloud-authentik.md).

--- a/docs/integrations/nextcloud-authentik-blueprint.yaml
+++ b/docs/integrations/nextcloud-authentik-blueprint.yaml
@@ -1,0 +1,38 @@
+# Reference blueprint — apply manually in Authentik (production DB is authoritative; not loaded by Helm).
+# Or recreate the provider using docs/integrations/nextcloud-authentik.md
+---
+version: 1
+metadata:
+  name: Homelab Nextcloud OIDC
+  labels:
+    blueprints.goauthentik.io/description: OAuth2 provider and application for Nextcloud
+entries:
+  - model: authentik_providers_oauth2.oauth2provider
+    id: nextcloud-provider
+    identifiers:
+      name: Provider for Nextcloud
+    attrs:
+      name: Provider for Nextcloud
+      client_type: confidential
+      client_id: homelab-nextcloud
+      client_secret: homelab-nextcloud-change-me
+      authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+      invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+      sub_mode: user_uuid
+      redirect_uris:
+        - matching_mode: strict
+          url: https://nextcloud.cluster.f4mily.net/apps/user_oidc/code
+      property_mappings:
+        - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+        - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+        - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+  - model: authentik_core.application
+    identifiers:
+      slug: nextcloud
+    attrs:
+      name: Nextcloud
+      slug: nextcloud
+      provider: !KeyOf nextcloud-provider
+      launch_url: https://nextcloud.cluster.f4mily.net
+      meta_launch_url: https://nextcloud.cluster.f4mily.net

--- a/docs/integrations/nextcloud-authentik.md
+++ b/docs/integrations/nextcloud-authentik.md
@@ -1,0 +1,89 @@
+# Nextcloud login via Authentik
+
+Nextcloud uses the **OpenID Connect user backend** app (`user_oidc`) against Authentik at `https://login.f4mily.net`.
+
+## Prerequisites
+
+1. Nextcloud reachable at `https://nextcloud.cluster.f4mily.net` (pod Ready, `status.php` 200).
+2. SOPS secret `nextcloud-authentik-oauth` in the `nextcloud` namespace (see below).
+3. Authentik **Application + OAuth2 provider** (slug **`nextcloud`**) — not in GitOps blueprints (Authentik DB is authoritative).
+
+## 1. OAuth secret (GitOps)
+
+From `gitops-homelab/` with `SOPS_AGE_KEY_FILE` set:
+
+```bash
+just nextcloud-authentik-oauth
+```
+
+Creates `apps/base/nextcloud/nextcloud-authentik-oauth.secret.yaml` (`client-id`: `homelab-nextcloud`, random `client-secret`).
+
+Commit, push, Flux reconcile.
+
+## 2. Authentik provider (admin UI)
+
+Create **Applications → Application** with provider **OAuth2/OIDC**:
+
+| Field | Value |
+|-------|--------|
+| Application slug | `nextcloud` |
+| Provider name | Provider for Nextcloud |
+| Client type | Confidential |
+| Client ID | `homelab-nextcloud` (same as SOPS `client-id`) |
+| Client secret | Same as SOPS `client-secret` |
+| Redirect URIs (strict) | `https://nextcloud.cluster.f4mily.net/apps/user_oidc/code` |
+| Signing key | authentik Self-signed Certificate (default) |
+| Subject mode | Based on the User's UUID |
+| Scopes | `openid`, `profile`, `email` |
+
+Discovery URL (for Nextcloud UI / `occ`):
+
+```text
+https://login.f4mily.net/application/o/nextcloud/.well-known/openid-configuration
+```
+
+Optional: [Authentik Nextcloud integration](https://docs.goauthentik.io/integrations/services/nextcloud/) (quota/groups scope mapping).
+
+## 3. GitOps / cluster (automatic)
+
+Helm init `occ-oidc-setup` (see `apps/base/nextcloud/helmrelease.yaml`):
+
+- Enables app `user_oidc`
+- Sets `allow_local_remote_servers` (cluster → Authentik)
+- Registers provider `authentik` via `occ user_oidc:provider` when the SOPS secret exists
+- Sets `allow_multiple_user_backends=0` → login redirects to Authentik (no local form)
+
+After reconcile:
+
+```bash
+kubectl -n nextcloud exec deploy/nextcloud -- php occ user_oidc:provider authentik
+kubectl -n nextcloud exec deploy/nextcloud -- php occ config:app:get user_oidc allow_multiple_user_backends
+```
+
+## Verify
+
+1. Open https://nextcloud.cluster.f4mily.net → redirect to Authentik.
+2. Log in with an Authentik user → Nextcloud dashboard (user provisioned on first login).
+
+## Break-glass (local admin)
+
+If OIDC is misconfigured:
+
+```text
+https://nextcloud.cluster.f4mily.net/login?direct=1
+```
+
+Uses the **local** admin from `nextcloud-admin` (created on first `occ maintenance:install`).  
+Re-enable SSO later: `occ config:app:set --value=0 user_oidc allow_multiple_user_backends`.
+
+## Notes
+
+- **No local account required** for normal use — Authentik users are provisioned on first OIDC login.
+- Server-side encryption in Nextcloud is **incompatible** with OIDC; use LDAP if you need it ([Authentik docs](https://docs.goauthentik.io/integrations/services/nextcloud/)).
+- Do not create a personal Nextcloud account on the login form unless testing; use Authentik instead.
+
+## References
+
+- [Authentik — Nextcloud](https://docs.goauthentik.io/integrations/services/nextcloud/)
+- [user_oidc app](https://github.com/nextcloud/user_oidc)
+- Helm: `apps/base/nextcloud/helmrelease.yaml`

--- a/justfile
+++ b/justfile
@@ -98,6 +98,31 @@ grafana-authentik-oauth:
     echo ""
     echo "See docs/integrations/grafana-authentik.md"
 
+# Nextcloud ↔ Authentik OAuth (nextcloud namespace)
+nextcloud-authentik-oauth:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    : "${SOPS_AGE_KEY_FILE:?Set SOPS_AGE_KEY_FILE to your age private key}"
+    client_id="homelab-nextcloud"
+    client_secret="$(openssl rand -base64 32 | tr -d '\n')"
+    dir="apps/base/nextcloud"
+    cd "$dir"
+    kubectl create secret generic nextcloud-authentik-oauth \
+      --namespace nextcloud \
+      --from-literal=client-id="$client_id" \
+      --from-literal=client-secret="$client_secret" \
+      --dry-run=client -o yaml >nextcloud-authentik-oauth.secret.yaml
+    sops --encrypt --in-place nextcloud-authentik-oauth.secret.yaml
+    echo "Created: $dir/nextcloud-authentik-oauth.secret.yaml"
+    echo ""
+    echo "Next:"
+    echo "  1. Add nextcloud-authentik-oauth.secret.yaml to apps/base/nextcloud/kustomization.yaml"
+    echo "  2. Commit, push, flux reconcile"
+    echo "  3. In Authentik create application slug nextcloud (see docs/integrations/nextcloud-authentik.md)"
+    echo "     Client secret: $client_secret"
+    echo ""
+    echo "See docs/integrations/nextcloud-authentik.md"
+
 # Encrypt a plaintext *.secret.yaml in place
 sops-encrypt file:
     #!/usr/bin/env bash


### PR DESCRIPTION
## Summary
- Install/configure `user_oidc` via init container when `nextcloud-authentik-oauth` secret exists
- SSO-only login (`allow_multiple_user_backends=0`) after provider is registered
- Docs + `just nextcloud-authentik-oauth` + reference blueprint

## Manual step (Authentik admin)
Create application slug `nextcloud` per `docs/integrations/nextcloud-authentik.md` (discovery currently 404).

## Test plan
- [ ] Flux applies secret + HelmRelease
- [ ] Authentik app created, discovery 200
- [ ] https://nextcloud.cluster.f4mily.net redirects to Authentik
- [ ] First login provisions Nextcloud user


Made with [Cursor](https://cursor.com)