### PR TITLE
fix(tandoor): drop server-snippets causing 404

### DIFF
--- a/apps/base/tandoor/ingress.yaml
+++ b/apps/base/tandoor/ingress.yaml
@@ -13,30 +13,14 @@ metadata:
     gethomepage.dev/pod-selector: app=tandoor
     nginx.org/ssl-redirect: "false"
     nginx.org/redirect-to-https: "true"
-    # Legacy Docker hostname → canonical rezepte.f4mily.net
-    nginx.org/server-snippets: |
-      if ($host = recipes.f4mily.net) {
-        return 301 https://rezepte.f4mily.net$request_uri;
-      }
 spec:
   ingressClassName: nginx
   tls:
     - hosts:
         - rezepte.f4mily.net
-        - recipes.f4mily.net
       secretName: wildcard-f4mily-net-tls
   rules:
     - host: rezepte.f4mily.net
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: tandoor
-                port:
-                  number: 80
-    - host: recipes.f4mily.net
       http:
         paths:
           - path: /

--- a/apps/overlays/main/cluster-config.yaml
+++ b/apps/overlays/main/cluster-config.yaml
@@ -58,10 +58,9 @@ data:
   host_teslamate: teslamate.f4mily.net
   url_teslamate_grafana: https://teslamate.f4mily.net/grafana/
   host_tandoor: rezepte.f4mily.net
-  host_tandoor_legacy: recipes.f4mily.net
   # Public URL (scheme required for Django CSRF_TRUSTED_ORIGINS behind TLS ingress).
+  # Include legacy recipes hostname for bookmarks still using the old Docker URL.
   url_tandoor: https://rezepte.f4mily.net,https://recipes.f4mily.net
-  # Comma-separated Django ALLOWED_HOSTS (public host + legacy alias + local debugging).
   tandoor_allowed_hosts: rezepte.f4mily.net,recipes.f4mily.net,localhost,127.0.0.1
   host_linkwarden: linkwarden.f4mily.net
   host_readeck: readeck.f4mily.net

--- a/apps/overlays/main/kustomization.yaml
+++ b/apps/overlays/main/kustomization.yaml
@@ -259,16 +259,6 @@ replacements:
   - source:
       kind: ConfigMap
       name: homelab-cluster-config
-      fieldPath: data.host_tandoor_legacy
-    targets:
-      - select: {kind: Ingress, name: tandoor}
-        fieldPaths:
-          - spec.rules.1.host
-          - spec.tls.0.hosts.1
-
-  - source:
-      kind: ConfigMap
-      name: homelab-cluster-config
       fieldPath: data.tandoor_allowed_hosts
     targets:
       - select: {kind: Deployment, name: tandoor}

--- a/docs/runbooks/tandoor-csrf.md
+++ b/docs/runbooks/tandoor-csrf.md
@@ -29,7 +29,8 @@ Expected env:
 | Cause | Fix |
 |-------|-----|
 | Wrong TLS secret on Ingress (`wildcard-cluster-*` on public host) | Overlay must use `publicTlsSecret` for `tandoor` — see `apps/overlays/main/kustomization.yaml` |
-| Old bookmark `recipes.f4mily.net` | Redirects to `rezepte`; both origins must be in `CSRF_TRUSTED_ORIGINS` |
+| `nginx.org/server-snippets` with `if` on Tandoor Ingress | Breaks F5 NGINX routing → 404; do not use — redirect legacy host in DNS instead |
+| Old bookmark `recipes.f4mily.net` | Use `https://rezepte.f4mily.net`; keep both origins in `CSRF_TRUSTED_ORIGINS` |
 | Stale cookies after `SECRET_KEY` or domain change | Clear site data for `rezepte.f4mily.net` / `recipes.f4mily.net`, retry in private window |
 | DNS still on old Docker host (`192.168.10.244`) | `dig rezepte.f4mily.net` → **192.168.10.245** (Talos VIP) |
 


### PR DESCRIPTION
## Summary
- Revert Tandoor Ingress to single-host (no server-snippets / second rule)
- Keep PR #182 TLS fix (`publicTlsSecret`) and dual CSRF origins

## Root cause
`nginx.org/server-snippets` with `if ($host = ...)` breaks F5 NGINX location routing → 404 for all paths.

## Test plan
- [ ] Flux reconcile apps
- [ ] https://rezepte.f4mily.net/ returns 302 to login (not 404)

Made with [Cursor](https://cursor.com)