### PR TITLE
fix(nextcloud): cronjob failures and KubeJobFailed alerts

### DIFF
--- a/apps/base/nextcloud/helmrelease.yaml
+++ b/apps/base/nextcloud/helmrelease.yaml
@@ -47,7 +47,8 @@ spec:
         allowInsecureImages: true
     image:
       # renovate: datasource=docker depName=docker.io/library/nextcloud
-      tag: 33.0.3
+      # Chart uses tag as-is (no -apache suffix); must match apache image used by occ init containers.
+      tag: 33.0.3-apache
     ingress:
       enabled: false
     service:
@@ -425,6 +426,25 @@ spec:
       # crond sidecar requires root; use CronJob with same UID as the app pod.
       type: cronjob
       cronjob:
+        # Chart default failedJobsHistoryLimit=5 → five parallel KubeJobFailed alerts.
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 2
+        activeDeadlineSeconds: 1800
+        backoffLimit: 2
+        resources:
+          requests:
+            cpu: 50m
+            memory: 256Mi
+          limits:
+            memory: 1Gi
+        command:
+          - php
+          - -d
+          - memory_limit=512M
+          - -f
+          - /var/www/html/cron.php
+          - --
+          - --verbose
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/docs/runbooks/monitoring-stack.md
+++ b/docs/runbooks/monitoring-stack.md
@@ -84,11 +84,19 @@ kubectl wait -n monitoring --for=condition=ready pod -l app.kubernetes.io/name=v
 
 If it persists: Longhorn UI → volume for `vmsingle-*` PVC → check health; last resort detach/reattach volume or restore from backup (metrics gap).
 
-## Stale chart default alerts (KubeControllerManager*, KubeJobFailed, …)
+## Stale chart default alerts (KubeControllerManager*, ScrapePoolHasNoTargets, …)
 
-Symptom: Alerts from `runbooks.prometheus-operator.dev` despite intending to use only P0 VMRules.
+Symptom: Alerts from chart VMRules (`ScrapePoolHasNoTargets`, `KubeJobFailed`, …) despite intending to use only P0 VMRules.
 
-Cause: `defaultRules.enabled: false` is ignored by `victoria-metrics-k8s-stack` — use **`defaultRules.create: false`**. After fixing Helm values, **orphaned VMRule CRs may remain** until deleted once.
+Cause: the chart template prefers **`defaultRules.enabled`** (default `true`). Setting only `create: false` still renders chart VMRules including `ScrapePoolHasNoTargets` (`vmagent` group). After fixing Helm values, **orphaned VMRule CRs may remain** until deleted once.
+
+Git fix (both required):
+
+```yaml
+defaultRules:
+  create: false
+  enabled: false
+```
 
 One-time cleanup (keeps `homelab-platform-*` / `workload-remediation` VMRules):
 
@@ -99,7 +107,43 @@ kubectl get vmrule -n monitoring
 # Expect only homelab-platform-p0 and homelab-workload-remediation — no vm-k8s-stack-*.rules
 ```
 
-Talos: keep `kubeApiServer`, `kubeControllerManager`, `kubeScheduler`, and `kubeEtcd` scrapes disabled — control-plane Endpoints are not reliably reachable from vmagent (→ `TargetDown`, `KubeAPIInstanceUnreachable`).
+## ScrapePoolHasNoTargets (vmagent empty scrape pools)
+
+Symptom: `ScrapePoolHasNoTargets` — vmagent has a scrape job with 0 discovered targets for 30m+.
+
+Common homelab causes:
+
+| Cause | Typical `scrape_job` / pool names |
+|-------|-----------------------------------|
+| Talos control-plane scrapes disabled in Git but **orphan VMServiceScrape CRs** remain | `serviceScrape/monitoring/vm-k8s-stack-kube-controller-manager/0`, `…-kube-scheduler/0`, `…-kube-etcd/0` (often **3 alerts**) |
+| Wrong port on a Pod/Service endpoint | custom `VMPodScrape` / sidecar port with no `/metrics` |
+| Selector mismatch | `extra-scrapes` CR finds no Services/Pods |
+
+Talos: keep `kubeApiServer`, `kubeControllerManager`, `kubeScheduler`, and `kubeEtcd` **disabled** in `helmrelease.yaml` — control-plane metrics are not reachable via standard Endpoints (empty pools or `TargetDown`).
+
+Diagnose (needs cluster access):
+
+```bash
+kubectl get vmpodscrape,vmservicescrape,vmstaticscrape,vmprobe -A
+# vmagent targets UI (port-forward vmagent pod :8429)
+kubectl port-forward -n monitoring svc/vmagent-vm-k8s-stack 8429:8429
+# open http://127.0.0.1:8429/targets — search "0/0 up"
+curl -s 'http://127.0.0.1:8429/metrics' | grep 'vm_promscrape_scrape_pool_targets{.*} 0$' || true
+curl -sG 'http://127.0.0.1:8429/api/v1/query' --data-urlencode \
+  'query=sum(vm_promscrape_scrape_pool_targets) without(status,instance,pod) == 0'
+```
+
+Remove orphan Talos control-plane scrapes (after Git has them `enabled: false`):
+
+```bash
+kubectl get vmservicescrape -n monitoring -o name | grep -E 'kube-(api-server|controller-manager|scheduler|etcd)|kube-proxy' || true
+kubectl delete vmservicescrape -n monitoring \
+  vm-k8s-stack-kube-controller-manager \
+  vm-k8s-stack-kube-scheduler \
+  vm-k8s-stack-kube-etcd \
+  vm-k8s-stack-kube-api-server 2>/dev/null || true
+flux reconcile helmrelease vm-k8s-stack -n monitoring
+```
 
 If `KubeJobFailed` persists **after** VMRule cleanup, check real Jobs (not monitoring noise):
 
@@ -108,6 +152,8 @@ kubectl get jobs -A --field-selector status.successful!=1
 kubectl logs -n nextcloud job/<name>
 kubectl logs -n renovate job/<name>
 ```
