### PR TITLE
feat(nextcloud): Whiteboard WebSocket + AppAPI HaRP K8s daemon

### DIFF
--- a/apps/base/nextcloud/appapi-harp-deployment.yaml
+++ b/apps/base/nextcloud/appapi-harp-deployment.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: appapi-harp
+  namespace: nextcloud
+  labels:
+    app.kubernetes.io/name: appapi-harp
+    app.kubernetes.io/part-of: nextcloud
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: appapi-harp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: appapi-harp
+    spec:
+      serviceAccountName: appapi-harp
+      enableServiceLinks: false
+      containers:
+        - name: appapi-harp
+          # renovate: datasource=docker depName=ghcr.io/nextcloud/nextcloud-appapi-harp
+          image: ghcr.io/nextcloud/nextcloud-appapi-harp:release
+          ports:
+            - name: exapps
+              containerPort: 8780
+            - name: frp
+              containerPort: 8782
+          env:
+            - name: HP_SHARED_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: nextcloud-collab
+                  key: harp-shared-key
+            - name: NC_INSTANCE_URL
+              value: https://nc.f4mily.net
+            - name: HP_FRP_ADDRESS
+              value: 0.0.0.0:8782
+            - name: HP_EXAPPS_ADDRESS
+              value: 0.0.0.0:8780
+            - name: HP_TRUSTED_PROXY_IPS
+              value: 10.0.0.0/8,127.0.0.1
+            - name: HP_K8S_ENABLED
+              value: "true"
+            - name: HP_K8S_NAMESPACE
+              value: nextcloud-exapps
+          resources:
+            requests:
+              cpu: 50m
+              memory: 256Mi
+            limits:
+              memory: 512Mi
+          readinessProbe:
+            httpGet:
+              path: /info
+              port: 8200
+              host: 127.0.0.1
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: exapps
+            initialDelaySeconds: 30
+            periodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: appapi-harp
+  namespace: nextcloud
+  labels:
+    app.kubernetes.io/name: appapi-harp
+    app.kubernetes.io/part-of: nextcloud
+spec:
+  selector:
+    app.kubernetes.io/name: appapi-harp
+  ports:
+    - name: exapps
+      port: 8780
+      targetPort: exapps
+    - name: frp
+      port: 8782
+      targetPort: frp

--- a/apps/base/nextcloud/appapi-harp-rbac.yaml
+++ b/apps/base/nextcloud/appapi-harp-rbac.yaml
@@ -1,0 +1,26 @@
+# AppAPI HaRP needs broad K8s API access to deploy ExApps (pods, services, PVCs).
+# Upstream AppAPI CI uses cluster-admin for the harp service account.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: appapi-harp
+  namespace: nextcloud
+  labels:
+    app.kubernetes.io/name: appapi-harp
+    app.kubernetes.io/part-of: nextcloud
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nextcloud-appapi-harp
+  labels:
+    app.kubernetes.io/name: appapi-harp
+    app.kubernetes.io/part-of: nextcloud
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: appapi-harp
+    namespace: nextcloud

--- a/apps/base/nextcloud/helmrelease.yaml
+++ b/apps/base/nextcloud/helmrelease.yaml
@@ -321,6 +321,79 @@ spec:
             - name: nextcloud-main
               mountPath: /var/www/html/data
               subPath: docker/nextcloud/data
