### PR TITLE
feat(cnpg): scale postgres clusters to 3 instances for HA

### DIFF
--- a/infrastructure/overlays/main/database-clusters/cluster.yaml
+++ b/infrastructure/overlays/main/database-clusters/cluster.yaml
@@ -13,7 +13,10 @@ spec:
   # renovate: datasource=docker depName=ghcr.io/cloudnative-pg/postgresql versioning=loose
   imageName: ghcr.io/cloudnative-pg/postgresql:18.4
 
-  instances: 1
+  # HA across the 3 Talos nodes. CNPG auto-creates a minAvailable:2 PDB at >=2
+  # instances, so a node drain (system-upgrade-controller) evicts one replica at
+  # a time with failover instead of taking the database down.
+  instances: 3
 
   postgresql:
     parameters:

--- a/infrastructure/overlays/main/database-clusters/immich-postgres/cluster.yaml
+++ b/infrastructure/overlays/main/database-clusters/immich-postgres/cluster.yaml
@@ -15,7 +15,9 @@ spec:
   description: "Immich PostgreSQL with VectorChord"
   # renovate: datasource=docker depName=ghcr.io/tensorchord/cloudnative-vectorchord versioning=loose
   imageName: ghcr.io/tensorchord/cloudnative-vectorchord:16.13
-  instances: 1
+  # HA across the 3 Talos nodes; CNPG auto-creates a minAvailable:2 PDB at >=2
+  # instances so node drains evict one replica at a time with failover.
+  instances: 3
 
   postgresql:
     shared_preload_libraries:


### PR DESCRIPTION
## Problem (#240)

Beide CNPG-Cluster liefen `instances: 1`. CNPG legt dafür eine `minAvailable:1` PDB an → **ALLOWED DISRUPTIONS: 0**. Ein Node-Drain durch system-upgrade-controller blockiert damit am DB-Pod (bzw. nimmt die DB beim Evict kurz offline). Eine manuelle PDB würde das nicht verbessern.

## Fix

`homelab-postgres` und `immich-postgres` auf **`instances: 3`**. Ab 2 Instanzen erzeugt CNPG selbst eine `minAvailable:2` PDB → Drains evicten **eine** Replica nach der anderen, mit automatischem Failover. Verteilung über die 3 Talos-Nodes via vorhandener `podAntiAffinityType: preferred`.

## Auswirkung / Betrieb

- **Online scale-up**: CNPG bootstrappt 2 Replicas je Cluster (pg_basebackup), keine Downtime.
- **Storage**: 3× PVC à 10Gi je Cluster auf `truenas-iscsi` (vorher 1×). 
- **Ressourcen**: 3× requests (homelab 3×512Mi, immich 3×512Mi).
- **Grenze**: schützt vor Node-Drain/-Ausfall, **nicht** vor iSCSI-Backend-Ausfall (alle Replicas auf truenas-iscsi) — vgl. iSCSI-Outage 06/2026.

## Verifikation

- `just validate` ✅ (kustomize build + kubeconform)
- yamllint ✅
- Nach Merge prüfen: `kubectl get cluster -n cnpg-system` → 3/3 ready, `kubectl get pdb -n cnpg-system` → ALLOWED DISRUPTIONS 1.

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)