### PR TITLE
fix: tighten pod resource limits cluster-wide

### DIFF
--- a/apps/base/immich/helmrelease.yaml
+++ b/apps/base/immich/helmrelease.yaml
@@ -87,7 +87,7 @@ spec:
           cpu: 50m
           memory: 768Mi
         limits:
-          memory: 1536Mi
+          memory: 1Gi
     machine-learning:
       enabled: true
       controllers:
@@ -108,4 +108,4 @@ spec:
           cpu: 200m
           memory: 512Mi
         limits:
-          memory: 1536Mi
+          memory: 1Gi

--- a/apps/base/jellyfin/deployment.yaml
+++ b/apps/base/jellyfin/deployment.yaml
@@ -43,7 +43,7 @@ spec:
               cpu: 50m
               memory: 256Mi
             limits:
-              memory: 1536Mi
+              memory: 1Gi
           livenessProbe:
             httpGet:
               path: /health

--- a/apps/base/linkding/helmrelease.yaml
+++ b/apps/base/linkding/helmrelease.yaml
@@ -32,6 +32,10 @@ spec:
       targetPath: common.variables.secret.OIDC_RP_CLIENT_SECRET
   values:
     common:
+      deployment:
+        cpuRequest: 25m
+        memoryRequest: 128Mi
+        memoryLimit: 512Mi
       ingress:
         enabled: false
       persistence:

--- a/apps/base/tandoor/deployment.yaml
+++ b/apps/base/tandoor/deployment.yaml
@@ -143,7 +143,7 @@ spec:
               cpu: 100m
               memory: 768Mi
             limits:
-              memory: 3Gi
+              memory: 1536Mi
           securityContext:
             runAsUser: 0
             runAsNonRoot: false


### PR DESCRIPTION
Tighten memory limits and add missing resources to prevent node OOM.

## Problem
Several apps have excessive memory limits (up to 3Gi) or lack resource limits entirely, risking node instability in a resource-constrained homelab.

## Changes

| App | Before | After | Rationale |
|-----|--------|-------|-----------|
| Linkding | (no resources) | 25m/128Mi req, 512Mi limit | Lightweight bookmarking — similar to gatus |
| Tandoor | 3Gi limit | 1536Mi limit | 2x headroom over 768Mi request |
| Jellyfin | 1536Mi limit | 1Gi limit | 4x headroom over 256Mi request |
| Immich server | 1536Mi limit | 1Gi limit | 1.3x headroom over 768Mi request |
| Immich ML | 1536Mi limit | 1Gi limit | 2x headroom over 512Mi request |

## Verification
- All limits maintain at minimum 1.3x buffer over requests
- Infrastructure components unchanged (already well-provisioned)
- 40/41 files now have resources (was 39/41)

Closes #203