### PR TITLE
fix(deps): pin floating image tags to concrete versions

### DIFF
--- a/apps/base/goloom/deployment.yaml
+++ b/apps/base/goloom/deployment.yaml
@@ -22,8 +22,11 @@ spec:
       #   - name: goloom-registry
       containers:
         - name: goloom
-          # renovate: datasource=docker depName=git.f4mily.net/kreativmonkey/goloon
-          image: git.f4mily.net/kreativmonkey/goloon:latest
+          # Own app image on a self-hosted Forgejo registry with no version tags.
+          # Pin to a digest so reschedules cannot silently change the running build;
+          # bump the digest on release (CI or manually). No Renovate marker: the
+          # private registry is not reliably resolvable by Renovate's docker datasource.
+          image: git.f4mily.net/kreativmonkey/goloon:latest@sha256:72273e3f5052fbd09865826e7a23fdae5b7051fdbf3893b9e1095319442657ca
           imagePullPolicy: Always
           ports:
             - containerPort: 8080

--- a/apps/base/nextcloud/appapi-harp-deployment.yaml
+++ b/apps/base/nextcloud/appapi-harp-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: appapi-harp
           # renovate: datasource=docker depName=ghcr.io/nextcloud/nextcloud-appapi-harp
-          image: ghcr.io/nextcloud/nextcloud-appapi-harp:release
+          image: ghcr.io/nextcloud/nextcloud-appapi-harp:v0.4.2
           ports:
             - name: exapps
               containerPort: 8780

--- a/apps/base/nextcloud/whiteboard-deployment.yaml
+++ b/apps/base/nextcloud/whiteboard-deployment.yaml
@@ -22,7 +22,7 @@ spec:
       containers:
         - name: whiteboard
           # renovate: datasource=docker depName=ghcr.io/nextcloud-releases/whiteboard
-          image: ghcr.io/nextcloud-releases/whiteboard:stable
+          image: ghcr.io/nextcloud-releases/whiteboard:v1.5.3
           ports:
             - name: http
               containerPort: 3002

--- a/apps/base/paperless-ngx/document-services.yaml
+++ b/apps/base/paperless-ngx/document-services.yaml
@@ -65,8 +65,8 @@ spec:
     spec:
       containers:
         - name: tika
-          # renovate: datasource=docker depName=docker.io/apache/tika
-          image: docker.io/apache/tika:latest
+          # renovate: datasource=docker depName=docker.io/apache/tika versioning=loose
+          image: docker.io/apache/tika:3.3.1.0
           ports:
             - name: http
               containerPort: 9998

--- a/apps/base/teslamate/deployment-grafana.yaml
+++ b/apps/base/teslamate/deployment-grafana.yaml
@@ -24,7 +24,7 @@ spec:
       containers:
         - name: grafana
           # renovate: datasource=docker depName=docker.io/teslamate/grafana
-          image: docker.io/teslamate/grafana:latest
+          image: docker.io/teslamate/grafana:3.0.0
           imagePullPolicy: Always
           ports:
             - containerPort: 3000

--- a/infrastructure/base/mcp-server/deployment.yaml
+++ b/infrastructure/base/mcp-server/deployment.yaml
@@ -25,7 +25,8 @@ spec:
           type: RuntimeDefault
       containers:
         - name: mcp-server
-          image: quay.io/containers/kubernetes_mcp_server:latest
+          # renovate: datasource=docker depName=quay.io/containers/kubernetes_mcp_server
+          image: quay.io/containers/kubernetes_mcp_server:v0.0.61
           args:
             - --port
             - "8080"


### PR DESCRIPTION
## Problem (#242)

`latest`/`stable`/`release` lösen bei jedem Reschedule neu auf → Version kann sich mitten im Betrieb ändern, Renovate kann nicht bumpen (Semver auf floating-Tag unmöglich).

## Fix (Hybrid)

Auf die **aktuell deployten** Versionen gepinnt (Digests aus dem laufenden Cluster ermittelt, kein Überraschungs-Upgrade):

| Image | vorher | nachher | Quelle |
|-------|--------|---------|--------|
| apache/tika | latest | `3.3.1.0` | Digest-Match ✅ |
| teslamate/grafana | latest | `3.0.0` | Digest-Match ✅ |
| kubernetes_mcp_server | latest | `v0.0.61` | neuestes Semver + Marker neu |
| whiteboard | stable | `v1.5.3` | neuestes Stable |
| nextcloud-appapi-harp | release | `v0.4.2` | neuestes Stable |
| goloon | latest | `latest@sha256:7227…` | Digest-Pin |

- tika: `versioning=loose` (4-stelliges `3.3.1.0`).
- mcp-server: Marker neu ergänzt (lag vorher ganz ohne Tracking).
- **goloon**: eigenes App-Image in self-hosted Forgejo-Registry ohne Versions-Tags → Digest-Pin statt Marker (private Registry für Renovate-docker nicht zuverlässig auflösbar, vgl. Codeberg/#249). **Trade-off:** neue goloom-Releases deployen nicht mehr automatisch — Digest bei Release bumpen (CI/manuell). Falls automatisch gewünscht: Flux image-update-automation, sag Bescheid.

## Verifikation

- `just renovate-audit` ✅ (alle Images getrackt/gepinnt)
- yamllint ✅

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)