### PR TITLE
feat(nextcloud): public URL nc.f4mily.net

### DIFF
--- a/apps/base/nextcloud/helmrelease.yaml
+++ b/apps/base/nextcloud/helmrelease.yaml
@@ -94,17 +94,17 @@ spec:
         secretName: nextcloud-admin
         usernameKey: username
         passwordKey: password
-      host: nextcloud.cluster.f4mily.net
+      host: nc.f4mily.net
       trustedDomains:
-        - nextcloud.cluster.f4mily.net
+        - nc.f4mily.net
       # Required so the chart mounts defaultConfigs (autoconfig.php reads POSTGRES_*).
       configs:
         cluster.config.php: |-
           <?php
           $CONFIG = array(
-            'overwritehost' => 'nextcloud.cluster.f4mily.net',
+            'overwritehost' => 'nc.f4mily.net',
             'overwriteprotocol' => 'https',
-            'overwrite.cli.url' => 'https://nextcloud.cluster.f4mily.net',
+            'overwrite.cli.url' => 'https://nc.f4mily.net',
             'allow_local_remote_servers' => true,
           );
       # Shared TrueNAS export: files are UID 1000 from Docker (PUID). Run non-root as 1000 so
@@ -186,6 +186,8 @@ spec:
                 secretKeyRef:
                   name: nextcloud-admin
                   key: password
+            - name: NEXTCLOUD_PUBLIC_HOST
+              value: nc.f4mily.net
           command:
             - /bin/sh
             - -ec
@@ -219,7 +221,10 @@ spec:
               php occ config:system:set dbpassword --value="${POSTGRES_PASSWORD}"
               php occ config:system:set redis host --value=nextcloud-redis-master
               php occ config:system:set redis port --value=6379
-              php occ config:system:set overwrite.cli.url --value="https://nextcloud.cluster.f4mily.net"
+              php occ config:system:set overwritehost --value="${NEXTCLOUD_PUBLIC_HOST}"
+              php occ config:system:set overwriteprotocol --value=https
+              php occ config:system:set overwrite.cli.url --value="https://${NEXTCLOUD_PUBLIC_HOST}"
+              php occ config:system:set trusted_domains 0 --value="${NEXTCLOUD_PUBLIC_HOST}"
               php occ maintenance:update:htaccess --no-interaction
               php occ maintenance:mode --off || true
               php occ status

--- a/apps/base/nextcloud/ingress.yaml
+++ b/apps/base/nextcloud/ingress.yaml
@@ -17,10 +17,10 @@ spec:
   ingressClassName: nginx
   tls:
     - hosts:
-        - nextcloud.cluster.f4mily.net
-      secretName: wildcard-cluster-f4mily-net-tls
+        - nc.f4mily.net
+      secretName: wildcard-f4mily-net-tls
   rules:
-    - host: nextcloud.cluster.f4mily.net
+    - host: nc.f4mily.net
       http:
         paths:
           - path: /

--- a/apps/overlays/main/cluster-config.yaml
+++ b/apps/overlays/main/cluster-config.yaml
@@ -70,7 +70,7 @@ data:
 
   # Cluster-internal apps (covered by *.cluster.f4mily.net wildcard):
   host_goloom: goloom.cluster.f4mily.net
-  host_nextcloud: nextcloud.cluster.f4mily.net
+  host_nextcloud: nc.f4mily.net
   host_homer: homer.cluster.f4mily.net
   host_grafana: grafana.cluster.f4mily.net
   host_victoria_metrics: metrics.cluster.f4mily.net

--- a/apps/overlays/main/kustomization.yaml
+++ b/apps/overlays/main/kustomization.yaml
@@ -328,6 +328,11 @@ replacements:
         fieldPaths:
           - spec.rules.0.host
           - spec.tls.0.hosts.0
+      - select: {kind: HelmRelease, name: nextcloud}
+        fieldPaths:
+          - spec.values.nextcloud.host
+          - spec.values.nextcloud.trustedDomains.0
+          - spec.values.nextcloud.extraInitContainers.2.env.[name=NEXTCLOUD_PUBLIC_HOST].value
 
   - source:
       kind: ConfigMap
@@ -424,6 +429,8 @@ replacements:
         fieldPaths: [spec.tls.0.secretName]
       - select: {kind: Ingress, name: authentik}
         fieldPaths: [spec.tls.0.secretName]
+      - select: {kind: Ingress, name: nextcloud}
+        fieldPaths: [spec.tls.0.secretName]
 
   - source:
       kind: ConfigMap
