### PR TITLE
feat: add Authentik OIDC for linkding

### DIFF
--- a/apps/base/authentik/blueprints/linkding-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/linkding-oauth.configmap.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authentik-linkding-blueprint
+  namespace: authentik
+  labels:
+    app.kubernetes.io/part-of: authentik
+data:
+  linkding.yaml: |
+    version: 1
+    metadata:
+      name: Homelab Linkding OIDC
+      labels:
+        blueprints.goauthentik.io/description: OAuth2 provider and application for Linkding bookmark manager
+    entries:
+      - model: authentik_providers_oauth2.oauth2provider
+        id: linkding-provider
+        identifiers:
+          client_id: homelab-linkding
+        attrs:
+          name: Provider for Linkding
+          client_type: confidential
+          client_id: homelab-linkding
+          # Must match apps/base/linkding/linkding-authentik-oauth.secret.yaml (client-secret).
+          client_secret: homelab-linkding-change-me
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+          encryption_key: null
+          redirect_uris:
+            - matching_mode: strict
+              url: https://bookmarks.f4mily.net/oidc/callback/
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+      - model: authentik_core.application
+        identifiers:
+          slug: linkding
+        attrs:
+          name: Linkding
+          slug: linkding
+          provider: !KeyOf linkding-provider
+          launch_url: https://bookmarks.f4mily.net
+          meta_launch_url: https://bookmarks.f4mily.net

--- a/apps/base/linkding/helmrelease.yaml
+++ b/apps/base/linkding/helmrelease.yaml
@@ -21,6 +21,15 @@ spec:
         kind: HelmRepository
         name: rubxkube-repo
         namespace: flux-system
+  valuesFrom:
+    - kind: Secret
+      name: linkding-authentik-oauth
+      valuesKey: client-id
+      targetPath: common.variables.secret.OIDC_RP_CLIENT_ID
+    - kind: Secret
+      name: linkding-authentik-oauth
+      valuesKey: client-secret
+      targetPath: common.variables.secret.OIDC_RP_CLIENT_SECRET
   values:
     common:
       ingress:
@@ -35,3 +44,12 @@ spec:
       variables:
         nonSecret:
           TZ: Europe/Berlin
+          # OIDC
+          LD_ENABLE_OIDC: "True"
+          OIDC_OP_AUTHORIZATION_ENDPOINT: https://login.f4mily.net/application/o/linkding/authorize/
+          OIDC_OP_TOKEN_ENDPOINT: https://login.f4mily.net/application/o/linkding/token/
+          OIDC_OP_USER_ENDPOINT: https://login.f4mily.net/application/o/linkding/userinfo/
+          OIDC_OP_JWKS_ENDPOINT: https://login.f4mily.net/application/o/linkding/jwks/
+          OIDC_RP_SCOPES: openid profile email
+          OIDC_USERNAME_CLAIM: preferred_username
+          LD_CSRF_TRUSTED_ORIGINS: https://bookmarks.f4mily.net

--- a/apps/base/linkding/kustomization.yaml
+++ b/apps/base/linkding/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - namespace.yaml
   - helmrelease.yaml
   - ingress.yaml
+  - linkding-authentik-oauth.secret.yaml

