### PR TITLE
fix(tandoor): ingress timeout/body-size annotations, remove unused STATIC_CDN

### DIFF
--- a/apps/base/tandoor/deployment.yaml
+++ b/apps/base/tandoor/deployment.yaml
@@ -64,8 +64,6 @@ spec:
             # Built-in container nginx + cluster ingress nginx
             - name: ALLAUTH_TRUSTED_PROXY_COUNT
               value: "2"
-            - name: STATIC_CDN
-              value: "1"
             - name: EMAIL_HOST
               value: mail.f4mily.net
             - name: EMAIL_PORT

--- a/apps/base/tandoor/ingress.yaml
+++ b/apps/base/tandoor/ingress.yaml
@@ -13,6 +13,10 @@ metadata:
     gethomepage.dev/pod-selector: app=tandoor
     nginx.org/ssl-redirect: "false"
     nginx.org/redirect-to-https: "true"
+    # Match Tandoor internal client_max_body_size (512M in Recipes.conf)
+    nginx.org/client-max-body-size: "512M"
+    nginx.org/proxy-read-timeout: "300s"
+    nginx.org/proxy-send-timeout: "300s"
 spec:
   ingressClassName: nginx
   tls:

--- a/docs/runbooks/tandoor-csrf.md
+++ b/docs/runbooks/tandoor-csrf.md
@@ -37,6 +37,41 @@ Expected env:
 | Stale cookies after `SECRET_KEY` or domain change | Clear site data for `rezepte.f4mily.net` / `recipes.f4mily.net`, retry in private window |
 | DNS still on old Docker host (`192.168.10.244`) | `dig rezepte.f4mily.net` → **192.168.10.245** (Talos VIP) |
 
+
+## Diagnosis: 502 Bad Gateway
+
+### Symptom
+502 when accessing `https://rezepte.f4mily.net`.
+
+### Quick checks
+
+```bash
+# Check if tandoor pod is running
+kubectl get pods -n tandoor
+
+# Check if endpoints exist for the service
+kubectl get endpoints tandoor -n tandoor
+
+# Check ingress controller endpoint state (look for tandoor errors)
+kubectl logs -n ingress-nginx -l app.kubernetes.io/name=nginx-ingress --tail=50 2>&1 | grep -i tandoor
+```
+
+### Common causes
+
+| Cause | Fix |
+|-------|-----|
+| Pod restarting / not ready (endpoints missing) | `kubectl rollout restart deployment/tandoor -n tandoor`; wait for Ready |
+| Ingress controller not updated after pod restart | Flux reconciles automatically within interval, or `flux reconcile kustomization apps --with-source` |
+| `nginx.org/proxy-set-headers` on Tandoor Ingress | Known to break upstream routing -> 502 (PR #184). Do not add. |
+| Wrong service targetPort | Service `tandoor` port 80 -> targetPort 8080 (matches TANDOOR_PORT) |
+| Pod OOM / resource limit | Check `kubectl top pods -n tandoor`; limit is 3Gi memory |
+
+### Resolution
+1. `kubectl get pods -n tandoor` -- if pod is CrashLoopBackOff, check logs.
+2. If pod is Running but 502 persists: `kubectl rollout restart deployment/tandoor -n tandoor`.
+3. Verify ingress controller picked up endpoints: ingress controller logs should show no `no endpointslices for service tandoor` warnings.
+4. If needed: `flux reconcile kustomization apps --with-source`.
+
 ## After GitOps fix
 
 ```bash


### PR DESCRIPTION
- Add nginx.org/client-max-body-size: 512M (matches internal Tandoor limit)\n- Add nginx.org/proxy-read-timeout: 300s and proxy-send-timeout: 300s\n- Remove unused STATIC_CDN=1 env var\n- Add 502 diagnosis section to CSRF runbook