### PR TITLE
fix(readeck): track image via gitea-tags datasource

### DIFF
--- a/apps/base/readeck/deployment.yaml
+++ b/apps/base/readeck/deployment.yaml
@@ -19,7 +19,9 @@ spec:
       enableServiceLinks: false
       containers:
         - name: readeck
-          # renovate: datasource=docker depName=codeberg.org/readeck/readeck
+          # Codeberg's container registry is not reliably resolvable by Renovate's
+          # docker datasource; track the matching git tags via the Forgejo/Gitea API instead.
+          # renovate: datasource=gitea-tags depName=readeck/readeck
           image: codeberg.org/readeck/readeck:0.22.3
           imagePullPolicy: IfNotPresent
           ports:


### PR DESCRIPTION
## Problem

Renovate Dependency Dashboard:
> Failed to look up docker package `codeberg.org/readeck/readeck`: no-result

Codebergs Container-Registry verlangt für jeden Pull einen Bearer-Token und implementiert den `/v2/`-Ping nicht so, wie Renovates `docker`-Datasource es erwartet → Lookup schlägt fehl (`no-result`), obwohl Image + Tags existieren.

## Fix

Versions-Lookup von der Registry entkoppeln: Codeberg läuft auf Forgejo, und die Git-Tags entsprechen exakt den Container-Tags (`0.22.3` …). Tracking via `datasource=gitea-tags depName=readeck/readeck` (Renovate-Default-Registry für gitea-tags = codeberg.org). Image-Zeile unverändert, nur der Marker.

```diff
-# renovate: datasource=docker depName=codeberg.org/readeck/readeck
+# renovate: datasource=gitea-tags depName=readeck/readeck
 image: codeberg.org/readeck/readeck:0.22.3
```

## Verifikation

- Git-Tags via Codeberg-API geprüft: `0.22.3` == aktueller Image-Tag ✅
- `just renovate-audit` ✅ · yamllint ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)