### PR TITLE
fix(gatus): persist uptime history in SQLite on PVC

### DIFF
--- a/apps/base/gatus/README.md
+++ b/apps/base/gatus/README.md
@@ -12,4 +12,18 @@ Gatus nutzt `strategy: Recreate` statt RollingUpdate.
 
 ## Persistence
 
-SQLite-DB auf `truenas-iscsi` (RWO). History bleibt über Pod-Neustarts erhalten. Bei `Recreate`-bedingtem kurzzeitigem Downtime gibt's keinen Deadlock.
+Helm `persistence.enabled: true` legt ein PVC unter `/data` an — **Gatus selbst** muss SQLite dort konfigurieren, sonst bleibt `storage.type: memory` (Default) und die History geht bei jedem Pod-Neustart verloren.
+
+```yaml
+persistence:
+  enabled: true
+  storageClass: truenas-iscsi  # RWO
+
+config:
+  storage:
+    type: sqlite
+    path: /data/data.db
+    caching: true
+```
+
+Siehe [Helm-Chart README](https://github.com/TwiN/helm-charts/blob/master/charts/gatus/README.md) und [Gatus Storage](https://github.com/TwiN/gatus#storage).

--- a/apps/base/gatus/helmrelease.yaml
+++ b/apps/base/gatus/helmrelease.yaml
@@ -46,6 +46,12 @@ spec:
       # Metriken für VictoriaMetrics-Scraping aktivieren
       metrics: true
 
+      # PVC mountPath ist /data — ohne storage bleibt Default "memory" (History weg nach Restart)
+      storage:
+        type: sqlite
+        path: /data/data.db
+        caching: true
+
       # UI
       ui:
         title: Cluster Status


### PR DESCRIPTION
## Summary
- Add `config.storage.type: sqlite` with `path: /data/data.db` (Helm PVC mount)
- Enable `storage.caching` for faster dashboard loads
- Document that `persistence.enabled` alone is not enough

## Root cause
Gatus defaults to `storage.type: memory`. The chart mounts a PVC at `/data`, but without explicit SQLite config every pod restart wipes uptime history and events.

## Test plan
- [ ] `flux reconcile helmrelease gatus -n gatus`
- [ ] Wait for checks to run, note uptime on dashboard
- [ ] `kubectl rollout restart deployment -n gatus -l app.kubernetes.io/name=gatus`
- [ ] Uptime/history still present after restart
- [ ] `kubectl exec -n gatus deploy/gatus -- ls -la /data/data.db`

Made with [Cursor](https://cursor.com)