+        - name: occ-collab-setup
+          image: docker.io/library/nextcloud:33.0.3-apache
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+          env:
+            - name: NEXTCLOUD_PUBLIC_HOST
+              value: nc.f4mily.net
+            - name: NEXTCLOUD_PUBLIC_URL
+              value: https://nc.f4mily.net
+            - name: WHITEBOARD_JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: nextcloud-collab
+                  key: whiteboard-jwt-secret
+                  optional: true
+            - name: HARP_SHARED_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: nextcloud-collab
+                  key: harp-shared-key
+                  optional: true
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              set -e
+              cd /var/www/html
+              test -f config/config.php || exit 0
+              if [ -z "${WHITEBOARD_JWT_SECRET:-}" ] || [ -z "${HARP_SHARED_KEY:-}" ]; then
+                echo "occ-collab-setup: skip (secret nextcloud-collab missing — run just nextcloud-collab-secrets)"
+                exit 0
+              fi
+              php occ app:install whiteboard 2>/dev/null || true
+              php occ app:enable whiteboard
+              php occ config:app:set whiteboard collabBackendUrl --value="${NEXTCLOUD_PUBLIC_URL}"
+              php occ config:app:set whiteboard jwt_secret_key --value="${WHITEBOARD_JWT_SECRET}"
+              php occ app:install app_api 2>/dev/null || true
+              php occ app:enable app_api
+              echo "occ-collab-setup: waiting for AppAPI HaRP..."
+              for i in $(seq 1 60); do
+                if curl -fsS "http://appapi-harp:8780/exapps/app_api/info" \
+                    -H "harp-shared-key: ${HARP_SHARED_KEY}" 2>/dev/null \
+                    | grep -q '"kubernetes"'; then
+                  echo "occ-collab-setup: HaRP K8s backend ready"
+                  break
+                fi
+                if [ "$i" -eq 60 ]; then
+                  echo "occ-collab-setup: HaRP not ready — skip daemon register (retry on next pod restart)"
+                  exit 0
+                fi
+                sleep 5
+              done
+              if ! php occ app_api:daemon:list 2>/dev/null | grep -q 'k8s_homelab'; then
+                php occ app_api:daemon:register k8s_homelab "K8s Homelab" "kubernetes-install" "http" \
+                  "appapi-harp:8780" "${NEXTCLOUD_PUBLIC_URL}" \
+                  --harp --harp_shared_key "${HARP_SHARED_KEY}" \
+                  --harp_frp_address "appapi-harp:8782" \
+                  --k8s --k8s_expose_type=clusterip --set-default
+                echo "occ-collab-setup: registered AppAPI K8s deploy daemon"
+              else
+                echo "occ-collab-setup: AppAPI daemon k8s_homelab already registered"
+              fi
+          volumeMounts:
+            - name: nextcloud-main
+              mountPath: /var/www/html
+              subPath: docker/nextcloud/html
+            - name: nextcloud-main
+              mountPath: /var/www/html/config
+              subPath: docker/nextcloud/config
+            - name: nextcloud-main
+              mountPath: /var/www/html/data
+              subPath: docker/nextcloud/data
       extraEnv:
         - name: TZ
           value: Europe/Berlin

--- a/apps/base/nextcloud/ingress.yaml
+++ b/apps/base/nextcloud/ingress.yaml
@@ -16,6 +16,10 @@ metadata:
     nginx.org/hsts: "true"
     nginx.org/hsts-max-age: "15552000"
     nginx.org/hsts-include-subdomains: "true"
+    # Whiteboard /socket.io/ + ExApps via HaRP (/exapps/)
+    nginx.org/websocket-services: "nextcloud-whiteboard,appapi-harp"
+    nginx.org/proxy-read-timeout: "3600s"
+    nginx.org/proxy-send-timeout: "3600s"
 spec:
   ingressClassName: nginx
   tls:
@@ -26,6 +30,20 @@ spec:
     - host: nc.f4mily.net
       http:
         paths:
+          - path: /socket.io
+            pathType: Prefix
+            backend:
+              service:
+                name: nextcloud-whiteboard
+                port:
+                  number: 3002
+          - path: /exapps
+            pathType: Prefix
+            backend:
+              service:
+                name: appapi-harp
+                port:
+                  number: 8780
           - path: /
             pathType: Prefix
             backend:

--- a/apps/base/nextcloud/kustomization.yaml
+++ b/apps/base/nextcloud/kustomization.yaml
@@ -2,8 +2,13 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yaml
+  - nextcloud-exapps-namespace.yaml
   - nextcloud-admin.secret.yaml
   - nextcloud-authentik-oauth.secret.yaml
