### PR TITLE
fix(monitoring): disable chart default VMRules on Talos

### DIFF
--- a/KI-ALERT-PLAN.md
+++ b/KI-ALERT-PLAN.md
@@ -103,7 +103,7 @@ Siehe [`docs/integrations/grafana-authentik.md`](docs/integrations/grafana-authe
 
 | Task | Status |
 |------|--------|
-| `defaultRules.enabled: false` (nur P0-VMRules) | ✅ |
+| `defaultRules.create: false` (nur P0-VMRules) | ✅ |
 | Alertmanager: Default → blackhole, nur critical/warning → ntfy | ✅ |
 | längere `group_wait` / `repeat_interval` | ✅ |
 | ntfy-Bridge (`apps/base/monitoring/ntfy-bridge/`) | ✅ |
@@ -167,5 +167,6 @@ docs/runbooks/
 
 | Datum | Änderung |
 |-------|----------|
+| 2026-05-30 | Fix `defaultRules.create: false`; Talos control-plane scrapes aus |
 | 2026-05-30 | CNPG VMPodScrape mit namespace/pod-Relabeling; enablePodMonitor deaktiviert |
 | 2026-05-21 | Phase 1–3 implementiert, Plan angelegt |

--- a/apps/base/monitoring/vm-k8s-stack/helmrelease.yaml
+++ b/apps/base/monitoring/vm-k8s-stack/helmrelease.yaml
@@ -201,8 +201,9 @@ spec:
       enabled: true
 
     # Chart defaults (~100+ rules) are too noisy for a homelab; use platform P0 VMRules only.
+    # Note: chart uses `create`, not `enabled` — `enabled: false` has no effect.
     defaultRules:
-      enabled: false
+      create: false
 
     # ============================================
     # GRAFANA
@@ -365,20 +366,21 @@ spec:
     # ============================================
     # KUBE CONTROLLER MANAGER
     # ============================================
+    # Talos: control-plane metrics are not reachable via standard Endpoints scrape.
     kubeControllerManager:
-      enabled: true
+      enabled: false
 
     # ============================================
     # KUBE SCHEDULER
     # ============================================
     kubeScheduler:
-      enabled: true
+      enabled: false
 
     # ============================================
     # KUBE ETCD
     # ============================================
     kubeEtcd:
-      enabled: true
+      enabled: false
 
     # ============================================
     # KUBE PROXY

--- a/docs/runbooks/monitoring-stack.md
+++ b/docs/runbooks/monitoring-stack.md
@@ -84,6 +84,22 @@ kubectl wait -n monitoring --for=condition=ready pod -l app.kubernetes.io/name=v
 
 If it persists: Longhorn UI → volume for `vmsingle-*` PVC → check health; last resort detach/reattach volume or restore from backup (metrics gap).
 
+## Stale chart default alerts (KubeControllerManager*, KubeJobFailed, …)
+
+Symptom: Alerts from `runbooks.prometheus-operator.dev` despite intending to use only P0 VMRules.
+
+Cause: `defaultRules.enabled: false` is ignored by `victoria-metrics-k8s-stack` — use **`defaultRules.create: false`**.
+
+After fixing Helm values:
+
+```bash
+flux reconcile helmrelease vm-k8s-stack -n monitoring
+kubectl get vmrule -n monitoring
+# Expect only homelab-platform-* and workload-remediation rules, not vm-k8s-stack-kube-*.rules
+```
+
+Talos: keep `kubeControllerManager`, `kubeScheduler`, and `kubeEtcd` scrapes disabled — control-plane endpoints are not reachable like on kubeadm clusters.
+
 ## Flux
 
 ```bash


### PR DESCRIPTION
## Summary
- Replace ineffective `defaultRules.enabled: false` with `defaultRules.create: false` (chart 0.79.1 ignores `enabled`)
- Disable `kubeControllerManager`, `kubeScheduler`, and `kubeEtcd` scrapes on Talos
- Document stale default-rule cleanup in monitoring runbook

## Context
Alerts like `KubeControllerManagerInstanceUnreachable` and `KubeJobFailed` (renovate) came from chart default VMRules that were never actually disabled.

## Test plan
- [ ] `flux reconcile helmrelease vm-k8s-stack -n monitoring`
- [ ] `kubectl get vmrule -n monitoring` — no `vm-k8s-stack-kube-*.rules`
- [ ] Confirm firing default alerts resolve within ~15m
- [ ] Optional: `kubectl logs -n renovate job/$(kubectl get jobs -n renovate -o name | tail -1 | cut -d/ -f2)` if renovate still fails operationally

Made with [Cursor](https://cursor.com)