### PR TITLE
fix(renovate): add docker markers for untracked images

### DIFF
--- a/apps/base/forgejo/redis.yaml
+++ b/apps/base/forgejo/redis.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
         - name: redis
           # bitnami/redis moved to bitnamilegacy; tag must be full version (7.4 does not exist)
+          # renovate: datasource=docker depName=docker.io/bitnamilegacy/redis versioning=docker
           image: docker.io/bitnamilegacy/redis:8.2.1-debian-12-r0
           env:
             - name: ALLOW_EMPTY_PASSWORD

--- a/apps/base/paperless-ngx/document-services.yaml
+++ b/apps/base/paperless-ngx/document-services.yaml
@@ -17,6 +17,7 @@ spec:
     spec:
       containers:
         - name: gotenberg
+          # renovate: datasource=docker depName=docker.io/gotenberg/gotenberg
           image: docker.io/gotenberg/gotenberg:8.7
           args:
             - gotenberg
@@ -64,6 +65,7 @@ spec:
     spec:
       containers:
         - name: tika
+          # renovate: datasource=docker depName=docker.io/apache/tika
           image: docker.io/apache/tika:latest
           ports:
             - name: http

--- a/apps/base/paperless-ngx/scanner-smb.yaml
+++ b/apps/base/paperless-ngx/scanner-smb.yaml
@@ -28,6 +28,7 @@ spec:
               subPath: paperless/consume
       containers:
         - name: samba
+          # renovate: datasource=docker depName=ghcr.io/dockur/samba
           image: ghcr.io/dockur/samba:4.22.6
           env:
             - name: NAME

--- a/apps/base/searxng/valkey-deployment.yaml
+++ b/apps/base/searxng/valkey-deployment.yaml
@@ -22,6 +22,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: valkey
+          # renovate: datasource=docker depName=docker.io/valkey/valkey versioning=docker
           image: docker.io/valkey/valkey:9.1.0-alpine
           imagePullPolicy: IfNotPresent
           args:

--- a/apps/base/teslamate/deployment-grafana.yaml
+++ b/apps/base/teslamate/deployment-grafana.yaml
@@ -23,6 +23,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: grafana
+          # renovate: datasource=docker depName=docker.io/teslamate/grafana
           image: docker.io/teslamate/grafana:latest
           imagePullPolicy: Always
           ports:

--- a/apps/base/teslamate/mosquitto.yaml
+++ b/apps/base/teslamate/mosquitto.yaml
@@ -19,6 +19,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: mosquitto
+          # renovate: datasource=docker depName=docker.io/library/eclipse-mosquitto versioning=docker
           image: docker.io/eclipse-mosquitto:2
           imagePullPolicy: IfNotPresent
           args:


### PR DESCRIPTION
## Problem

Der `kubernetes`-Manager matcht in `managerFilePatterns` nur exakt benannte `deployment|statefulset|daemonset|job|cronjob.yaml`. Präfixierte Dateinamen fallen durch → 6 Images für Renovate unsichtbar (#241).

## Fix

Generischer `# renovate: datasource=docker depName=…` Marker über jede der 6 Image-Zeilen. Greift via bestehendem `custom.regex`-Manager, kein Double-Manager-Risiko.

| Datei | Image | versioning |
|-------|-------|-----------|
| paperless-ngx/document-services.yaml | gotenberg, apache/tika | semver / – |
| paperless-ngx/scanner-smb.yaml | dockur/samba | semver |
| searxng/valkey-deployment.yaml | valkey/valkey | docker (`-alpine` suffix) |
| teslamate/deployment-grafana.yaml | teslamate/grafana | – |
| teslamate/mosquitto.yaml | eclipse-mosquitto | docker (major-only) |
| forgejo/redis.yaml | bitnamilegacy/redis | docker |

## Caveats

- `apache/tika:latest` und `teslamate/grafana:latest`: Marker macht sie sichtbar, aber `:latest` liefert kein verwertbares Version-Target → separat auf konkreten Tag pinnen (follow-up).
- `forgejo/redis` zeigt auf tote Registry (`bitnamilegacy`) → Marker wirkungslos bis Valkey-Drop-in (#243).

## Verifikation

- `just lint` ✅
- `just renovate-audit` ✅ (alle Images jetzt mit Marker)

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)