@@ -433,8 +440,6 @@ replacements:
       - select: {kind: Ingress, name: tandoor}
         fieldPaths: [spec.tls.0.secretName]
       - select: {kind: Ingress, name: goloom}
-        fieldPaths: [spec.tls.0.secretName]
-      - select: {kind: Ingress, name: nextcloud}
         fieldPaths: [spec.tls.0.secretName]
       - select: {kind: Ingress, name: grafana}
         fieldPaths: [spec.tls.0.secretName]

--- a/docs/integrations/nextcloud-authentik-blueprint.yaml
+++ b/docs/integrations/nextcloud-authentik-blueprint.yaml
@@ -22,7 +22,7 @@ entries:
       sub_mode: user_uuid
       redirect_uris:
         - matching_mode: strict
-          url: https://nextcloud.cluster.f4mily.net/apps/user_oidc/code
+          url: https://nc.f4mily.net/apps/user_oidc/code
       property_mappings:
         - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
         - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
@@ -34,5 +34,5 @@ entries:
       name: Nextcloud
       slug: nextcloud
       provider: !KeyOf nextcloud-provider
-      launch_url: https://nextcloud.cluster.f4mily.net
-      meta_launch_url: https://nextcloud.cluster.f4mily.net
+      launch_url: https://nc.f4mily.net
+      meta_launch_url: https://nc.f4mily.net

--- a/docs/integrations/nextcloud-authentik.md
+++ b/docs/integrations/nextcloud-authentik.md
@@ -4,7 +4,7 @@ Nextcloud uses the **OpenID Connect user backend** app (`user_oidc`) against Aut
 
 ## Prerequisites
 
-1. Nextcloud reachable at `https://nextcloud.cluster.f4mily.net` (pod Ready, `status.php` 200).
+1. Nextcloud reachable at `https://nc.f4mily.net` (pod Ready, `status.php` 200).
 2. SOPS secret `nextcloud-authentik-oauth` in the `nextcloud` namespace (see below).
 3. Authentik **Application + OAuth2 provider** (slug **`nextcloud`**) — not in GitOps blueprints (Authentik DB is authoritative).
 
@@ -31,7 +31,7 @@ Create **Applications → Application** with provider **OAuth2/OIDC**:
 | Client type | Confidential |
 | Client ID | `homelab-nextcloud` (same as SOPS `client-id`) |
 | Client secret | Same as SOPS `client-secret` |
-| Redirect URIs (strict) | `https://nextcloud.cluster.f4mily.net/apps/user_oidc/code` |
+| Redirect URIs (strict) | `https://nc.f4mily.net/apps/user_oidc/code` |
 | **Signing key** | **Required:** `authentik Self-signed Certificate` (or any certificate key pair) |
 | Subject mode | Based on the User's UUID |
 | Scopes | `openid`, `profile`, `email`, `groups` (or custom property mapping with `groups` claim) |
@@ -86,7 +86,7 @@ kubectl -n nextcloud exec deploy/nextcloud -- php occ config:app:get user_oidc a
 
 ## Verify
 
-1. Open https://nextcloud.cluster.f4mily.net → redirect to Authentik.
+1. Open https://nc.f4mily.net → redirect to Authentik.
 2. Log in with an Authentik user → Nextcloud dashboard (user provisioned on first login).
 
 ## Troubleshooting
@@ -104,7 +104,7 @@ Log: `kubectl exec -n nextcloud deploy/nextcloud -- tail -20 /var/www/html/data/
 If OIDC is misconfigured:
 
 ```text
-https://nextcloud.cluster.f4mily.net/login?direct=1
+https://nc.f4mily.net/login?direct=1
 ```
 
 Uses the **local** admin from `nextcloud-admin` (created on first `occ maintenance:install`).  


### PR DESCRIPTION
## Summary
- Host `nc.f4mily.net` (public TLS + DNS via homelab-infrastructure)
- Sync `overwritehost`, `overwrite.cli.url`, `trusted_domains`, `.htaccess` on deploy
- Authentik redirect URI docs → `https://nc.f4mily.net/apps/user_oidc/code`

## Manual follow-up
- Authentik: update redirect URI + launch URL
- DNS: merge homelab-infrastructure branch `feat/dns-nc-f4mily-net`

## Test plan
- [ ] https://nc.f4mily.net/status.php → 200
- [ ] OIDC login works after Authentik redirect URI update

Made with [Cursor](https://cursor.com)