### PR TITLE
fix(monitoring): CNPG scrape relabeling for namespace alerts

### DIFF
--- a/KI-ALERT-PLAN.md
+++ b/KI-ALERT-PLAN.md
@@ -53,6 +53,7 @@ kubectl port-forward -n monitoring svc/vmalertmanager-vm-k8s-stack 9093:9093
 | Overlay `apps/overlays/main` → `../../base/monitoring` | ✅ |
 | Velero ServiceMonitor wieder aktiv | ✅ |
 | Nginx Ingress VMServiceScrape wieder aktiv | ✅ |
+| CNPG VMPodScrape + namespace/pod relabeling | ✅ |
 | `defaultRules` Noise-Reduktion (K3s/Talos) | ✅ |
 
 ---
@@ -166,4 +167,5 @@ docs/runbooks/
 
 | Datum | Änderung |
 |-------|----------|
+| 2026-05-30 | CNPG VMPodScrape mit namespace/pod-Relabeling; enablePodMonitor deaktiviert |
 | 2026-05-21 | Phase 1–3 implementiert, Plan angelegt |

--- a/apps/base/monitoring/extra-scrapes/cnpg-vmpodscrape.yaml
+++ b/apps/base/monitoring/extra-scrapes/cnpg-vmpodscrape.yaml
@@ -1,0 +1,28 @@
+# CNPG instance metrics — explicit scrape with namespace/pod relabeling.
+# Auto PodMonitor from enablePodMonitor lacks these labels (CNPG #8978), which
+# breaks alerts filtering on namespace="cnpg-system".
+# Disable enablePodMonitor on Cluster CRs when using this scrape.
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMPodScrape
+metadata:
+  name: cnpg-clusters
+  namespace: cnpg-system
+  labels:
+    release: victoriametrics
+spec:
+  namespaceSelector:
+    matchNames:
+      - cnpg-system
+  selector:
+    matchExpressions:
+      - key: cnpg.io/cluster
+        operator: Exists
+  podMetricsEndpoints:
+    - port: metrics
+      interval: 30s
+      path: /metrics
+      relabelConfigs:
+        - sourceLabels: [__meta_kubernetes_namespace]
+          targetLabel: namespace
+        - sourceLabels: [__meta_kubernetes_pod_name]
+          targetLabel: pod

--- a/apps/base/monitoring/extra-scrapes/kustomization.yaml
+++ b/apps/base/monitoring/extra-scrapes/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - velero-vmservicescrape.yaml
   - nginx-ingress-vmservicescrape.yaml
+  - cnpg-vmpodscrape.yaml

--- a/docs/runbooks/cnpg-cluster-offline.md
+++ b/docs/runbooks/cnpg-cluster-offline.md
@@ -9,8 +9,17 @@ Alert `CNPGClusterOffline` or `CNPGClusterInstanceDown`.
 ```bash
 kubectl get cluster -n cnpg-system
 kubectl get pods -n cnpg-system -l cnpg.io/cluster
+kubectl get vmpodscrape -n cnpg-system cnpg-clusters
 kubectl logs -n cnpg-system -l cnpg.io/podRole=instance --tail=80
 ```
+
+In Grafana / VictoriaMetrics:
+
+```promql
+cnpg_collector_up{namespace="cnpg-system"}
+```
+
+Expect one series per CNPG instance with `namespace`, `pod`, and `cluster` labels. If the series exist without `namespace`, check `apps/base/monitoring/extra-scrapes/cnpg-vmpodscrape.yaml` relabeling and that `enablePodMonitor: false` on Cluster CRs (avoids duplicate/conflicting PodMonitors).
 
 ## Common causes
 

--- a/infrastructure/overlays/main/database-clusters/cluster.yaml
+++ b/infrastructure/overlays/main/database-clusters/cluster.yaml
@@ -35,7 +35,8 @@ spec:
       memory: 1Gi
 
   monitoring:
-    enablePodMonitor: true
+    # Metrics scraped via apps/base/monitoring/extra-scrapes/cnpg-vmpodscrape.yaml
+    enablePodMonitor: false
 
   affinity:
     podAntiAffinityType: preferred

--- a/infrastructure/overlays/main/database-clusters/immich-postgres/cluster.yaml
+++ b/infrastructure/overlays/main/database-clusters/immich-postgres/cluster.yaml
@@ -37,7 +37,8 @@ spec:
       memory: 2Gi
 
   monitoring:
-    enablePodMonitor: true
+    # Metrics scraped via apps/base/monitoring/extra-scrapes/cnpg-vmpodscrape.yaml
+    enablePodMonitor: false
 
   env:
     - name: AWS_DEFAULT_REGION


### PR DESCRIPTION
## Summary
- Add explicit `VMPodScrape` for CNPG with `namespace`/`pod` relabeling so `CNPGClusterOffline` stops false-firing
- Disable operator-managed `enablePodMonitor` on both Postgres clusters to avoid duplicate/conflicting scrapes
- Update runbook and KI-ALERT-PLAN

## Test plan
- [ ] Flux reconcile `infra-base`, `apps`, `apps-monitoring-rules`
- [ ] `kubectl get vmpodscrape -n cnpg-system cnpg-clusters`
- [ ] Grafana: `cnpg_collector_up{namespace="cnpg-system"}` returns 2 series
- [ ] Confirm `CNPGClusterOffline` resolves and stays resolved

Made with [Cursor](https://cursor.com)