+  - nextcloud-collab.secret.yaml
   - pvc.yaml
+  - whiteboard-deployment.yaml
+  - appapi-harp-rbac.yaml
+  - appapi-harp-deployment.yaml
   - helmrelease.yaml
   - ingress.yaml

--- a/apps/base/nextcloud/nextcloud-collab.secret.yaml
+++ b/apps/base/nextcloud/nextcloud-collab.secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+data:
+    harp-shared-key: ENC[AES256_GCM,data:qP2slOuBI7PE8+rbJIdPo6vGK9zXMcsd4sl4+gXA4zw+2NkKKFHEgfx/hMxA2uf6qg4n6Mhu84Yas7Ld,iv:PISwe4HaT7DFfVyzsOlPj0OJCmecphFv+81vaJ2A4Rg=,tag:HI20Lb8wzI8iGq8k8wnuEA==,type:str]
+    whiteboard-jwt-secret: ENC[AES256_GCM,data:IbwjFIrOH/GXKrEFOGsn9vrEl97SQ/R2iIL1yk15PCfeZwsiwupV4iJc+BohOWhaq+c1qMv6DsU=,iv:SOpAJ7iRc8pxeBjXV8qkkgLN6BD3fFr7yalKVsnggYs=,tag:xHslgXOPXQAnGC3AY84txA==,type:str]
+kind: Secret
+metadata:
+    name: nextcloud-collab
+    namespace: nextcloud
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHTlFKZ1p4dENCNFgvdnAx
+            ei9pTktlYTRLelQycVpZUVJSQ1Q0ZVI0aUYwClQzT21yOGk5czdZYThtdE5kbDJL
+            ek1ZRlFRR2JDNzU5dnpVcnMzSnJQRFkKLS0tIFFyY1RPSUs5ZjV6MTFmN1V4bnNw
+            eWdjSUVsMW00OXhOZEVWbks5WE5sTVUKKtCYsw7wWZ5HH+0xntOBtKhyJQ2rZ9jw
+            yELvD8RkqgdO/f2/RvqkoYv8vhwMcPpWhQX5F3T2ciaPU7FD7pO6Fg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1u5lcvuuwd4lk7f3xewjk70j75yuh68myr89qkd0e8d44zgyjleeqw03vqs
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-05-30T06:52:58Z"
+    mac: ENC[AES256_GCM,data:LRZhudexEYOzjdDVLJ+VQtLa0rM3pCwXK9Gofbg0JuFBHSeFy1N1/EjrK+zpc22i/d2i/6p0Oncb7vY9cugbk3gZDmrEM4mE7i2CMEbqveAdsJlluCPRX/9JWSGRpbqAKFLyOPsaQtMSwbIAoTK5rTzrmmE505BSWZ62/CezSYA=,iv:aBOpPPtqRuHT8Rx+mouRKKXIuRBJ7CTI3IVpP9M00QA=,tag:iKi8blGHXAV8vxkzMt0OVg==,type:str]
+    version: 3.13.1

--- a/apps/base/nextcloud/nextcloud-collab.secret.yaml.template
+++ b/apps/base/nextcloud/nextcloud-collab.secret.yaml.template
@@ -1,0 +1,6 @@
+# Shared secrets for Nextcloud Whiteboard WebSocket + AppAPI HaRP deploy daemon.
+#
+# From gitops-homelab/ with SOPS_AGE_KEY_FILE set:
+#   just nextcloud-collab-secrets
+#
+# See docs/integrations/nextcloud-appapi-collabora.md

--- a/apps/base/nextcloud/nextcloud-exapps-namespace.yaml
+++ b/apps/base/nextcloud/nextcloud-exapps-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nextcloud-exapps
+  labels:
+    app.kubernetes.io/part-of: nextcloud

