### PR TITLE
fix(renovate): remove negative lookahead from customManager regex

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -65,7 +65,7 @@
         "/(^|/)(apps|infrastructure|clusters)/.+\\.ya?ml$/"
       ],
       "matchStrings": [
-        "#\\s*renovate:\\s*datasource=(?<datasource>(?!custom\\.grafana-plugins)\\S+)\\s+depName=(?<depName>\\S+)(?:\\s+versioning=(?<versioning>\\S+))?(?:\\s+extractVersion=(?<extractVersion>\\S+))?\\s*\\n\\s*-\\s+[^@\\s]+@(?<currentValue>[^\\s#]+)"
+        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(?:\\s+versioning=(?<versioning>\\S+))?(?:\\s+extractVersion=(?<extractVersion>\\S+))?\\s*\\n\\s*-\\s+[^@\\s]+@(?<currentValue>[^\\s#]+)"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
     },


### PR DESCRIPTION
Fixes Renovate configuration validation error.

## Problem
Renovate reports 'Invalid regExp for customManagers' for the third customManager's matchString. The negative lookahead `(?!custom\\.grafana-plugins)` causes this validation failure.

## Fix
Remove the negative lookahead from the regex. The dedicated Grafana plugins customManager (customManager #4) already handles datasource=custom.grafana-plugins exclusively with its own matchString. There is no risk of double-matching because Renovate deduplicates dependencies with identical datasource/depName.

Closes #207