### PR TITLE
feat(nextcloud): OIDC group provisioning

### DIFF
--- a/apps/base/nextcloud/helmrelease.yaml
+++ b/apps/base/nextcloud/helmrelease.yaml
@@ -276,10 +276,12 @@ spec:
                 --clientid="${OIDC_CLIENT_ID}" \
                 --clientsecret="${OIDC_CLIENT_SECRET}" \
                 --discoveryuri="https://login.f4mily.net/application/o/nextcloud/.well-known/openid-configuration" \
-                --scope="openid profile email" \
+                --scope="openid profile email groups" \
                 --mapping-uid=sub \
                 --mapping-display-name=name \
                 --mapping-email=email \
+                --mapping-groups=groups \
+                --group-provisioning=1 \
                 --unique-uid=0
               php occ config:app:set --value=0 user_oidc allow_multiple_user_backends
               php occ config:app:set user_oidc login_button_text --value="Authentik"

--- a/docs/integrations/nextcloud-authentik.md
+++ b/docs/integrations/nextcloud-authentik.md
@@ -32,11 +32,32 @@ Create **Applications → Application** with provider **OAuth2/OIDC**:
 | Client ID | `homelab-nextcloud` (same as SOPS `client-id`) |
 | Client secret | Same as SOPS `client-secret` |
 | Redirect URIs (strict) | `https://nextcloud.cluster.f4mily.net/apps/user_oidc/code` |
+| **Signing key** | **Required:** `authentik Self-signed Certificate` (or any certificate key pair) |
+| Subject mode | Based on the User's UUID |
+| Scopes | `openid`, `profile`, `email`, `groups` (or custom property mapping with `groups` claim) |
+
+### Groups and Nextcloud admin
+
+Nextcloud `user_oidc` does **not** auto-promote users unless **group provisioning** is enabled and the ID token contains a `groups` claim.
+
+- GitOps enables `--mapping-groups=groups --group-provisioning=1`.
+- Authentik group **`admin`** maps to Nextcloud group **`admin`** (platform administrators).
+- Optional: [Authentik Nextcloud property mapping](https://docs.goauthentik.io/integrations/services/nextcloud/) to control quota and rename groups (e.g. `Nextcloud Admins` → `admin`).
+
+One-off promote existing OIDC user:
+
+```bash
+kubectl -n nextcloud exec deploy/nextcloud -- php occ group:adduser admin '<authentik-sub-uuid>'
+```
 
 If Nextcloud still sends `/index.php/apps/user_oidc/code`, pretty URLs are not active (wrong `overwrite.cli.url` or stale `.htaccess` on NFS). GitOps runs `occ maintenance:update:htaccess` on deploy; you can also add the `index.php` URI in Authentik as fallback.
-| Signing key | authentik Self-signed Certificate (default) |
-| Subject mode | Based on the User's UUID |
-| Scopes | `openid`, `profile`, `email` |
+
+**Important:** Without a **Signing key**, Authentik issues ID tokens with **HS256** only. Nextcloud `user_oidc` rejects that (`Unsupported JWT alg: HS256`). After setting the signing key, discovery must list **RS256** and JWKS must not be empty:
+
+```bash
+curl -sS https://login.f4mily.net/application/o/nextcloud/.well-known/openid-configuration | jq .id_token_signing_alg_values_supported
+curl -sS https://login.f4mily.net/application/o/nextcloud/jwks/ | jq .
+```
 
 Discovery URL (for Nextcloud UI / `occ`):
 
@@ -53,6 +74,7 @@ Helm init `occ-oidc-setup` (see `apps/base/nextcloud/helmrelease.yaml`):
 - Enables app `user_oidc`
 - Sets `allow_local_remote_servers` (cluster → Authentik)
 - Registers provider `authentik` via `occ user_oidc:provider` when the SOPS secret exists
+- Enables **group provisioning** from Authentik `groups` claim (incl. `admin` → Nextcloud admin)
 - Sets `allow_multiple_user_backends=0` → login redirects to Authentik (no local form)
 
 After reconcile:
@@ -66,6 +88,16 @@ kubectl -n nextcloud exec deploy/nextcloud -- php occ config:app:get user_oidc a
 
 1. Open https://nextcloud.cluster.f4mily.net → redirect to Authentik.
 2. Log in with an Authentik user → Nextcloud dashboard (user provisioned on first login).
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `Unsupported JWT alg: HS256` | OAuth provider has **no Signing key** | Authentik → Provider → **Signing key** = certificate key pair |
+| Discovery 404 | Application slug ≠ `nextcloud` | Create application with slug `nextcloud` |
+| Redirect URI mismatch | Authentik URI ≠ Nextcloud `redirect_uri` | Use `/apps/user_oidc/code` (or add `/index.php/...`) |
+
+Log: `kubectl exec -n nextcloud deploy/nextcloud -- tail -20 /var/www/html/data/nextcloud.log`
 
 ## Break-glass (local admin)
 


### PR DESCRIPTION
## Summary
- Enable `user_oidc` group provisioning from Authentik `groups` claim
- Document admin group mapping (`admin` Authentik group → Nextcloud `admin`)

## Test plan
- [ ] User with Authentik `admin` group gets Nextcloud admin on login
- [ ] Existing user promoted via `occ group:adduser admin <uuid>`

Made with [Cursor](https://cursor.com)