### PR TITLE
fix(outline): remove duplicate extraEnvVars

### DIFF
--- a/apps/base/outline/helmrelease.yaml
+++ b/apps/base/outline/helmrelease.yaml
@@ -186,10 +186,4 @@ spec:
       timeoutSeconds: 5
       failureThreshold: 6
 
-    # Extra env
-    extraEnvVars:
-      NODE_ENV: production
-      PORT: "3000"
-      DEBUG: http
-      ENABLE_UPDATES: "true"
-      PGSSLMODE: disable
+


### PR DESCRIPTION
Chart community-charts/outline v0.8.0 already sets `NODE_ENV`, `PORT`, `ENABLE_UPDATES`, `PGSSLMODE` from its own values (e.g. `service.port`, `autoUpdate.enabled`, `database.sslMode`). `extraEnvVars` created duplicate entries -> HelmRelease install failed.