### PR TITLE
fix(tandoor): CSRF behind ingress via proxy headers

### DIFF
--- a/apps/base/tandoor/deployment.yaml
+++ b/apps/base/tandoor/deployment.yaml
@@ -18,6 +18,7 @@ spec:
         app: tandoor
         app.kubernetes.io/name: tandoor
     spec:
+      enableServiceLinks: false
       securityContext:
         fsGroup: 0
       containers:

--- a/apps/base/tandoor/ingress.yaml
+++ b/apps/base/tandoor/ingress.yaml
@@ -13,14 +13,26 @@ metadata:
     gethomepage.dev/pod-selector: app=tandoor
     nginx.org/ssl-redirect: "false"
     nginx.org/redirect-to-https: "true"
+    nginx.org/proxy-set-headers: "tandoor-proxy-headers"
 spec:
   ingressClassName: nginx
   tls:
     - hosts:
         - rezepte.f4mily.net
+        - recipes.f4mily.net
       secretName: wildcard-f4mily-net-tls
   rules:
     - host: rezepte.f4mily.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: tandoor
+                port:
+                  number: 80
+    - host: recipes.f4mily.net
       http:
         paths:
           - path: /

--- a/apps/base/tandoor/kustomization.yaml
+++ b/apps/base/tandoor/kustomization.yaml
@@ -4,5 +4,6 @@ resources:
   - namespace.yaml
   - pvc.yaml
   - tandoor-app.secret.yaml
+  - proxy-headers-configmap.yaml
   - deployment.yaml
   - ingress.yaml

--- a/apps/base/tandoor/proxy-headers-configmap.yaml
+++ b/apps/base/tandoor/proxy-headers-configmap.yaml
@@ -1,0 +1,10 @@
+# Static upstream headers for Django behind TLS-terminated F5 NGINX Ingress.
+# NIC→pod is HTTP; without this, X-Forwarded-Proto can be "http" and break CSRF/session.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tandoor-proxy-headers
+  namespace: tandoor
+data:
+  X-Forwarded-Proto: "https"
+  X-Forwarded-Port: "443"

--- a/apps/overlays/main/cluster-config.yaml
+++ b/apps/overlays/main/cluster-config.yaml
@@ -58,6 +58,7 @@ data:
   host_teslamate: teslamate.f4mily.net
   url_teslamate_grafana: https://teslamate.f4mily.net/grafana/
   host_tandoor: rezepte.f4mily.net
+  host_tandoor_legacy: recipes.f4mily.net
   # Public URL (scheme required for Django CSRF_TRUSTED_ORIGINS behind TLS ingress).
   # Include legacy recipes hostname for bookmarks still using the old Docker URL.
   url_tandoor: https://rezepte.f4mily.net,https://recipes.f4mily.net

--- a/apps/overlays/main/kustomization.yaml
+++ b/apps/overlays/main/kustomization.yaml
@@ -259,6 +259,16 @@ replacements:
   - source:
       kind: ConfigMap
       name: homelab-cluster-config
+      fieldPath: data.host_tandoor_legacy
+    targets:
+      - select: {kind: Ingress, name: tandoor}
+        fieldPaths:
+          - spec.rules.1.host
+          - spec.tls.0.hosts.1
+
+  - source:
+      kind: ConfigMap
+      name: homelab-cluster-config
       fieldPath: data.tandoor_allowed_hosts
     targets:
       - select: {kind: Deployment, name: tandoor}

--- a/docs/runbooks/tandoor-csrf.md
+++ b/docs/runbooks/tandoor-csrf.md
@@ -22,17 +22,24 @@ Expected env:
 
 - `CSRF_TRUSTED_ORIGINS=https://rezepte.f4mily.net,https://recipes.f4mily.net`
 - `ALLOWED_HOSTS=rezepte.f4mily.net,recipes.f4mily.net,...`
-- `ALLAUTH_TRUSTED_PROXY_COUNT=2` (container nginx + ingress)
+- `ALLAUTH_TRUSTED_PROXY_COUNT=2` (one external ingress + in-container nginx)
+
+Ingress must expose **both** hostnames in `spec.tls` and `spec.rules` (legacy `recipes` SNI fails otherwise).
+Annotation `nginx.org/proxy-set-headers: tandoor-proxy-headers` forces `X-Forwarded-Proto: https`
+(TLS terminates at ingress; without it Django may treat requests as HTTP → CSRF/session issues).
 
 ## Common causes
 
 | Cause | Fix |
 |-------|-----|
 | Wrong TLS secret on Ingress (`wildcard-cluster-*` on public host) | Overlay must use `publicTlsSecret` for `tandoor` — see `apps/overlays/main/kustomization.yaml` |
-| `nginx.org/server-snippets` with `if` on Tandoor Ingress | Breaks F5 NGINX routing → 404; do not use — redirect legacy host in DNS instead |
-| Old bookmark `recipes.f4mily.net` | Use `https://rezepte.f4mily.net`; keep both origins in `CSRF_TRUSTED_ORIGINS` |
+| Missing `X-Forwarded-Proto: https` at ingress | ConfigMap `tandoor-proxy-headers` + `nginx.org/proxy-set-headers` on Ingress |
+| `nginx.org/server-snippets` with `if` on Tandoor Ingress | Breaks F5 NGINX routing → 404; do not use |
+| Old bookmark `recipes.f4mily.net` without Ingress host/TLS entry | Second rule + TLS SAN; both origins in `CSRF_TRUSTED_ORIGINS` |
+| HTTP URL (`http://rezepte…`) | CSRF origins are HTTPS-only; always open `https://rezepte.f4mily.net` |
 | Stale cookies after `SECRET_KEY` or domain change | Clear site data for `rezepte.f4mily.net` / `recipes.f4mily.net`, retry in private window |
 | DNS still on old Docker host (`192.168.10.244`) | `dig rezepte.f4mily.net` → **192.168.10.245** (Talos VIP) |
+| Access via Netbird/extra reverse proxy | Try `ALLAUTH_TRUSTED_PROXY_COUNT=3` (two external proxies) |
 
 ## After GitOps fix
 


### PR DESCRIPTION
## Summary
- Add ConfigMap `tandoor-proxy-headers` with `X-Forwarded-Proto: https` wired via `nginx.org/proxy-set-headers`
- Expose legacy host `recipes.f4mily.net` on Ingress TLS + second rule (SNI was failing; Origin mismatch with CSRF trusted origins)
- `enableServiceLinks: false` on Deployment; runbook updated

## Root cause
PR #182/#183 fixed TLS cert and removed breaking server-snippets, but CSRF could still fail because:
1. TLS terminates at F5 NGINX while the pod connection is HTTP — Django may not see HTTPS without explicit `X-Forwarded-Proto: https`
2. `recipes.f4mily.net` was in `CSRF_TRUSTED_ORIGINS` but not on Ingress → TLS SNI failure / wrong host for users with old bookmarks

## Test plan
- [ ] `flux reconcile kustomization apps --with-source`
- [ ] `kubectl rollout restart deployment/tandoor -n tandoor`
- [ ] Clear cookies for `rezepte.f4mily.net` / `recipes.f4mily.net`
- [ ] Login at https://rezepte.f4mily.net (form + Authentik SSO)
- [ ] https://recipes.f4mily.net loads with valid `*.f4mily.net` cert (no SNI error)
- [ ] Recipe edit / Vue API calls work without CSRF 403

Made with [Cursor](https://cursor.com)