### PR TITLE
fix(outline): add infrastructure DB credential for CNPG role creation

### DIFF
--- a/apps/base/outline/helmrelease.yaml
+++ b/apps/base/outline/helmrelease.yaml
@@ -154,12 +154,12 @@ spec:
             redis: 6379
         persistence:
           enabled: false
-        resources:
-          requests:
-            cpu: 25m
-            memory: 64Mi
-          limits:
-            memory: 128Mi
+      resources:
+        requests:
+          cpu: 25m
+          memory: 64Mi
+        limits:
+          memory: 128Mi
 
     resources:
       requests:
@@ -185,5 +185,3 @@ spec:
       periodSeconds: 10
       timeoutSeconds: 5
       failureThreshold: 6
-
-

--- a/apps/overlays/main/db-secrets/outline-db-credentials.secret.yaml
+++ b/apps/overlays/main/db-secrets/outline-db-credentials.secret.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
-    password: ENC[AES256_GCM,data:zChoBG8FpZRRdV4prEzXRIUWuEqGipRGFacAHv1u2w8oHj9rN7g50D9g1xqzdw0crq+A1O/b841+Sl2b,iv:S9QXajzGc6T2+pIn92GNh4Alccx28xK4egJ7hMxL47k=,tag:26t1nengqmA+e5DhDxALOA==,type:str]
-    username: ENC[AES256_GCM,data:Ro/MWHFWa3hkF6pH,iv:spXOfcOKwJ70kNTyEd76ss6Kz2aO8at9i8+yQ4p2sT0=,tag:/W1FIoi27GO82CtZcT8gzA==,type:str]
+    password: ENC[AES256_GCM,data:KtMcZUlor7O/Jea4BheXSLp7TIdmpwU9LrEmEyugIDU=,iv:TZ0Ai+6CRjATkjXJS/7WszdltSEJQeN0fsa/QfvAHTE=,tag:GaG0BmXpyMKROVTs8O9QSA==,type:str]
+    username: ENC[AES256_GCM,data:obPnwDbtFY6aUqS3,iv:DBjecbafC/Vv2PHiqF/VjQ7aNgIoCffnpNnAa6cv8H0=,tag:qnx+/RVB65Jv6IoUG5udWg==,type:str]
 kind: Secret
 metadata:
     name: outline-db-credentials
@@ -10,14 +10,14 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBkb0ppMXBKNVI4RVhSUFZx
-            ZWhOQnJTek5GbFpCRmlWZWh2WlZ0SDY2L3dNCnczY2RHV0k3cldkQUF2QmtWeURr
-            aWRwQ0owUnB2cjdnUU5BU1NyNk5Od2cKLS0tIGdpeHYzajRFN1Qwd1Z1bXh3OFdB
-            MGwxaTBjbDlsV0ZaQ3k1UUxBQlVVNDQK7wAFG+9CtSta8O+bLsnnsL9qBFLlW1ZS
-            ZEapBsvYZJGSMPBUyJu0lgpbTDyNa0RqBW8aOHIoh5+310tlDh115w==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBIVFR2bFJKQ1pNVEM4S0ts
+            K3Y5aGVpTjZVMTNDNDE5d1I1SStXbHFTdHl3ClRFT01Ma2dLRXNLMHhubWM2elJ0
+            NS9pQkY4aENXbXRvRm9NSVlPOHZBVVUKLS0tIGZlVlZVVXJqb1k4ZTVqUlFDelhz
+            a3lZa20wQ0FISWx2WEhsS1B1MHU4c1kKzk5YT/pSqI2hH5Dlo0QISTBfzZP99KDc
+            RKwspEpuk6ZgNyj+fa7Qq6zUmviItCMYgfXZiyKxl1VxrmDHQsA5zQ==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1u5lcvuuwd4lk7f3xewjk70j75yuh68myr89qkd0e8d44zgyjleeqw03vqs
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-06-05T22:55:04Z"
-    mac: ENC[AES256_GCM,data:dwx4iZf4EJa/AUW6SpKnKBvXtzYx6AeuTa41WMxPUfx/r2WVwtUdfvAcZHlFyP8OWaP1oqTIaA1wUgiGLGTxhneWo5/TUQslMbjIEByXQWgktyBXafN5ZdwDCgP7NcgTIxSGjppaSNHaNk07F996PWKA7kuuoIFhT1WKgEhhATQ=,iv:5XzHhnR4OceLLc/eIWzEkd2R18bBx2s6jQBJDSYVrEg=,tag:oxFEHEbZGaQU/MTMpIZq2A==,type:str]
+    lastmodified: "2026-06-06T06:44:46Z"
+    mac: ENC[AES256_GCM,data:mQt1Ir1/91dF4CIuGq/B1UHTrBBiWIWLQVIYQwajAJ7NT+bjfF3mSShJMzQDaCpJuQYEfsedQRfCGeSXgRxC/1+jKOqn1CJH/iAbWKvX4d8Ppvb6Sj/V05Cl14NiyZ4MtbvDm39JYRvtGwBfN0Y9labTnJCnVRily8o9DLDioSA=,iv:oyrfSpFy0DzvbZG9A2dDBHq7WV9tjYATj/h1toOT+KA=,tag:VngktQBPuMWt0+/WrwMC7w==,type:str]
     version: 3.13.1

