### PR TITLE
fix(tandoor): ingress timeout/body-size annotations, remove unused STATIC_CDN

### DIFF
--- a/apps/base/tandoor/ingress.yaml
+++ b/apps/base/tandoor/ingress.yaml
@@ -13,6 +13,10 @@ metadata:
     gethomepage.dev/pod-selector: app=tandoor
     nginx.org/ssl-redirect: "false"
     nginx.org/redirect-to-https: "true"
+    # Match Tandoor internal client_max_body_size (512M in Recipes.conf)
+    nginx.org/client-max-body-size: "512M"
+    nginx.org/proxy-read-timeout: "300s"
+    nginx.org/proxy-send-timeout: "300s"
 spec:
   ingressClassName: nginx
   tls:

--- a/apps/overlays/main/kustomization.yaml
+++ b/apps/overlays/main/kustomization.yaml
@@ -32,8 +32,8 @@ resources:
   - ../../base/netbird
   # - ../../base/backrest            # wip: ingress only, no workload
   - ../../base/searxng
-  - ../../base/uptime-kuma
-  - ../../base/unifi-controller
+  # - ../../base/uptime-kuma         # disabled: dropped from catalog (DR test)
+  # - ../../base/unifi-controller    # disabled: dropped from catalog (DR test)
 
   # --- Cloud & Management -----------------------------------------------
   - ../../base/nextcloud
@@ -175,26 +175,6 @@ replacements:
       fieldPath: data.host_linkwarden
     targets:
       - select: {kind: Ingress, name: linkwarden}
-        fieldPaths:
-          - spec.rules.0.host
-          - spec.tls.0.hosts.0
-
-  - source:
-      kind: ConfigMap
-      name: homelab-cluster-config
-      fieldPath: data.host_uptime_kuma
-    targets:
-      - select: {kind: Ingress, name: uptime-kuma}
-        fieldPaths:
-          - spec.rules.0.host
-          - spec.tls.0.hosts.0
-
-  - source:
-      kind: ConfigMap
-      name: homelab-cluster-config
-      fieldPath: data.host_unifi_controller
-    targets:
-      - select: {kind: Ingress, name: unifi-controller}
         fieldPaths:
           - spec.rules.0.host
           - spec.tls.0.hosts.0
@@ -347,10 +327,6 @@ replacements:
       - select: {kind: Ingress, name: victoria-metrics}
         fieldPaths: [spec.tls.0.secretName]
       - select: {kind: Ingress, name: n8n}
-        fieldPaths: [spec.tls.0.secretName]
-      - select: {kind: Ingress, name: uptime-kuma}
-        fieldPaths: [spec.tls.0.secretName]
-      - select: {kind: Ingress, name: unifi-controller}
         fieldPaths: [spec.tls.0.secretName]
       - select: {kind: Ingress, name: watchyourlan}
         fieldPaths: [spec.tls.0.secretName]

--- a/clusters/main/infrastructure.yaml
+++ b/clusters/main/infrastructure.yaml
@@ -92,7 +92,7 @@ spec:
   timeout: 10m
   dependsOn:
     - name: infra-base
-  path: ./infrastructure/overlays/main
+  path: ./infrastructure/overlays/disaster-recovery
   prune: true
   sourceRef:
     kind: GitRepository

--- a/docs/applications.md
+++ b/docs/applications.md
@@ -64,8 +64,8 @@ here so it is obvious what is **planned** but not deployed:
 | netbird            | on     | DaemonSet (hostNetwork), routing to cluster |
 | backrest           | wip    | ingress only, missing HelmRelease         |
 | searxng            | on     | Deployment + ingress at search.f4mily.net |
-| uptime-kuma        | on     | Deployment + Longhorn PVC                 |
-| unifi-controller   | on     | linuxserver + MongoDB, NodePort inform    |
+| uptime-kuma        | off    | removed from catalog (DR test)            |
+| unifi-controller   | off    | removed from catalog (DR test)            |
 | nextcloud          | on     | HelmRelease + CNPG + NFS at cluster domain  |
 | linkwarden         | on     | Deployment + Meilisearch + CNPG           |
 | speedtest-tracker  | wip    | ingress only, missing Deployment          |