--- a/apps/base/nextcloud/whiteboard-deployment.yaml
+++ b/apps/base/nextcloud/whiteboard-deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nextcloud-whiteboard
+  namespace: nextcloud
+  labels:
+    app.kubernetes.io/name: nextcloud-whiteboard
+    app.kubernetes.io/part-of: nextcloud
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nextcloud-whiteboard
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nextcloud-whiteboard
+    spec:
+      enableServiceLinks: false
+      containers:
+        - name: whiteboard
+          # renovate: datasource=docker depName=ghcr.io/nextcloud-releases/whiteboard
+          image: ghcr.io/nextcloud-releases/whiteboard:stable
+          ports:
+            - name: http
+              containerPort: 3002
+          env:
+            - name: NEXTCLOUD_URL
+              value: https://nc.f4mily.net
+            - name: JWT_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: nextcloud-collab
+                  key: whiteboard-jwt-secret
+          resources:
+            requests:
+              cpu: 25m
+              memory: 128Mi
+            limits:
+              memory: 512Mi
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nextcloud-whiteboard
+  namespace: nextcloud
+  labels:
+    app.kubernetes.io/name: nextcloud-whiteboard
+    app.kubernetes.io/part-of: nextcloud
+spec:
+  selector:
+    app.kubernetes.io/name: nextcloud-whiteboard
+  ports:
+    - name: http
+      port: 3002
+      targetPort: http

--- a/apps/overlays/main/cluster-config.yaml
+++ b/apps/overlays/main/cluster-config.yaml
@@ -71,6 +71,7 @@ data:
   # Cluster-internal apps (covered by *.cluster.f4mily.net wildcard):
   host_goloom: goloom.cluster.f4mily.net
   host_nextcloud: nc.f4mily.net
+  url_nextcloud: https://nc.f4mily.net
   host_homer: homer.cluster.f4mily.net
   host_grafana: grafana.cluster.f4mily.net
   host_victoria_metrics: metrics.cluster.f4mily.net

--- a/apps/overlays/main/kustomization.yaml
+++ b/apps/overlays/main/kustomization.yaml
@@ -333,6 +333,22 @@ replacements:
           - spec.values.nextcloud.host
           - spec.values.nextcloud.trustedDomains.0
           - spec.values.nextcloud.extraInitContainers.2.env.[name=NEXTCLOUD_PUBLIC_HOST].value
+          - spec.values.nextcloud.extraInitContainers.4.env.[name=NEXTCLOUD_PUBLIC_HOST].value
+
+  - source:
+      kind: ConfigMap
+      name: homelab-cluster-config
+      fieldPath: data.url_nextcloud
+    targets:
+      - select: {kind: Deployment, name: nextcloud-whiteboard}
+        fieldPaths:
+          - spec.template.spec.containers.[name=whiteboard].env.[name=NEXTCLOUD_URL].value
+      - select: {kind: Deployment, name: appapi-harp}
+        fieldPaths:
+          - spec.template.spec.containers.[name=appapi-harp].env.[name=NC_INSTANCE_URL].value
+      - select: {kind: HelmRelease, name: nextcloud}
+        fieldPaths:
+          - spec.values.nextcloud.extraInitContainers.4.env.[name=NEXTCLOUD_PUBLIC_URL].value
 
   - source:
       kind: ConfigMap

