### PR TITLE
fix(mcp-server): use /healthz for probes instead of /mcp

### DIFF
--- a/infrastructure/base/mcp-server/deployment.yaml
+++ b/infrastructure/base/mcp-server/deployment.yaml
@@ -36,13 +36,13 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /mcp
+              path: /healthz
               port: 8080
             initialDelaySeconds: 10
             periodSeconds: 15
           readinessProbe:
             httpGet:
-              path: /mcp
+              path: /healthz
               port: 8080
             initialDelaySeconds: 5
             periodSeconds: 10


### PR DESCRIPTION
/mcp endpoint requires POST with JSON-RPC body, returns empty on GET causing probe failures. /healthz responds to GET.