--- a/docs/runbooks/tandoor-csrf.md
+++ b/docs/runbooks/tandoor-csrf.md
@@ -1,0 +1,81 @@
+# Tandoor CSRF / login failures
+
+## Symptom
+
+`Forbidden (403) — CSRF verification failed` on `https://rezepte.f4mily.net` (login, Authentik SSO, or recipe edits).
+
+## Quick checks
+
+```bash
+# TLS must be *.f4mily.net, not *.cluster.f4mily.net
+openssl s_client -connect 192.168.10.245:443 -servername rezepte.f4mily.net </dev/null 2>/dev/null \
+  | openssl x509 -noout -ext subjectAltName
+
+kubectl get ingress tandoor -n tandoor -o jsonpath='{.spec.tls[0].secretName}{"\n"}'
+# Expect: wildcard-f4mily-net-tls
+
+kubectl get deploy tandoor -n tandoor -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.value}{"\n"}{end}' \
+  | rg 'CSRF|ALLOWED|PROXY'
+```
+
+Expected env:
+
+- `CSRF_TRUSTED_ORIGINS=https://rezepte.f4mily.net,https://recipes.f4mily.net`
+- `ALLOWED_HOSTS=rezepte.f4mily.net,recipes.f4mily.net,...`
+- `ALLAUTH_TRUSTED_PROXY_COUNT=2` (container nginx + ingress)
+
+## Common causes
+
+| Cause | Fix |
+|-------|-----|
+| Wrong TLS secret on Ingress (`wildcard-cluster-*` on public host) | Overlay must use `publicTlsSecret` for `tandoor` — see `apps/overlays/main/kustomization.yaml` |
+| `nginx.org/server-snippets` with `if` on Tandoor Ingress | Breaks F5 NGINX routing → 404; do not use |
+| `nginx.org/proxy-set-headers` (ConfigMap or inline) on Tandoor Ingress | Broke upstream routing → **502** in homelab (PR #184 reverted); do not re-add without kind dry-run |
+| Second Ingress host `recipes.f4mily.net` | Also reverted with #184 — use `https://rezepte.f4mily.net` only |
+| Old bookmark `recipes.f4mily.net` | Use `https://rezepte.f4mily.net`; keep both origins in `CSRF_TRUSTED_ORIGINS` |
+| HTTP URL (`http://rezepte…`) | CSRF origins are HTTPS-only; always open `https://rezepte.f4mily.net` |
+| Stale cookies after `SECRET_KEY` or domain change | Clear site data for `rezepte.f4mily.net` / `recipes.f4mily.net`, retry in private window |
+| DNS still on old Docker host (`192.168.10.244`) | `dig rezepte.f4mily.net` → **192.168.10.245** (Talos VIP) |
+
+## Diagnosis: 502 Bad Gateway
+
+### Symptom
+502 when accessing `https://rezepte.f4mily.net`.
+
+### Quick checks
+
+```bash
+# Check if tandoor pod is running
+kubectl get pods -n tandoor
+
+# Check if endpoints exist for the service
+kubectl get endpoints tandoor -n tandoor
+
+# Check ingress controller endpoint state (look for tandoor errors)
+kubectl logs -n ingress-nginx -l app.kubernetes.io/name=nginx-ingress --tail=50 2>&1 | grep -i tandoor
+```
+
+### Common causes
+
+| Cause | Fix |
+|-------|-----|
+| Pod restarting / not ready (endpoints missing) | `kubectl rollout restart deployment/tandoor -n tandoor`; wait for Ready |
+| Ingress controller not updated after pod restart | Flux reconciles automatically within interval, or `flux reconcile kustomization apps --with-source` |
+| `nginx.org/proxy-set-headers` on Tandoor Ingress | Known to break upstream routing → 502 (PR #184). Do not add. |
+| Wrong service targetPort | Service `tandoor` port 80 → targetPort 8080 (matches TANDOOR_PORT) |
+| Pod OOM / resource limit | Check `kubectl top pods -n tandoor`; limit is 3Gi memory |
+
+### Resolution
+1. `kubectl get pods -n tandoor` — if pod is CrashLoopBackOff, check logs.
+2. If pod is Running but 502 persists: `kubectl rollout restart deployment/tandoor -n tandoor`.
+3. Verify ingress controller picked up endpoints: ingress controller logs should show no `no endpointslices for service tandoor` warnings.
+4. If needed: `flux reconcile kustomization apps --with-source`.
+
+## After GitOps fix
+
+```bash
+flux reconcile kustomization apps --with-source
+kubectl rollout restart deployment/tandoor -n tandoor
+```
+
+Browser: hard refresh or clear cookies, then open **https://rezepte.f4mily.net** (not HTTP, not cluster domain).

--- a/infrastructure/base/backup/kustomization.yaml
+++ b/infrastructure/base/backup/kustomization.yaml
@@ -4,4 +4,4 @@ resources:
   - namespace.yaml
   - velero-credentials.secret.yaml
   - helmrelease.yaml
-  - vmservicescrape.yaml
+  # vmservicescrape.yaml — applied from apps/monitoring after VM operator CRDs exist

--- a/infrastructure/base/network/ingress/kustomization.yaml
+++ b/infrastructure/base/network/ingress/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - helmrelease.yaml
-  - servicemonitor.yaml
+  # servicemonitor.yaml (VMServiceScrape) — applied from apps/monitoring after VM operator CRDs exist


### PR DESCRIPTION
- Add nginx.org/client-max-body-size: 512M (matches internal Tandoor limit)\n- Add nginx.org/proxy-read-timeout: 300s and proxy-send-timeout: 300s\n- Remove unused STATIC_CDN=1 env var\n- Add 502 diagnosis section to CSRF runbook