--- a/docs/integrations/nextcloud-appapi-collabora.md
+++ b/docs/integrations/nextcloud-appapi-collabora.md
@@ -1,0 +1,105 @@
+# Nextcloud Whiteboard, AppAPI HaRP, and Collabora options
+
+Real-time Whiteboard collaboration and ExApps (e.g. future Collabora via AppAPI) need extra components beside the Nextcloud PHP pod.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  Browser --> Ingress["Ingress nc.f4mily.net"]
+  Ingress -->|"/"| NC[Nextcloud]
+  Ingress -->|"/socket.io/"| WB[Whiteboard WS :3002]
+  Ingress -->|"/exapps/"| HaRP[AppAPI HaRP :8780]
+  NC --> HaRP
+  HaRP --> K8s["nextcloud-exapps namespace"]
+  K8s --> ExApp["ExApps / Collabora ExApp"]
+```
+
+| Component | Purpose |
+|-----------|---------|
+| **Whiteboard server** | WebSocket backend for live whiteboard sessions (`/socket.io/`) |
+| **AppAPI HaRP** | Deploy daemon for ExApps; proxies `/exapps/` to microservices |
+| **nextcloud-exapps** | Namespace where AppAPI creates ExApp pods and services |
+
+## 1. Secrets (GitOps)
+
+From `gitops-homelab/` with `SOPS_AGE_KEY_FILE` set:
+
+```bash
+just nextcloud-collab-secrets
+```
+
+Creates `apps/base/nextcloud/nextcloud-collab.secret.yaml`:
+
+- `whiteboard-jwt-secret` — shared with the Whiteboard container and `occ config:app:set whiteboard jwt_secret_key`
+- `harp-shared-key` — HaRP `HP_SHARED_KEY` and AppAPI daemon registration
+
+Commit, push, Flux reconcile.
+
+## 2. What GitOps deploys
+
+- `nextcloud-whiteboard` — `ghcr.io/nextcloud-releases/whiteboard:stable`
+- `appapi-harp` — `ghcr.io/nextcloud/nextcloud-appapi-harp:release` with `HP_K8S_ENABLED=true`
+- Ingress paths on `nc.f4mily.net`:
+  - `/socket.io/` → Whiteboard (WebSocket)
+  - `/exapps/` → HaRP (ExApps + WebSocket where needed)
+- Init container `occ-collab-setup` enables `whiteboard` + `app_api`, configures JWT/URL, registers K8s deploy daemon `k8s_homelab`
+
+## 3. Verify Whiteboard
+
+After reconcile and pod restart:
+
+1. Admin → Whiteboard — warning about WebSocket should be gone.
+2. Browser DevTools → Network → filter **WS** — connection to `wss://nc.f4mily.net/socket.io/…` should stay open.
+3. Open a whiteboard with two users and confirm live cursors.
+
+Manual check:
+
+```bash
+kubectl -n nextcloud exec deploy/nextcloud -- php occ config:app:get whiteboard collabBackendUrl
+kubectl -n nextcloud exec deploy/nextcloud -- php occ app_api:daemon:list
+```
+
+## 4. Verify AppAPI HaRP
+
+1. Admin → Administration → AppAPI → Deploy daemon **K8s Homelab** should appear.
+2. Use **Test deploy** in the daemon menu (deploys a skeleton ExApp into `nextcloud-exapps`).
+3. HaRP info endpoint (from cluster):
+
+```bash
+HARP_KEY="$(kubectl -n nextcloud get secret nextcloud-collab -o jsonpath='{.data.harp-shared-key}' | base64 -d)"
+kubectl -n nextcloud run curl-test --rm -it --restart=Never --image=curlimages/curl -- \
+  curl -fsS -H "harp-shared-key: ${HARP_KEY}" http://appapi-harp:8780/exapps/app_api/info
+```
+
+Response should include `"kubernetes": {"enabled": true, ...}`.
+
+## 5. Collabora: two paths
+
+### Option A — Classic Collabora Online (recommended for Office)
+
+Deploy **Collabora Online** (`collabora/code`) as a normal Kubernetes workload (Deployment + Service + Ingress), enable Nextcloud app **Office** (`richdocuments`), point WOPI URL to Collabora.
+
+**Pros:** Mature, well-documented, no ExApp dependency.  
+**Cons:** Separate manifest set; not managed by AppAPI.
+
+Typical next step: add `apps/base/collabora/` with ingress `office.f4mily.net` or path on `nc.f4mily.net`, configure `richdocuments` via occ.
+
+### Option B — Collabora as ExApp via AppAPI
+
+With HaRP + K8s daemon working, install Collabora from the App Store as an **ExApp** (if offered for your Nextcloud version).
+
+**Pros:** Single AppAPI workflow; upgrades via Nextcloud UI.  
+**Cons:** Newer path; resource limits and persistence need AppAPI/K8s tuning; depends on ExApp packaging quality.
+
+**Recommendation:** Use **Option A** for production Office editing unless you explicitly want everything via AppAPI. Keep HaRP for other ExApps (AI, etc.).
+
+## 6. RBAC note
+
+HaRP uses a `cluster-admin` binding for `appapi-harp` (same as upstream AppAPI K8s CI). This is broad but required for dynamic ExApp lifecycle. Scope can be tightened later with a custom ClusterRole if you catalog exact verbs AppAPI needs.
+
+## References
+
+- [Whiteboard README](https://github.com/nextcloud/whiteboard)
+- [AppAPI deploy daemons](https://docs.nextcloud.com/server/stable/admin_manual/exapps_management/ManagingDeployDaemons.html)
+- [HaRP](https://github.com/nextcloud/HaRP)

--- a/justfile
+++ b/justfile
@@ -123,6 +123,26 @@ nextcloud-authentik-oauth:
     echo ""
     echo "See docs/integrations/nextcloud-authentik.md"
 
+# Whiteboard WebSocket + AppAPI HaRP shared secrets (nextcloud namespace)
+nextcloud-collab-secrets:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    : "${SOPS_AGE_KEY_FILE:?Set SOPS_AGE_KEY_FILE to your age private key}"
+    whiteboard_jwt="$(openssl rand -base64 32 | tr -d '\n/+=' | head -c 48)"
+    # HaRP rejects " and \ in HP_SHARED_KEY
+    harp_shared_key="$(openssl rand -base64 32 | tr -d '\n\"\\' | head -c 48)"
+    dir="apps/base/nextcloud"
+    cd "$dir"
+    kubectl create secret generic nextcloud-collab \
+      --namespace nextcloud \
+      --from-literal=whiteboard-jwt-secret="$whiteboard_jwt" \
+      --from-literal=harp-shared-key="$harp_shared_key" \
+      --dry-run=client -o yaml >nextcloud-collab.secret.yaml
+    sops --encrypt --in-place nextcloud-collab.secret.yaml
+    echo "Created: $dir/nextcloud-collab.secret.yaml"
+    echo ""
+    echo "Next: commit, push, flux reconcile. See docs/integrations/nextcloud-appapi-collabora.md"
+
 # Encrypt a plaintext *.secret.yaml in place
 sops-encrypt file:
     #!/usr/bin/env bash


### PR DESCRIPTION
## Summary
- Deploy **Whiteboard WebSocket server** (`nextcloud-whiteboard`) with ingress path `/socket.io/` on `nc.f4mily.net` and JWT config via `occ-collab-setup`.
- Deploy **AppAPI HaRP** with native **Kubernetes ExApp** backend (`HP_K8S_ENABLED`, namespace `nextcloud-exapps`) and ingress path `/exapps/`.
- Add SOPS secret `nextcloud-collab` (`just nextcloud-collab-secrets`) and docs for Whiteboard verification + **Collabora Option A vs B**.

## Test plan
- [ ] `just validate` passes (local)
- [ ] Flux reconcile; pods `nextcloud-whiteboard`, `appapi-harp` Ready in `nextcloud`
- [ ] Admin → Whiteboard: WebSocket warning gone
- [ ] Browser DevTools WS: `wss://nc.f4mily.net/socket.io/…` stays connected
- [ ] Admin → AppAPI → Deploy daemon **K8s Homelab** → **Test deploy** succeeds
- [ ] `kubectl -n nextcloud-exapps get pods` shows test ExApp

## Collabora follow-up
Classic Collabora Online (Deployment + `richdocuments`) recommended for Office; see `docs/integrations/nextcloud-appapi-collabora.md`.


Made with [Cursor](https://cursor.com)