### PR TITLE
fix(monitoring): remove blackbox probes for disabled apps

### DIFF
--- a/apps/base/monitoring/extra-scrapes/blackbox-vmprobe.yaml
+++ b/apps/base/monitoring/extra-scrapes/blackbox-vmprobe.yaml
@@ -29,7 +29,6 @@ spec:
         - https://search.f4mily.net
         - https://teslamate.f4mily.net
         - https://bookmarks.f4mily.net
-        - https://linkwarden.f4mily.net
         - https://readeck.f4mily.net
         - https://fitness.f4mily.net
         - https://nc.f4mily.net
@@ -39,7 +38,5 @@ spec:
         - https://metrics.cluster.f4mily.net
         - https://n8n.cluster.f4mily.net
         - https://homer.cluster.f4mily.net
-        - https://uptime-kuma.cluster.f4mily.net
-        - https://unifi-controller.cluster.f4mily.net
         - https://watchyourlan.cluster.f4mily.net
   interval: 30s


### PR DESCRIPTION
## Summary
- Remove linkwarden, uptime-kuma, and unifi-controller from blackbox VMProbe targets (apps not deployed).

## Test plan
- [x] just validate
- [ ] EndpointDown alerts clear after reconcile


Made with [Cursor](https://cursor.com)