--- a/apps/base/linkding/linkding-authentik-oauth.secret.yaml
+++ b/apps/base/linkding/linkding-authentik-oauth.secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+data:
+    client-id: ENC[AES256_GCM,data:T4N6+zR5IOe417NFGQhD054MXA+Sw1Ns,iv:75zf0pA1x6ZyD/oP60gfZfLZbLoYc2oTuA7n3lHWX9o=,tag:9uu4RF/BpyW3QY8NKzR+aw==,type:str]
+    client-secret: ENC[AES256_GCM,data:6vpLU9BxzhOHee5+oJIMSNnQo0d9U8Uy70cZJVmaCn/fRwtu1Q3ku/35/tJntjczbmCjJXA3YoH6T06+,iv:OKY788WRlEJt8YjZd2I9hBtLKjXLwdCgGY5PIBih9T0=,tag:0SpNisT5wfnanBucHuFbBA==,type:str]
+kind: Secret
+metadata:
+    name: linkding-authentik-oauth
+    namespace: linkding
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpdy9XY01xV3poTEJQNGUz
+            THkvY2I2V0RkTjg1alZqUVJyY0ZKUCt3ZlNjCjhBRDdvWUNocTE3eGdHTzZmVDBt
+            c045OUdkdXY1ajJ5Y2J5SWVrM3d3SUkKLS0tIDJzc2pKL3B4bitQdnAzWlBMYk5z
+            NWViVnRRYkZTeVNQaWhZenhUWUs5NzAKrEwAhwkXE6+OqgxHMnv0wINiwcs6ClTS
+            XLOH8Nadh4loxBMcjWP805zj6ymX4RWfbllICp8tgZyJOOFwZI6asw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1u5lcvuuwd4lk7f3xewjk70j75yuh68myr89qkd0e8d44zgyjleeqw03vqs
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-03T17:58:57Z"
+    mac: ENC[AES256_GCM,data:0QhVtuFR2DekzG2+MNR1XUi03wBHVY5l29dPMU60tC+7zZTRY/+OY0AcUq0ETY0dUIrKD41mpytZAa94t2H8CWJwmtX6pjgRXaOnLVMG/QLhcGdyX3GwladnG7YKaE18uJNvlMzoezH+XEJDhdt76BgZGfatnHZy56FLCCanmpg=,iv:ya+/1NdUHgNRdnsMhE+ewPPqtLGTWJY/CeIZDEFkqwk=,tag:eR+IUrN8SP1gyh4TMDtjnw==,type:str]
+    version: 3.13.1

--- a/apps/base/linkding/linkding-authentik-oauth.secret.yaml.template
+++ b/apps/base/linkding/linkding-authentik-oauth.secret.yaml.template
@@ -1,0 +1,7 @@
+# OAuth credentials for Linkding ↔ Authentik (application slug: linkding)
+#
+# From gitops-homelab/ with SOPS_AGE_KEY_FILE set:
+#   just linkding-authentik-oauth
+#
+# Then sync client-secret into Authentik (Provider for Linkding) if the blueprint
+# was already applied with the placeholder.

