### PR TITLE
fix(nextcloud): pretty URLs for OIDC redirect

### DIFF
--- a/apps/base/nextcloud/helmrelease.yaml
+++ b/apps/base/nextcloud/helmrelease.yaml
@@ -104,6 +104,7 @@ spec:
           $CONFIG = array(
             'overwritehost' => 'nextcloud.cluster.f4mily.net',
             'overwriteprotocol' => 'https',
+            'overwrite.cli.url' => 'https://nextcloud.cluster.f4mily.net',
             'allow_local_remote_servers' => true,
           );
       # Shared TrueNAS export: files are UID 1000 from Docker (PUID). Run non-root as 1000 so
@@ -218,6 +219,8 @@ spec:
               php occ config:system:set dbpassword --value="${POSTGRES_PASSWORD}"
               php occ config:system:set redis host --value=nextcloud-redis-master
               php occ config:system:set redis port --value=6379
+              php occ config:system:set overwrite.cli.url --value="https://nextcloud.cluster.f4mily.net"
+              php occ maintenance:update:htaccess --no-interaction
               php occ maintenance:mode --off || true
               php occ status
           volumeMounts:

--- a/docs/integrations/nextcloud-authentik.md
+++ b/docs/integrations/nextcloud-authentik.md
@@ -32,6 +32,8 @@ Create **Applications → Application** with provider **OAuth2/OIDC**:
 | Client ID | `homelab-nextcloud` (same as SOPS `client-id`) |
 | Client secret | Same as SOPS `client-secret` |
 | Redirect URIs (strict) | `https://nextcloud.cluster.f4mily.net/apps/user_oidc/code` |
+
+If Nextcloud still sends `/index.php/apps/user_oidc/code`, pretty URLs are not active (wrong `overwrite.cli.url` or stale `.htaccess` on NFS). GitOps runs `occ maintenance:update:htaccess` on deploy; you can also add the `index.php` URI in Authentik as fallback.
 | Signing key | authentik Self-signed Certificate (default) |
 | Subject mode | Based on the User's UUID |
 | Scopes | `openid`, `profile`, `email` |


### PR DESCRIPTION
## Summary
- Set `overwrite.cli.url` in cluster config and `occ-db-sync` init
- Run `occ maintenance:update:htaccess` on deploy (NFS migration left stale rules)
- Document `/index.php/...` fallback for Authentik redirect URI

## Context
Nextcloud generated `redirect_uri=.../index.php/apps/user_oidc/code` because `overwrite.cli.url` was `http://localhost`. Ingress is fine.

## Test plan
- [ ] OIDC authorize URL uses `/apps/user_oidc/code` (no index.php)
- [ ] Authentik redirect URI matches

Made with [Cursor](https://cursor.com)