### PR TITLE
fix(monitoring): ScrapePoolHasNoTargets on Talos

### DIFF
--- a/KI-ALERT-PLAN.md
+++ b/KI-ALERT-PLAN.md
@@ -103,7 +103,7 @@ Siehe [`docs/integrations/grafana-authentik.md`](docs/integrations/grafana-authe
 
 | Task | Status |
 |------|--------|
-| `defaultRules.create: false` (nur P0-VMRules) | ✅ |
+| `defaultRules.create: false` + `enabled: false` (nur P0-VMRules) | ✅ |
 | Alertmanager: Default → blackhole, nur critical/warning → ntfy | ✅ |
 | längere `group_wait` / `repeat_interval` | ✅ |
 | ntfy-Bridge (`apps/base/monitoring/ntfy-bridge/`) | ✅ |
@@ -168,6 +168,7 @@ docs/runbooks/
 | Datum | Änderung |
 |-------|----------|
 | 2026-05-30 | kubeApiServer-Scrape aus; Script `purge-chart-vmrules.sh` für verwaiste VMRules |
+| 2026-06-02 | `defaultRules.enabled: false` — `create: false` allein ließ Chart-VMRules (ScrapePoolHasNoTargets) |
 | 2026-05-30 | Fix `defaultRules.create: false`; Talos control-plane scrapes aus |
 | 2026-05-30 | CNPG VMPodScrape mit namespace/pod-Relabeling; enablePodMonitor deaktiviert |
 | 2026-05-21 | Phase 1–3 implementiert, Plan angelegt |

--- a/apps/base/monitoring/vm-k8s-stack/helmrelease.yaml
+++ b/apps/base/monitoring/vm-k8s-stack/helmrelease.yaml
@@ -201,9 +201,10 @@ spec:
       enabled: true
 
     # Chart defaults (~100+ rules) are too noisy for a homelab; use platform P0 VMRules only.
-    # Note: chart uses `create`, not `enabled` — `enabled: false` has no effect.
+    # Template checks `enabled` first (chart default: true). `create: false` alone leaves ~39 rules.
     defaultRules:
       create: false
+      enabled: false
 
     # ============================================
     # GRAFANA

--- a/docs/runbooks/monitoring-stack.md
+++ b/docs/runbooks/monitoring-stack.md
@@ -84,11 +84,19 @@ kubectl wait -n monitoring --for=condition=ready pod -l app.kubernetes.io/name=v
 
 If it persists: Longhorn UI → volume for `vmsingle-*` PVC → check health; last resort detach/reattach volume or restore from backup (metrics gap).
 
-## Stale chart default alerts (KubeControllerManager*, KubeJobFailed, …)
+## Stale chart default alerts (KubeControllerManager*, ScrapePoolHasNoTargets, …)
 
-Symptom: Alerts from `runbooks.prometheus-operator.dev` despite intending to use only P0 VMRules.
+Symptom: Alerts from chart VMRules (`ScrapePoolHasNoTargets`, `KubeJobFailed`, …) despite intending to use only P0 VMRules.
 
-Cause: `defaultRules.enabled: false` is ignored by `victoria-metrics-k8s-stack` — use **`defaultRules.create: false`**. After fixing Helm values, **orphaned VMRule CRs may remain** until deleted once.
+Cause: the chart template prefers **`defaultRules.enabled`** (default `true`). Setting only `create: false` still renders chart VMRules including `ScrapePoolHasNoTargets` (`vmagent` group). After fixing Helm values, **orphaned VMRule CRs may remain** until deleted once.
+
+Git fix (both required):
+
+```yaml
+defaultRules:
+  create: false
+  enabled: false
+```
 
 One-time cleanup (keeps `homelab-platform-*` / `workload-remediation` VMRules):
 
@@ -99,7 +107,38 @@ kubectl get vmrule -n monitoring
 # Expect only homelab-platform-p0 and homelab-workload-remediation — no vm-k8s-stack-*.rules
 ```
 
-Talos: keep `kubeApiServer`, `kubeControllerManager`, `kubeScheduler`, and `kubeEtcd` scrapes disabled — control-plane Endpoints are not reliably reachable from vmagent (→ `TargetDown`, `KubeAPIInstanceUnreachable`).
+## ScrapePoolHasNoTargets (vmagent empty scrape pools)
+
+Symptom: `ScrapePoolHasNoTargets` — vmagent has a scrape job with 0 discovered targets for 30m+.
+
+Common homelab causes:
+
+| Cause | Typical `scrape_job` / pool names |
+|-------|-----------------------------------|
+| Talos control-plane scrapes disabled in Git but **orphan VMServiceScrape CRs** remain | `serviceScrape/monitoring/vm-k8s-stack-kube-controller-manager/0`, `…-kube-scheduler/0`, `…-kube-etcd/0` (often **3 alerts**) |
+| Wrong port on a Pod/Service endpoint | custom `VMPodScrape` / sidecar port with no `/metrics` |
+| Selector mismatch | `extra-scrapes` CR finds no Services/Pods |
+
+Talos: keep `kubeApiServer`, `kubeControllerManager`, `kubeScheduler`, and `kubeEtcd` **disabled** in `helmrelease.yaml` — control-plane metrics are not reachable via standard Endpoints (empty pools or `TargetDown`).
+
+Diagnose (needs cluster access):
+
+```bash
+kubectl get vmpodscrape,vmservicescrape,vmstaticscrape,vmprobe -A
+# vmagent targets UI (port-forward vmagent pod :8429)
+kubectl port-forward -n monitoring svc/vmagent-vm-k8s-stack 8429:8429
+# open http://127.0.0.1:8429/targets — search "0/0 up"
+curl -s 'http://127.0.0.1:8429/metrics' | grep 'vm_promscrape_scrape_pool_targets{.*} 0$' || true
+curl -sG 'http://127.0.0.1:8429/api/v1/query' --data-urlencode \
+  'query=sum(vm_promscrape_scrape_pool_targets) without(status,instance,pod) == 0'
+```
+
+Remove orphan Talos control-plane scrapes (after Git has them `enabled: false`):
+
+```bash
+./scripts/monitoring/purge-talos-vmservicescrapes.sh monitoring
+flux reconcile helmrelease vm-k8s-stack -n monitoring
+```
 
 If `KubeJobFailed` persists **after** VMRule cleanup, check real Jobs (not monitoring noise):
 

--- a/scripts/monitoring/purge-talos-vmservicescrapes.sh
+++ b/scripts/monitoring/purge-talos-vmservicescrapes.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Delete chart VMServiceScrapes for Talos-disabled control-plane jobs (empty scrape pools).
+# Safe after helmrelease sets kubeApiServer/kubeControllerManager/kubeScheduler/kubeEtcd enabled: false.
+set -euo pipefail
+
+NS="${1:-monitoring}"
+RELEASE="${2:-vm-k8s-stack}"
+
+names=(
+  "${RELEASE}-kube-api-server"
+  "${RELEASE}-kube-controller-manager"
+  "${RELEASE}-kube-scheduler"
+  "${RELEASE}-kube-etcd"
+  "${RELEASE}-kube-proxy"
+)
+
+echo "VMServiceScrapes in ${NS} (Talos control-plane) before cleanup:"
+kubectl get vmservicescrape -n "${NS}" -o name 2>/dev/null | grep -E 'kube-(api-server|controller-manager|scheduler|etcd)|kube-proxy' || true
+
+to_delete=()
+for n in "${names[@]}"; do
+  if kubectl get "vmservicescrape/${n}" -n "${NS}" >/dev/null 2>&1; then
+    to_delete+=("${n}")
+  fi
+done
+
+if ((${#to_delete[@]} == 0)); then
+  echo "No Talos control-plane VMServiceScrapes to delete."
+  exit 0
+fi
+
+echo "Deleting ${#to_delete[@]} VMServiceScrape(s): ${to_delete[*]}"
+kubectl delete vmservicescrape -n "${NS}" "${to_delete[@]}"
+
+echo "Reconcile HelmRelease:"
+echo "  flux reconcile helmrelease ${RELEASE} -n ${NS}"


### PR DESCRIPTION
## Summary
- Set `defaultRules.enabled: false` alongside `create: false` — chart template checks `enabled` first; `create: false` alone left ~39 chart VMRules including `ScrapePoolHasNoTargets`
- Document empty scrape pools (typical 3× Talos orphan `VMServiceScrape` for controller-manager/scheduler/etcd) and add `purge-talos-vmservicescrapes.sh`

## Test plan
- [x] `nix develop -c just validate` (helm template vm-k8s-stack: 0 VMRules with both flags)
- [ ] After merge: `flux reconcile helmrelease vm-k8s-stack -n monitoring`
- [ ] `./scripts/monitoring/purge-chart-vmrules.sh monitoring`
- [ ] `./scripts/monitoring/purge-talos-vmservicescrapes.sh monitoring`
- [ ] Confirm `ScrapePoolHasNoTargets` clears; vmagent `/targets` has no `0/0 up` pools


Made with [Cursor](https://cursor.com)