### PR TITLE
fix(monitoring): purge stale chart VMRules on Talos

### DIFF
--- a/KI-ALERT-PLAN.md
+++ b/KI-ALERT-PLAN.md
@@ -167,6 +167,7 @@ docs/runbooks/
 
 | Datum | Änderung |
 |-------|----------|
+| 2026-05-30 | kubeApiServer-Scrape aus; Script `purge-chart-vmrules.sh` für verwaiste VMRules |
 | 2026-05-30 | Fix `defaultRules.create: false`; Talos control-plane scrapes aus |
 | 2026-05-30 | CNPG VMPodScrape mit namespace/pod-Relabeling; enablePodMonitor deaktiviert |
 | 2026-05-21 | Phase 1–3 implementiert, Plan angelegt |

--- a/apps/base/monitoring/vm-k8s-stack/helmrelease.yaml
+++ b/apps/base/monitoring/vm-k8s-stack/helmrelease.yaml
@@ -360,8 +360,9 @@ spec:
     # ============================================
     # KUBE API SERVER SCRAPING
     # ============================================
+    # Talos: per-node apiserver Endpoints often look down from vmagent → TargetDown noise.
     kubeApiServer:
-      enabled: true
+      enabled: false
 
     # ============================================
     # KUBE CONTROLLER MANAGER

--- a/docs/runbooks/monitoring-stack.md
+++ b/docs/runbooks/monitoring-stack.md
@@ -88,17 +88,26 @@ If it persists: Longhorn UI → volume for `vmsingle-*` PVC → check health; la
 
 Symptom: Alerts from `runbooks.prometheus-operator.dev` despite intending to use only P0 VMRules.
 
-Cause: `defaultRules.enabled: false` is ignored by `victoria-metrics-k8s-stack` — use **`defaultRules.create: false`**.
+Cause: `defaultRules.enabled: false` is ignored by `victoria-metrics-k8s-stack` — use **`defaultRules.create: false`**. After fixing Helm values, **orphaned VMRule CRs may remain** until deleted once.
 
-After fixing Helm values:
+One-time cleanup (keeps `homelab-platform-*` / `workload-remediation` VMRules):
 
 ```bash
+./scripts/monitoring/purge-chart-vmrules.sh monitoring
 flux reconcile helmrelease vm-k8s-stack -n monitoring
 kubectl get vmrule -n monitoring
-# Expect only homelab-platform-* and workload-remediation rules, not vm-k8s-stack-kube-*.rules
+# Expect only homelab-platform-p0 and homelab-workload-remediation — no vm-k8s-stack-*.rules
 ```
 
-Talos: keep `kubeControllerManager`, `kubeScheduler`, and `kubeEtcd` scrapes disabled — control-plane endpoints are not reachable like on kubeadm clusters.
+Talos: keep `kubeApiServer`, `kubeControllerManager`, `kubeScheduler`, and `kubeEtcd` scrapes disabled — control-plane Endpoints are not reliably reachable from vmagent (→ `TargetDown`, `KubeAPIInstanceUnreachable`).
+
+If `KubeJobFailed` persists **after** VMRule cleanup, check real Jobs (not monitoring noise):
+
+```bash
+kubectl get jobs -A --field-selector status.successful!=1
+kubectl logs -n nextcloud job/<name>
+kubectl logs -n renovate job/<name>
+```
 
 ## Flux
 

--- a/scripts/monitoring/purge-chart-vmrules.sh
+++ b/scripts/monitoring/purge-chart-vmrules.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Remove chart-managed default VMRules left over after switching to defaultRules.create: false.
+# Safe: keeps homelab-platform-* and workload-remediation VMRules (separate Flux Kustomization).
+set -euo pipefail
+
+NS="${1:-monitoring}"
+
+echo "VMRules in ${NS} before cleanup:"
+kubectl get vmrule -n "${NS}" -o custom-columns=NAME:.metadata.name,MANAGED:.metadata.labels.app\\.kubernetes\\.io/managed-by,CHART:.metadata.labels.helm\\.sh/chart 2>/dev/null || true
+
+mapfile -t CHART_RULES < <(
+  kubectl get vmrule -n "${NS}" -o json \
+    | jq -r '.items[]
+      | select(
+          .metadata.labels["app.kubernetes.io/managed-by"] == "Helm"
+          and (.metadata.labels["app.kubernetes.io/name"] // "") == "victoria-metrics-k8s-stack"
+        )
+      | .metadata.name'
+)
+
+if ((${#CHART_RULES[@]} == 0)); then
+  echo "No chart default VMRules to delete."
+  exit 0
+fi
+
+echo "Deleting ${#CHART_RULES[@]} chart VMRule(s)…"
+kubectl delete vmrule -n "${NS}" "${CHART_RULES[@]}"
+
+echo "Reconcile HelmRelease so vm-k8s-stack stays in sync:"
+echo "  flux reconcile helmrelease vm-k8s-stack -n ${NS}"


### PR DESCRIPTION
## Summary
- Disable `kubeApiServer` scrape on Talos (per-node apiserver Endpoints → false `TargetDown` / `KubeAPIInstanceUnreachable`)
- Add `scripts/monitoring/purge-chart-vmrules.sh` to delete orphaned chart VMRules once
- Extend monitoring runbook with cleanup + real Job triage after noise is gone

## Test plan
- [ ] Merge → Flux reconcile `vm-k8s-stack`
- [ ] Run `./scripts/monitoring/purge-chart-vmrules.sh monitoring`
- [ ] `kubectl get vmrule -n monitoring` — only homelab P0 rules remain
- [ ] Chart alerts resolve within ~15m

Made with [Cursor](https://cursor.com)