### PR TITLE
feat: Outline wiki deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This cluster runs a variety of self-hosted applications. Uptime is monitored via
 | [**paperless-ngx**](https://docs.paperless-ngx.com/) | Documents | ![Uptime](https://status.cluster.f4mily.net/api/v1/endpoints/documents_paperless/uptimes/30d/badge.svg) |
 | [**readeck**](https://readeck.org/) | Documents | ![Uptime](https://status.cluster.f4mily.net/api/v1/endpoints/documents_readeck/uptimes/30d/badge.svg) |
 | [**Stirling-PDF**](https://github.com/Stirling-Tools/Stirling-PDF) | Documents | ![Uptime](https://status.cluster.f4mily.net/api/v1/endpoints/documents_sterling-pdf/uptimes/30d/badge.svg) |
+| [**Outline**](https://www.getoutline.com/) | Knowledge Base | ![Uptime](https://status.cluster.f4mily.net/api/v1/endpoints/application_outline/uptimes/30d/badge.svg) |
 | [**linkding**](https://github.com/sissis-m/linkding) | Bookmarks | ![Uptime](https://status.cluster.f4mily.net/api/v1/endpoints/application_linkding/uptimes/30d/badge.svg) |
 | [**tandoor**](https://tandoor.dev/) | Recipes | ![Uptime](https://status.cluster.f4mily.net/api/v1/endpoints/application_tandoor/uptimes/30d/badge.svg) |
 | [**SparkyFitness**](https://github.com/codewithcj/SparkyFitness) | Fitness | ![Uptime](https://status.cluster.f4mily.net/api/v1/endpoints/application_fitness/uptimes/30d/badge.svg) |

--- a/apps/base/gatus/helmrelease.yaml
+++ b/apps/base/gatus/helmrelease.yaml
@@ -158,6 +158,15 @@ spec:
              - "[STATUS] == 200"
              - "[RESPONSE_TIME] < 5000"
 
+        - name: outline
+          group: application
+          url: https://outline.f4mily.net/_health
+          interval: 60s
+          client: *default-dns
+          conditions:
+             - "[STATUS] == 200"
+             - "[RESPONSE_TIME] < 5000"
+
         - name: linkding
           group: application
           url: https://bookmarks.f4mily.net

--- a/apps/base/outline/helmrelease.yaml
+++ b/apps/base/outline/helmrelease.yaml
@@ -1,0 +1,195 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: outline
+  namespace: outline
+  annotations:
+    kustomize.toolkit.fluxcd.io/depends-on: postgresql.cnpg.io/Database/cnpg-system/homelab-postgres-outline
+spec:
+  interval: 1h
+  timeout: 15m
+  chart:
+    spec:
+      chart: outline
+      version: "0.8.0"
+      sourceRef:
+        kind: HelmRepository
+        name: community-charts
+        namespace: flux-system
+  valuesFrom:
+    - kind: Secret
+      name: outline-config
+      valuesKey: secret-key
+      targetPath: secretKey
+    - kind: Secret
+      name: outline-config
+      valuesKey: utils-secret
+      targetPath: utilsSecret
+    - kind: Secret
+      name: outline-config
+      valuesKey: oidc-client-secret
+      targetPath: auth.oidc.clientSecret
+    - kind: Secret
+      name: outline-config
+      valuesKey: smtp-password
+      targetPath: smtp.password
+  values:
+    replicaCount: 1
+
+    # Service name muss anders sein als "outline" — K8s injects OUTLINE_PORT=tcp://… und bricht den Listener (502)
+    fullnameOverride: outline-app
+
+    strategy:
+      type: Recreate
+
+    image:
+      repository: outlinewiki/outline
+      tag: ""
+
+    serviceAccount:
+      create: true
+      automount: true
+
+    podSecurityContext:
+      fsGroup: 1001
+      fsGroupChangePolicy: "OnRootMismatch"
+
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+      readOnlyRootFilesystem: false
+      runAsNonRoot: true
+      runAsUser: 1001
+      runAsGroup: 1001
+
+    # Eigenes Ingress (siehe ingress.yaml)
+    ingress:
+      enabled: false
+
+    url: https://outline.f4mily.net
+    defaultLanguage: de_DE
+
+    rateLimiter:
+      enabled: true
+      limit: 1000
+      window: 60
+
+    autoUpdate:
+      enabled: false
+      telemetry: false
+
+    web:
+      concurrency: 1
+      forceHttps: true
+      skipSSLVerification: false
+
+    logging:
+      level: info
+
+    fileStorage:
+      mode: local
+      uploadMaxSize: "262144000"
+      local:
+        rootDir: /var/lib/outline/data
+        persistence:
+          enabled: true
+          accessModes:
+            - ReadWriteOnce
+          size: 5Gi
+          storageClass: truenas-iscsi
+
+    # OIDC via Authentik
+    auth:
+      oidc:
+        enabled: true
+        clientId: "nj4Pmp5zMftJEESaFBZAUmwWRbqtSBJaoKzNAmen"
+        authUri: https://login.f4mily.net/application/o/authorize/
+        tokenUri: https://login.f4mily.net/application/o/token/
+        userInfoUri: https://login.f4mily.net/application/o/userinfo/
+        logoutUri: https://login.f4mily.net/application/o/outline/end-session/
+        usernameClaim: preferred_username
+        displayName: Authentik
+        scopes:
+          - openid
+          - profile
+          - email
+
+    # SMTP
+    smtp:
+      host: mail.f4mily.net
+      port: 465
+      secure: true
+      username: outline@f4mily.net
+      fromEmail: outline@f4mily.net
+      replyEmail: outline@f4mily.net
+
+    # DB via zentrales CNPG (CloudNativePG)
+    database:
+      connectionPoolMin: ""
+      connectionPoolMax: "20"
+      sslMode: disable
+
+    postgresql:
+      enabled: false
+
+    externalPostgresql:
+      host: homelab-postgres-rw.cnpg-system.svc.cluster.local
+      port: 5432
+      database: outline
+      username: outline
+      existingSecret: homelab-postgres-outline
+      passwordSecretKey: password
+
+    # Redis — Built-in Subchart, minimale Ressourcen (Cache only, kein Persistenz nötig)
+    redis:
+      enabled: true
+      architecture: standalone
+      auth:
+        enabled: false
+      master:
+        service:
+          ports:
+            redis: 6379
+        persistence:
+          enabled: false
+        resources:
+          requests:
+            cpu: 25m
+            memory: 64Mi
+          limits:
+            memory: 128Mi
+
+    resources:
+      requests:
+        cpu: 50m
+        memory: 256Mi
+      limits:
+        memory: 768Mi
+
+    livenessProbe:
+      httpGet:
+        path: /_health
+        port: http
+      initialDelaySeconds: 30
+      periodSeconds: 30
+      timeoutSeconds: 5
+      failureThreshold: 6
+
+    readinessProbe:
+      httpGet:
+        path: /_health
+        port: http
+      initialDelaySeconds: 20
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 6
+
+    # Extra env
+    extraEnvVars:
+      NODE_ENV: production
+      PORT: "3000"
+      DEBUG: http
+      ENABLE_UPDATES: "true"
+      PGSSLMODE: disable

--- a/apps/base/outline/helmrepository.yaml
+++ b/apps/base/outline/helmrepository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: community-charts
+  namespace: flux-system
+spec:
+  interval: 24h
+  url: https://community-charts.github.io/helm-charts

--- a/apps/base/outline/ingress.yaml
+++ b/apps/base/outline/ingress.yaml
@@ -1,0 +1,38 @@
+# Public HTTPS access (public wildcard TLS).
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: outline
+  namespace: outline
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: Outline
+    gethomepage.dev/description: Knowledge base & wiki
+    gethomepage.dev/group: Documents
+    gethomepage.dev/icon: outline.png
+    gethomepage.dev/app: outline
+    nginx.org/ssl-redirect: "false"
+    nginx.org/redirect-to-https: "true"
+    # Outline verwendet SSE für Live-Updates im Editor
+    nginx.org/proxy-read-timeout: "3600s"
+    nginx.org/proxy-send-timeout: "3600s"
+    # Uploads (Bilder, Anhänge) bis 250MB
+    nginx.org/client-max-body-size: "250m"
+    nginx.org/proxy-body-size: "250m"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - outline.f4mily.net
+      secretName: wildcard-f4mily-net-tls
+  rules:
+    - host: outline.f4mily.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: outline-app
+                port:
+                  name: http

--- a/apps/base/outline/kustomization.yaml
+++ b/apps/base/outline/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helmrepository.yaml
+  - helmrelease.yaml
+  - outline-config.secret.yaml
+  - ingress.yaml

--- a/apps/base/outline/namespace.yaml
+++ b/apps/base/outline/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: outline
+  labels:
+    app.kubernetes.io/name: outline
+    app.kubernetes.io/part-of: homelab

--- a/apps/base/outline/outline-config.secret.yaml
+++ b/apps/base/outline/outline-config.secret.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+data:
+    oidc-client-secret: ENC[AES256_GCM,data:jmrXVT61q+b0lCiW0MtHjLkL+xGtnNgyS/9UOHFbfsyktbHMAGbRuXMAe7nCEJ9w/n4/rW4UjxM72fVM93D/Gx3kp2ikEt3mtJx/mshtyWTYGusZT77oxYqQrXgK0el4NMz4utcZ28OXYLdSB1Sno8jcBB4hPCKCGvSrYMF8GNUu48kfNVM39Vf635yG0CKfONrTByRzMmtF/2P1Td8fKkaYML6Ar05rqdr5tA==,iv:mnUwcVKJqfbJOgfdb5A6Cjx2K95RNKRQDb3vEMSngkk=,tag:lhHSsVjarvUO3qfwc3/d7g==,type:str]
+    secret-key: ENC[AES256_GCM,data:28ZVFfhR7rhGZUMC5A0LE9yveJIKtOMBd8R4EB1/fO1yN1igNKJ58CYCmmf/JRgl6u7gYuCLZC8s2rMJfSkWWnMiszXkTjb8zDYWOklAkgI+U/cmxNWTzQ==,iv:oq1TYHQYob7RB66Cb4lWQ9QI1dlGRY+z8rF+2vdoONk=,tag:k8yFYUKQX6D3hms6rIoxLA==,type:str]
+    smtp-password: ENC[AES256_GCM,data:8xG9pICd99xDPBUiB/e57DowKmU=,iv:xsWqsK3pK4EhO9AXifSTvkntuHt7JAtZx8/ZOdriT+4=,tag:mx5bapb1rYHcd4OInnv2Bg==,type:str]
+    utils-secret: ENC[AES256_GCM,data:TTNuFHG6wxILZltlkJpsmE457NGZbUy2TGAQUO+FFfEO49ozo/Dinyem/0TOShxsnUajIRCH27VzsqnIWzfRKqGR81MAD+Y4akCLKxKKrXg17DiaykAMbQ==,iv:aU1bSLgcyu4S/ZQmU0C6Z077e98nXz3T/CTgem114rE=,tag:uhwCELPT8xPySt6GT4TJMg==,type:str]
+kind: Secret
+metadata:
+    name: outline-config
+    namespace: outline
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMNXpuVS9vV1ExSkZibW9D
+            L2d5QTRTVUdtZFBwV1ZBbVZZNnV2aytwTW1zCjlKdnQwdURwUVFGZDNDTlJvTnRC
+            ZGVlbXhGbGs2WitRUmpobTNKZERaRDAKLS0tIEpZRVE3UHhmVTkxVm0wZlF2aTF3
+            a0xJeE1pQ3dUb1JkUUlhZU1JVk5OZGcKudaKT8yiREWX1W6qFWAdaSXyXRYhmLHp
+            Dux5ex9fr8buwsxGsRrUVz8ZYSB4aFzUz8edsncbvJ5el4kTR9m7zw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1u5lcvuuwd4lk7f3xewjk70j75yuh68myr89qkd0e8d44zgyjleeqw03vqs
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-05T22:54:46Z"
+    mac: ENC[AES256_GCM,data:jlfKhS6RtKIstj6Lav/myUPFCwLUAkIx1AwZQmLz7Y3bfzb3x3eaBHOyHoPc3pf4wMY9G8KA08H9rRNtY2LwkTrZqWFvkybKhPbGPYcIvXQfnHZNzCmo9Pdo9TKUUSfDfvESnt8rksgCDKM85/1S7lMknYVSXMwmADjdqqM5h6E=,iv:5Fxj8/oXQbWryfg4Rw2YjIauBmngl5hZydYQ+GDD0oE=,tag:abtW2csdQPcZzNHXJfjl6w==,type:str]
+    version: 3.13.1

--- a/apps/overlays/main/cluster-config.yaml
+++ b/apps/overlays/main/cluster-config.yaml
@@ -46,6 +46,7 @@ data:
   host_forgejo: git.f4mily.net
   # Staging on cluster wildcard before moving production DNS:
   host_authentik: login.f4mily.net
+  host_outline: outline.f4mily.net
   host_linkding: bookmarks.f4mily.net
   host_homepage: home.f4mily.net
   host_immich: immich.f4mily.net

--- a/apps/overlays/main/databases/kustomization.yaml
+++ b/apps/overlays/main/databases/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - goloom.yaml
   - forgejo.yaml
   - sparkyfitness.yaml
+  - outline.yaml

--- a/apps/overlays/main/databases/outline.yaml
+++ b/apps/overlays/main/databases/outline.yaml
@@ -1,0 +1,10 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: homelab-postgres-outline
+  namespace: cnpg-system
+spec:
+  name: outline
+  owner: outline
+  cluster:
+    name: homelab-postgres

--- a/apps/overlays/main/db-secrets/kustomization.yaml
+++ b/apps/overlays/main/db-secrets/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   # linkwarden disabled in apps catalog — no linkwarden namespace
   # - linkwarden-db-credentials.secret.yaml
   - tandoor-db-credentials.secret.yaml
+  - outline-db-credentials.secret.yaml
 patches:
   - target:
       kind: Secret
@@ -94,6 +95,16 @@ patches:
       - op: replace
         path: /metadata/namespace
         value: forgejo
+  - target:
+      kind: Secret
+      name: outline-db-credentials
+    patch: |
+      - op: replace
+        path: /metadata/name
+        value: homelab-postgres-outline
+      - op: replace
+        path: /metadata/namespace
+        value: outline
   - target:
       kind: Secret
       name: sparkyfitness-db-credentials

--- a/apps/overlays/main/db-secrets/outline-db-credentials.secret.yaml
+++ b/apps/overlays/main/db-secrets/outline-db-credentials.secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+data:
+    password: ENC[AES256_GCM,data:zChoBG8FpZRRdV4prEzXRIUWuEqGipRGFacAHv1u2w8oHj9rN7g50D9g1xqzdw0crq+A1O/b841+Sl2b,iv:S9QXajzGc6T2+pIn92GNh4Alccx28xK4egJ7hMxL47k=,tag:26t1nengqmA+e5DhDxALOA==,type:str]
+    username: ENC[AES256_GCM,data:Ro/MWHFWa3hkF6pH,iv:spXOfcOKwJ70kNTyEd76ss6Kz2aO8at9i8+yQ4p2sT0=,tag:/W1FIoi27GO82CtZcT8gzA==,type:str]
+kind: Secret
+metadata:
+    name: outline-db-credentials
+    namespace: cnpg-system
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBkb0ppMXBKNVI4RVhSUFZx
+            ZWhOQnJTek5GbFpCRmlWZWh2WlZ0SDY2L3dNCnczY2RHV0k3cldkQUF2QmtWeURr
+            aWRwQ0owUnB2cjdnUU5BU1NyNk5Od2cKLS0tIGdpeHYzajRFN1Qwd1Z1bXh3OFdB
+            MGwxaTBjbDlsV0ZaQ3k1UUxBQlVVNDQK7wAFG+9CtSta8O+bLsnnsL9qBFLlW1ZS
+            ZEapBsvYZJGSMPBUyJu0lgpbTDyNa0RqBW8aOHIoh5+310tlDh115w==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1u5lcvuuwd4lk7f3xewjk70j75yuh68myr89qkd0e8d44zgyjleeqw03vqs
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-05T22:55:04Z"
+    mac: ENC[AES256_GCM,data:dwx4iZf4EJa/AUW6SpKnKBvXtzYx6AeuTa41WMxPUfx/r2WVwtUdfvAcZHlFyP8OWaP1oqTIaA1wUgiGLGTxhneWo5/TUQslMbjIEByXQWgktyBXafN5ZdwDCgP7NcgTIxSGjppaSNHaNk07F996PWKA7kuuoIFhT1WKgEhhATQ=,iv:5XzHhnR4OceLLc/eIWzEkd2R18bBx2s6jQBJDSYVrEg=,tag:oxFEHEbZGaQU/MTMpIZq2A==,type:str]
+    version: 3.13.1

--- a/apps/overlays/main/kustomization.yaml
+++ b/apps/overlays/main/kustomization.yaml
@@ -23,6 +23,7 @@ resources:
   - paperless-ngx-integrations.secret.yaml
 
   # --- Media & Documents ------------------------------------------------
+  - ../../base/outline
   - ../../base/audiobookshelf
   - ../../base/jellyfin
   - ../../base/kavita
@@ -77,6 +78,16 @@ resources:
 # ============================================================================
 replacements:
   # -------- Per-app hostnames (full-value replacement) ----------------------
+  - source:
+      kind: ConfigMap
+      name: homelab-cluster-config
+      fieldPath: data.host_outline
+    targets:
+      - select: {kind: Ingress, name: outline}
+        fieldPaths:
+          - spec.rules.0.host
+          - spec.tls.0.hosts.0
+
   - source:
       kind: ConfigMap
       name: homelab-cluster-config
@@ -301,6 +312,8 @@ replacements:
       name: homelab-cluster-config
       fieldPath: data.publicTlsSecret
     targets:
+      - select: {kind: Ingress, name: outline}
+        fieldPaths: [spec.tls.0.secretName]
       - select: {kind: Ingress, name: audiobookshelf}
         fieldPaths: [spec.tls.0.secretName]
       - select: {kind: Ingress, name: forgejo}

--- a/docs/migrations/outline-docker-to-kubernetes.md
+++ b/docs/migrations/outline-docker-to-kubernetes.md
@@ -1,0 +1,145 @@
+# Outline: Docker (production) → Kubernetes
+
+Migrate the production Outline stack (Docker Compose on dedicated host) to the homelab
+cluster (Flux HelmRelease, CloudNativePG `homelab-postgres`, iSCSI PVC).
+
+**Source reference:** `Migration/outline_ea/compose.yaml`, `Migration/outline_ea/env`
+
+**Target:** `apps/base/outline/`, `homelab-infrastructure/dns/servers.tf` (`outline` on
+`module.talos_cluster` VIP **192.168.10.245**).
+
+## Architecture comparison
+
+| Component | Docker (production) | Kubernetes (homelab) |
+|-----------|---------------------|----------------------|
+| App | `outlinewiki/outline` (Traefik `outline.f4mily.net`) | HelmRelease `outline` — Community Chart 0.8.0 |
+| DB | `postgres:16` – `outline` / `user` | CNPG `homelab-postgres` — DB `outline` / role `outline` |
+| Redis | `redis` standalone | Built-in Bitnami Redis subchart (no persistence) |
+| Uploads | `./storage-data/uploads` auf Docker-Host | PVC `outline-app` → `truenas-iscsi` 5Gi RWO |
+| Ingress | Traefik `outline.f4mily.net` | NGINX `outline.f4mily.net` (wildcard TLS) |
+| Auth | OIDC via Authentik | Same (OIDC config in HelmRelease values) |
+| SMTP | `mail.f4mily.net:465` | Same |
+
+## Prerequisites
+
+- [ ] Export under repo root `Migration/outline_ea/` (`database-data/`, `storage-data/uploads/`).
+- [ ] Cluster: `kubectl get database -n cnpg-system homelab-postgres-outline`
+- [ ] Dev shell: `nix develop` (`kubectl`, `pg_dump`, `pg_restore`, `flux`)
+- [ ] SOPS-encrypted Secrets erstellt (siehe Phase 0)
+- [ ] DNS `outline.f4mily.net` → cluster ingress (**192.168.10.245**), nicht alter Docker-Host
+- [ ] Maintenance window (Outline offline während DB-Import)
+
+## Phase 0 — SOPS secrets
+
+### 1. App-Secrets (SECRET_KEY, UTILS_SECRET, OIDC, SMTP)
+
+Die Werte stehen in `Migration/outline_ea/env`.
+
+```bash
+cd apps/base/outline
+# 1. Template mit den Werten aus env befüllen (bereits erledigt)
+# 2. Mit SOPS verschlüsseln:
+sops --encrypt --age $(cat $SOPS_AGE_KEY_FILE.pub) outline-config.secret.yaml.template > outline-config.secret.yaml
+# 3. Template NICHT committen
+```
+
+### 2. DB-Credentials
+
+Nachdem der CNPG `Database` CR (in `apps/overlays/main/databases/outline.yaml`) deployed ist,
+generiert CNPG automatisch einen Secret mit Username/Password. Diesen müssen wir in die
+SOPS-verschlüsselte `outline-db-credentials.secret.yaml` übernehmen:
+
+```bash
+# 1. Nach Flux-Sync das CNPG-generierte Secret holen:
+kubectl get secret -n cnpg-system homelab-postgres-outline -o jsonpath='{.data.password}' | base64 -d
+
+# 2. Ausgabe kopieren
+# 3. SOPS-Secret entschlüsseln und Passwort ersetzen:
+cd apps/overlays/main/db-secrets
+sops outline-db-credentials.secret.yaml   # öffnet Editor
+# → password Wert durch das CNPG-Passwort ersetzen, speichern + schließen
+```
+
+## Phase 1 — Database export from Migration PGDATA
+
+Die alte PostgreSQL 16-Installation hat ihre Daten in `Migration/outline_ea/database-data/`.
+
+```bash
+REPO_ROOT=/home/sebastian/git/git.f4mily.net/homelab
+PGDATA="$REPO_ROOT/Migration/outline_ea/database-data"
+OUT="$REPO_ROOT/Migration/outline.dump"
+
+docker run --rm \
+  -v "$PGDATA:/var/lib/postgresql/data:ro" \
+  -e PGDATA=/var/lib/postgresql/data \
+  postgres:16 \
+  sh -c 'pg_ctl -D /var/lib/postgresql/data -o "-c listen_addresses=" start -w && \
+    pg_dump -U user -Fc --no-owner --no-acl outline > /tmp/outline.dump && \
+    pg_ctl -D /var/lib/postgresql/data stop -m fast' \
+  && docker cp "$(docker ps -lq):/tmp/outline.dump" "$OUT"
+```
+
+Verify:
+
+```bash
+pg_restore -l "$OUT" | head -20
+ls -lh "$OUT"
+```
+
+## Phase 2 — Restore in CNPG
+
+Die CNPG-Datenbank läuft auf `homelab-postgres-rw.cnpg-system.svc.cluster.local`.
+
+```bash
+# 1. Port-Forward zum CNPG-Cluster:
+kubectl port-forward -n cnpg-system service/homelab-postgres-rw 5432:5432 &
+
+# 2. Passwort aus dem CNPG-Secret holen:
+PGPASSWORD=$(kubectl get secret -n cnpg-system homelab-postgres-outline -o jsonpath='{.data.password}' | base64 -d)
+
+# 3. Restore:
+pg_restore -h localhost -U outline -d outline --no-owner --no-acl -v "$OUT"
+
+# 4. Verbindung testen:
+PGPASSWORD="$PGPASSWORD" psql -h localhost -U outline -d outline -c "\dt"
+```
+
+**Wichtig:** `--no-owner` und `--no-acl` weil der CNPG `outline`-Role eine andere OID hat
+als der alte Docker-Postgres-User.
+
+## Phase 3 — Uploads auf PVC kopieren
+
+```bash
+# PVC ist nach HelmRelease-Deployment vorhanden
+kubectl get pvc -n outline
+
+# Pod identifizieren:
+POD=$(kubectl get pods -n outline -l app.kubernetes.io/name=outline -o jsonpath='{.items[0].metadata.name}')
+
+# Migration uploads in den PVC kopieren:
+kubectl cp "$REPO_ROOT/Migration/outline_ea/storage-data/uploads/." "$POD:/var/lib/outline/data/uploads/"
+```
+
+## Phase 4 — DNS und Go-Live
+
+```bash
+# 1. DNS-Eintrag für outline.f4mily.net prüfen/aktualisieren:
+#    homelab-infrastructure/dns/servers.tf → module.talos_cluster
+#    Hostname muss auf 192.168.10.245 (VIP) zeigen, nicht auf alten Docker-Host.
+cd "$REPO_ROOT/../homelab-infrastructure"
+nix develop .#tofu
+cd dns
+just dns::plan
+
+# 2. Wenn DNS-Umstellung nötig: just dns::apply
+
+# 3. Outline testen: https://outline.f4mily.net
+```
+
+## Rollback
+
+Falls etwas schiefgeht:
+
+1. Outline deaktivieren: `apps/overlays/main/kustomization.yaml` — `../../base/outline` auskommentieren
+2. Flux sync: `flux reconcile kustomization apps --with-source`
+3. Alte Docker-Compose-Instanz wieder starten


### PR DESCRIPTION
### Outline wiki

HelmRelease deployment via community-charts/outline v0.8.0.

### Changes
- New `apps/base/outline/` — namespace, HelmRepository, HelmRelease, ingress, SOPS-encrypted config
- CNPG Database CR + DB credentials secret (SOPS-encrypted)
- Ingress: outline.f4mily.net (public TLS), proxy-read-timeout for SSE
- Old uploads path preserved via 5Gi truenas-iscsi PVC
- Gatus health endpoint + migration doc

### Post-merge steps (see migration doc)
1. DNS: apply in homelab-infrastructure
2. Extract CNPG password → update SOPS db-secret
3. pg\_dump from old database-data/ → restore to CNPG
4. Copy uploads to PVC
5. Wait for Flux reconciliation