### PR TITLE
fix(tandoor): public TLS cert and legacy CSRF origins

### DIFF
--- a/apps/base/tandoor/deployment.yaml
+++ b/apps/base/tandoor/deployment.yaml
@@ -57,10 +57,10 @@ spec:
                   name: homelab-postgres-tandoor
                   key: password
             - name: ALLOWED_HOSTS
-              value: rezepte.f4mily.net,localhost,127.0.0.1
+              value: rezepte.f4mily.net,recipes.f4mily.net,localhost,127.0.0.1
             # Django 4+ origin check when TLS terminates at ingress (see docs.tandoor.dev)
             - name: CSRF_TRUSTED_ORIGINS
-              value: https://rezepte.f4mily.net
+              value: https://rezepte.f4mily.net,https://recipes.f4mily.net
             # Built-in container nginx + cluster ingress nginx
             - name: ALLAUTH_TRUSTED_PROXY_COUNT
               value: "2"

--- a/apps/base/tandoor/ingress.yaml
+++ b/apps/base/tandoor/ingress.yaml
@@ -13,14 +13,30 @@ metadata:
     gethomepage.dev/pod-selector: app=tandoor
     nginx.org/ssl-redirect: "false"
     nginx.org/redirect-to-https: "true"
+    # Legacy Docker hostname → canonical rezepte.f4mily.net
+    nginx.org/server-snippets: |
+      if ($host = recipes.f4mily.net) {
+        return 301 https://rezepte.f4mily.net$request_uri;
+      }
 spec:
   ingressClassName: nginx
   tls:
     - hosts:
         - rezepte.f4mily.net
+        - recipes.f4mily.net
       secretName: wildcard-f4mily-net-tls
   rules:
     - host: rezepte.f4mily.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: tandoor
+                port:
+                  number: 80
+    - host: recipes.f4mily.net
       http:
         paths:
           - path: /

--- a/apps/overlays/main/cluster-config.yaml
+++ b/apps/overlays/main/cluster-config.yaml
@@ -58,10 +58,11 @@ data:
   host_teslamate: teslamate.f4mily.net
   url_teslamate_grafana: https://teslamate.f4mily.net/grafana/
   host_tandoor: rezepte.f4mily.net
+  host_tandoor_legacy: recipes.f4mily.net
   # Public URL (scheme required for Django CSRF_TRUSTED_ORIGINS behind TLS ingress).
-  url_tandoor: https://rezepte.f4mily.net
-  # Comma-separated Django ALLOWED_HOSTS (public host + local debugging).
-  tandoor_allowed_hosts: rezepte.f4mily.net,localhost,127.0.0.1
+  url_tandoor: https://rezepte.f4mily.net,https://recipes.f4mily.net
+  # Comma-separated Django ALLOWED_HOSTS (public host + legacy alias + local debugging).
+  tandoor_allowed_hosts: rezepte.f4mily.net,recipes.f4mily.net,localhost,127.0.0.1
   host_linkwarden: linkwarden.f4mily.net
   host_readeck: readeck.f4mily.net
   url_readeck: https://readeck.f4mily.net

--- a/apps/overlays/main/kustomization.yaml
+++ b/apps/overlays/main/kustomization.yaml
@@ -259,6 +259,16 @@ replacements:
   - source:
       kind: ConfigMap
       name: homelab-cluster-config
+      fieldPath: data.host_tandoor_legacy
+    targets:
+      - select: {kind: Ingress, name: tandoor}
+        fieldPaths:
+          - spec.rules.1.host
+          - spec.tls.0.hosts.1
+
+  - source:
+      kind: ConfigMap
+      name: homelab-cluster-config
       fieldPath: data.tandoor_allowed_hosts
     targets:
       - select: {kind: Deployment, name: tandoor}
@@ -447,14 +457,14 @@ replacements:
         fieldPaths: [spec.tls.0.secretName]
       - select: {kind: Ingress, name: nextcloud}
         fieldPaths: [spec.tls.0.secretName]
