### PR TITLE
fix(nextcloud): HSTS server-snippets

### DIFF
--- a/apps/base/nextcloud/ingress.yaml
+++ b/apps/base/nextcloud/ingress.yaml
@@ -17,6 +17,8 @@ metadata:
     nginx.org/hsts-max-age: "15552000"
     nginx.org/hsts-include-subdomains: "true"
     nginx.org/hsts-behind-proxy: "true"
+    nginx.org/server-snippets: |
+      add_header Strict-Transport-Security "max-age=15552000; includeSubDomains" always;
 spec:
   ingressClassName: nginx
   tls:


### PR DESCRIPTION
Emit Strict-Transport-Security on nc.f4mily.net responses.

Made with [Cursor](https://cursor.com)