--- a/infrastructure/overlays/main/database-clusters/credentials/kustomization.yaml
+++ b/infrastructure/overlays/main/database-clusters/credentials/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - forgejo-db-credentials.secret.yaml
   - sparkyfitness-db-credentials.secret.yaml
   - sparkyfitness-app-db-credentials.secret.yaml
+  - outline-db-credentials.secret.yaml

--- a/infrastructure/overlays/main/database-clusters/credentials/outline-db-credentials.secret.yaml
+++ b/infrastructure/overlays/main/database-clusters/credentials/outline-db-credentials.secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+data:
+    password: ENC[AES256_GCM,data:Xi3DaW68lbAM0dp/PCUY9CM1g823Rk++3zXrGImb8gI=,iv:0FsGvvxxR/qdTHi3sO8gqeeUPGTAMtteOxThCtLRYYo=,tag:xv5ouzyWN8WwVoGljHzNTg==,type:str]
+    username: ENC[AES256_GCM,data:KktY+RiET0CoWRy/,iv:4u7IkU2JabuGZ0sq2Pc0WGbpEXPceKjv1nCk0lH2aI0=,tag:DOqtHr84kFcqxKjfWkTbTQ==,type:str]
+kind: Secret
+metadata:
+    name: outline-db-credentials
+    namespace: cnpg-system
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqRis0OTdZVTBuV1EwNGdt
+            ZkQ2R0ViUHdpTTNXUEZDWDMrZkxtdlZ5Sm4wCnBZcVVBTk5tbmh3ZlVUZDhteGZO
+            SmJrNjM1VkNqRzdidHRDSzVmcXMxOFUKLS0tICswR21jTkRXRCs5RnlSYzQ5NWoy
+            dG5xZkFOQVZTWTFNS29QNExMekk2WjgKv6BzOkEcombJrHmnKPMv2B500pdG9VqP
+            UCAK+jIoEkFpvfE17hC1Vded/ZELxqZkHRyL6Dk1diATR6OwcF3wFg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1u5lcvuuwd4lk7f3xewjk70j75yuh68myr89qkd0e8d44zgyjleeqw03vqs
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-06T06:43:07Z"
+    mac: ENC[AES256_GCM,data:WAwhuf9ACtZoZ+mznBgel5OQHJtZqbdbLhUQiIFpN+A9XWGAn2Y69MPy6gkKs/Jml92Y2bY655ysM3K07x5ZjIT+aFr2GUpV0zUIiryU4qV+8QUj23zOUBLQKpFExlH6MJI7ISIqlg1/J+3IpQ62NkCYIu4pjJ75myObhNkU/fU=,iv:TJrOVOHhMSazQzVI6SlfYRhHM8KqdJ7OT4+iiKTgrZg=,tag:dmFLztJbZDVVxDiBSmOIUw==,type:str]
+    version: 3.13.1


### PR DESCRIPTION
CNPG Database CR `homelab-postgres-outline` benötigt `outline-db-credentials` Secret in `cnpg-system` um die PostgreSQL-Rolle `outline` zu erstellen.

**Problem**: Das Secret existierte nur im Apps-Layer (mit Platzhalter-Passwort), nicht im Infrastructure-Layer. CNPG Database CR schlug fehl mit: `role "outline" does not exist`.

**Fix**:
- `infrastructure/overlays/main/database-clusters/credentials/outline-db-credentials.secret.yaml` neu mit echtem Passwort (SOPS-encrypted)
- Infrastructure-kustomization.yaml um neuen Eintrag ergänzt
- Apps-Layer-Secret mit selbem Passwort aktualisiert

Nach Merge: Flux sync → `outline-db-credentials` in `cnpg-system` → CNPG erstellt Role `outline` → Database CR `applied: true` → Outline Pod startet.