### PR TITLE
ci(renovate): rebase stale PRs onto base branch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended"
   ],
+  "rebaseWhen": "behind-base-branch",
   "nix": {
     "enabled": true
   },


### PR DESCRIPTION
## Problem

Alle 4 offenen Renovate-PRs (#236 #237 #245 #246) waren rot — nicht wegen ihrer Updates, sondern weil sie von einem alten main (`0685412`) abzweigten, der kurzzeitig eine kaputte `apps/base/gatus/helmrelease.yaml` (yamllint `461:8 syntax error`) trug. Auf main längst gefixt (`802a910`), aber Renovate hat die stale Branches nicht rebased → CI failte gegen einen bereits behobenen Fehler.

## Fix

`"rebaseWhen": "behind-base-branch"` → Renovate hält alle PRs kontinuierlich auf den aktuellen main rebased. CI validiert damit immer gegen den echten main-Stand; transiente, bereits gefixte main-Fehler hinterlassen keine roten PRs mehr.

Akut wurden die 4 PRs bereits per `update-branch` grün gezogen; dieser Change verhindert die Wiederholung.

## Verifikation

- `jq empty renovate.json` ✅
- `just validate` ✅

## Hinweis (separat)

Tiefere Ursache war, dass kaputtes YAML ~2,5h direkt auf main lag (Direkt-Push umgeht das PR-CI-Gate). Branch-Protection auf main (required check `validate`) würde das an der Wurzel verhindern — Policy-Entscheidung, nicht Teil dieses PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)