+
+**Nextcloud:** five alerts often = five retained failed CronJob runs (`failedJobsHistoryLimit: 5`). See [nextcloud-cronjob-failed.md](nextcloud-cronjob-failed.md).
 
 ## Flux
 

--- a/docs/runbooks/nextcloud-cronjob-failed.md
+++ b/docs/runbooks/nextcloud-cronjob-failed.md
@@ -1,0 +1,52 @@
+# Nextcloud CronJob failed (KubeJobFailed)
+
+## Symptom
+
+`KubeJobFailed` for namespace `nextcloud`, often **five** alerts at once.
+
+## Why five alerts?
+
+The Nextcloud Helm chart sets `cronjob.cronjob.failedJobsHistoryLimit: 5` by default. Each failed CronJob run leaves a Job object; Prometheus fires one alert per failed Job (`kube_job_failed > 0`).
+
+Homelab sets `failedJobsHistoryLimit: 1` in `apps/base/nextcloud/helmrelease.yaml`.
+
+## Quick checks
+
+```bash
+kubectl get cronjob,jobs -n nextcloud
+kubectl get jobs -n nextcloud --field-selector status.successful!=1
+kubectl logs -n nextcloud job/$(kubectl get jobs -n nextcloud -o name | tail -1 | cut -d/ -f2)
+kubectl describe job -n nextcloud <job-name>
+```
+
+CronJob name is usually `nextcloud-cron` (release name + `-cron`).
+
+## Common causes
+
+| Cause | Fix |
+|-------|-----|
+| Stale **chart** `KubeJobFailed` VMRule (not real jobs) | `./scripts/monitoring/purge-chart-vmrules.sh monitoring` — see [monitoring-stack.md](monitoring-stack.md) |
+| Wrong image tag (`33.0.3` without `-apache`) | Use `image.tag: 33.0.3-apache` in HelmRelease |
+| Cron OOM / timeout on large NFS tree | Raise `cronjob.cronjob.resources.limits.memory`; `php -d memory_limit=512M` in command |
+| Stale `.cron.lock` on NFS after killed pod | `kubectl exec -n nextcloud deploy/nextcloud -- rm -f /var/www/html/data/.cron.lock` (if present) |
+| `maintenance:mode` still on | `kubectl exec -n nextcloud deploy/nextcloud -- php occ maintenance:mode --off` |
+| Postgres/Redis unreachable from cron pod | Check CNPG + `nextcloud-redis-master`; same env as app via chart `nextcloud.env` |
+
+## Clear alerts after fix
+
+Failed Job objects must be deleted (or succeed on next run) for `kube_job_failed` to clear:
+
+```bash
+kubectl delete jobs -n nextcloud -l app.kubernetes.io/component=cronjob
+flux reconcile helmrelease nextcloud -n nextcloud
+```
+
+## Verify
+
+```bash
+kubectl create job -n nextcloud nextcloud-cron-manual --from=cronjob/nextcloud-cron
+kubectl logs -n nextcloud job/nextcloud-cron-manual -f
+kubectl wait -n nextcloud --for=condition=complete job/nextcloud-cron-manual --timeout=600s
+```
+
+Expected: Job completes, log shows cron tasks without fatal errors.


### PR DESCRIPTION
## Summary
- Configure Nextcloud Helm CronJob: `33.0.3-apache`, PHP memory limit, resources, `failedJobsHistoryLimit: 1`
- Add runbook `docs/runbooks/nextcloud-cronjob-failed.md`
- Link from monitoring-stack runbook

## Root cause
`KubeJobFailed` fires once per failed Job object. Chart default keeps **5** failed CronJob runs (`failedJobsHistoryLimit: 5`) → five alerts. Cron jobs likely fail (image tag without `-apache`, OOM on NFS cron, etc.).

## Test plan
- [ ] `flux reconcile helmrelease nextcloud -n nextcloud`
- [ ] `kubectl delete jobs -n nextcloud -l app.kubernetes.io/component=cronjob`
- [ ] Manual cron: `kubectl create job -n nextcloud test-cron --from=cronjob/nextcloud-cron`
- [ ] Confirm `KubeJobFailed` clears (or purge stale chart VMRules if no real jobs)

Made with [Cursor](https://cursor.com)