### PR TITLE
ci(renovate): restrict apache/tika to stable slim tags

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -144,6 +144,16 @@
   },
   "packageRules": [
     {
+      "description": "apache/tika: only stable 4-part numeric slim tags (no -full/-alpha/-SNAPSHOT)",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "docker.io/apache/tika"
+      ],
+      "allowedVersions": "/^\\d+\\.\\d+\\.\\d+\\.\\d+$/"
+    },
+    {
       "description": "Grafana plugins: only catalog versions; short soak before bump",
       "matchManagers": [
         "custom.regex"


### PR DESCRIPTION
## Problem

PR #251 schlug vor: `apache/tika 3.3.1.0 → 4.0.0-alpha-1.0-full` — ein Alpha-Prerelease **und** der falsche Image-Variant (`-full` statt slim). Ursache: `versioning=loose` filtert weder Prerelease- noch `-full`-Suffixe, also nahm Renovate den höchsten Tag.

## Fix

PackageRule für `docker.io/apache/tika` mit `allowedVersions: /^\d+\.\d+\.\d+\.\d+$/` → nur 4-stellige Numeric-Tags. Schließt `-alpha`, `-SNAPSHOT`, `-full` aus. Neuestes Stable = `3.3.1.0` (= aktueller Pin), Renovate proposed danach nichts Falsches mehr.

Ersetzt #251 (wird geschlossen).

## Verifikation

- `jq empty renovate.json` ✅
- `just validate` ✅
- tika-Stable-Tags geprüft: höchster 4-stelliger Numeric = `3.3.1.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)