+      - select: {kind: Ingress, name: tandoor}
+        fieldPaths: [spec.tls.0.secretName]
 
   - source:
       kind: ConfigMap
       name: homelab-cluster-config
       fieldPath: data.clusterTlsSecret
     targets:
-      - select: {kind: Ingress, name: tandoor}
-        fieldPaths: [spec.tls.0.secretName]
       - select: {kind: Ingress, name: goloom}
         fieldPaths: [spec.tls.0.secretName]
       - select: {kind: Ingress, name: grafana}

--- a/docs/runbooks/tandoor-csrf.md
+++ b/docs/runbooks/tandoor-csrf.md
@@ -1,0 +1,43 @@
+# Tandoor CSRF / login failures
+
+## Symptom
+
+`Forbidden (403) — CSRF verification failed` on `https://rezepte.f4mily.net` (login, Authentik SSO, or recipe edits).
+
+## Quick checks
+
+```bash
+# TLS must be *.f4mily.net, not *.cluster.f4mily.net
+openssl s_client -connect 192.168.10.245:443 -servername rezepte.f4mily.net </dev/null 2>/dev/null \
+  | openssl x509 -noout -ext subjectAltName
+
+kubectl get ingress tandoor -n tandoor -o jsonpath='{.spec.tls[0].secretName}{"\n"}'
+# Expect: wildcard-f4mily-net-tls
+
+kubectl get deploy tandoor -n tandoor -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.value}{"\n"}{end}' \
+  | rg 'CSRF|ALLOWED|PROXY'
+```
+
+Expected env:
+
+- `CSRF_TRUSTED_ORIGINS=https://rezepte.f4mily.net,https://recipes.f4mily.net`
+- `ALLOWED_HOSTS=rezepte.f4mily.net,recipes.f4mily.net,...`
+- `ALLAUTH_TRUSTED_PROXY_COUNT=2` (container nginx + ingress)
+
+## Common causes
+
+| Cause | Fix |
+|-------|-----|
+| Wrong TLS secret on Ingress (`wildcard-cluster-*` on public host) | Overlay must use `publicTlsSecret` for `tandoor` — see `apps/overlays/main/kustomization.yaml` |
+| Old bookmark `recipes.f4mily.net` | Redirects to `rezepte`; both origins must be in `CSRF_TRUSTED_ORIGINS` |
+| Stale cookies after `SECRET_KEY` or domain change | Clear site data for `rezepte.f4mily.net` / `recipes.f4mily.net`, retry in private window |
+| DNS still on old Docker host (`192.168.10.244`) | `dig rezepte.f4mily.net` → **192.168.10.245** (Talos VIP) |
+
+## After GitOps fix
+
+```bash
+flux reconcile kustomization apps --with-source
+kubectl rollout restart deployment/tandoor -n tandoor
+```
+
+Browser: hard refresh or clear cookies, then open **https://rezepte.f4mily.net** (not HTTP, not cluster domain).


### PR DESCRIPTION
## Summary
- Move Tandoor Ingress TLS from `wildcard-cluster-f4mily-net-tls` to `wildcard-f4mily-net-tls`
- Add legacy `recipes.f4mily.net` host + CSRF trusted origin + redirect to `rezepte.f4mily.net`
- Add runbook `docs/runbooks/tandoor-csrf.md`

## Root cause
Public hostname `rezepte.f4mily.net` was wired to the cluster wildcard cert (`*.cluster.f4mily.net`). Browsers see a cert/name mismatch; Django CSRF/login becomes flaky especially after cookie/session changes.

## Test plan
- [ ] `flux reconcile kustomization apps --with-source`
- [ ] `openssl s_client -connect 192.168.10.245:443 -servername rezepte.f4mily.net` shows `*.f4mily.net`
- [ ] Login at https://rezepte.f4mily.net (clear cookies if needed)
- [ ] https://recipes.f4mily.net redirects to rezepte

Made with [Cursor](https://cursor.com)