--- a/docs/integrations/linkding-authentik.md
+++ b/docs/integrations/linkding-authentik.md
@@ -1,0 +1,42 @@
+# Linkding ↔ Authentik (OIDC)
+
+Bookmark manager: `https://bookmarks.f4mily.net` — [Linkding OIDC](https://linkding.link/options/#ld_enable_oidc), [Authentik integration](https://goauthentik.io/integrations/).
+
+## GitOps
+
+| Artifact | Purpose |
+|----------|---------|
+| `apps/base/authentik/blueprints/linkding-oauth.configmap.yaml` | OAuth2 provider + application (`slug: linkding`, `client_id: homelab-linkding`) |
+| `apps/base/linkding/linkding-authentik-oauth.secret.yaml` | SOPS: `client-id`, `client-secret` (create with `just linkding-authentik-oauth`) |
+| `apps/base/linkding/helmrelease.yaml` | `common.variables.nonSecret.*` + `common.variables.secret.*` for OIDC env vars |
+
+Redirect URI (strict): `https://bookmarks.f4mily.net/oidc/callback/`
+
+Issuer URL: `https://login.f4mily.net/application/o/linkding/`
+
+## Einrichtung
+
+```bash
+# 1. SOPS secret (linkding namespace)
+just linkding-authentik-oauth
+
+# 2. Secret in kustomization eintragen (falls noch nicht):
+#    apps/base/linkding/kustomization.yaml → linkding-authentik-oauth.secret.yaml
+
+# 3. Commit, push, Flux reconcile
+flux reconcile kustomization apps -n flux-system --with-source
+flux reconcile helmrelease authentik -n authentik --timeout=10m
+flux reconcile helmrelease linkding -n linkding --timeout=5m
+```
+
+4. In **Authentik** → Provider **Provider for Linkding** → **Client secret** = Wert aus `linkding-authentik-oauth` (`client-secret`), falls Blueprint mit Platzhalter schon lief.
+
+5. Browser: `https://bookmarks.f4mily.net` → **Login with OIDC**.
+
+## Hinweise
+
+- Linkding verwendet `mozilla-django-oidc` — siehe [Dokumentation](https://mozilla-django-oidc.readthedocs.io/).
+- `OIDC_USE_PKCE=True` (default) — PKCE wird automatisch verwendet.
+- `OIDC_USERNAME_CLAIM=preferred_username` — nutzt den Authentik Username statt Email als Linkding-Username.
+- `encryption_key: null` am Provider — verschlüsselte ID-Tokens (JWE) werden von Linkding nicht unterstützt.
+- Superuser vor erstem OIDC-Login via User-Setup anlegen (Email muss mit OIDC-Provider übereinstimmen).

--- a/justfile
+++ b/justfile
@@ -148,6 +148,31 @@ nextcloud-authentik-oauth:
     echo ""
     echo "See docs/integrations/nextcloud-authentik.md"
 
+# Linkding ↔ Authentik OIDC (linkding namespace)
+linkding-authentik-oauth:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    : "${SOPS_AGE_KEY_FILE:?Set SOPS_AGE_KEY_FILE to your age private key}"
+    client_id="homelab-linkding"
+    client_secret="$(openssl rand -base64 32 | tr -d '\n')"
+    dir="apps/base/linkding"
+    cd "$dir"
+    kubectl create secret generic linkding-authentik-oauth \
+      --namespace linkding \
+      --from-literal=client-id="$client_id" \
+      --from-literal=client-secret="$client_secret" \
+      --dry-run=client -o yaml >linkding-authentik-oauth.secret.yaml
+    sops --encrypt --in-place linkding-authentik-oauth.secret.yaml
+    echo "Created: $dir/linkding-authentik-oauth.secret.yaml"
+    echo ""
+    echo "Next:"
+    echo "  1. Add linkding-authentik-oauth.secret.yaml to apps/base/linkding/kustomization.yaml"
+    echo "  2. Commit, push, flux reconcile"
+    echo "  3. In Authentik → Provider for Linkding → set Client secret to:"
+    echo "     $client_secret"
+    echo ""
+    echo "See docs/integrations/linkding-authentik.md"
+
 # Whiteboard WebSocket + AppAPI HaRP shared secrets (nextcloud namespace)
 nextcloud-collab-secrets:
     #!/usr/bin/env bash


### PR DESCRIPTION
## Summary

Add OIDC login via Authentik for linkding at `bookmarks.f4mily.net`.

## Changes

- **New**: `apps/base/authentik/blueprints/linkding-oauth.configmap.yaml` — Authentik blueprint with OAuth2 provider (`client_id: homelab-linkding`) + application slug `linkding`
- **New**: `apps/base/linkding/linkding-authentik-oauth.secret.yaml` — SOPS-encrypted secret (client-id, client-secret)
- **New**: `apps/base/linkding/linkding-authentik-oauth.secret.yaml.template`
- **New**: `docs/integrations/linkding-authentik.md`
- **Updated**: `apps/base/linkding/helmrelease.yaml` — `valuesFrom` secret, OIDC env vars (`LD_ENABLE_OIDC`, `OIDC_OP_*`, `OIDC_RP_*`, `LD_CSRF_TRUSTED_ORIGINS`)
- **Updated**: `apps/base/linkding/kustomization.yaml` — add secret resource
- **Updated**: `justfile` — `linkding-authentik-oauth` task

## OIDC Details

| Setting | Value |
|---------|-------|
| Redirect URI | `https://bookmarks.f4mily.net/oidc/callback/` |
| Endpoints base | `https://login.f4mily.net/application/o/linkding/` |
| Client ID | `homelab-linkding` |
| Scopes | `openid profile email` |
| Username claim | `preferred_username` |
| PKCE | enabled (default) |

## Setup after merge

```bash
just linkding-authentik-oauth
```

Then set the generated client-secret in Authentik → Provider for Linkding.