### PR TITLE
ci(renovate): point readeck gitea-tags lookup at Codeberg

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -154,6 +154,28 @@
       "allowedVersions": "/^\\d+\\.\\d+\\.\\d+\\.\\d+$/"
     },
     {
+      "description": "readeck is hosted on Codeberg (Forgejo); gitea-tags defaults to gitea.com",
+      "matchDatasources": [
+        "gitea-tags"
+      ],
+      "matchPackageNames": [
+        "readeck/readeck"
+      ],
+      "registryUrls": [
+        "https://codeberg.org"
+      ]
+    },
+    {
+      "description": "readeck image lives on Codeberg's registry, unresolvable via docker datasource; tracked via gitea-tags instead",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "codeberg.org/readeck/readeck"
+      ],
+      "enabled": false
+    },
+    {
       "description": "Grafana plugins: only catalog versions; short soak before bump",
       "matchManagers": [
         "custom.regex"


### PR DESCRIPTION
## Problem

> Failed to look up gitea-tags package `readeck/readeck`: no-result

Die `gitea-tags`-Datasource defaultet auf **`gitea.com`** — readeck liegt aber auf **codeberg.org**. Der Marker aus #249 hatte keine `registryUrl`, und die generische Marker-Regex kann keine erfassen → Lookup auf gitea.com = no-result.

## Fix

Zwei additive packageRules (kein Deployment-Change, Marker bleibt):
- `gitea-tags` + `readeck/readeck` → `registryUrls: [https://codeberg.org]` → Lookup trifft die richtige Forgejo-API.
- `docker` + `codeberg.org/readeck/readeck` → `enabled: false` → unterdrückt einen evtl. docker-no-result vom kubernetes-Manager auf dasselbe Image.

## Verifikation

- Codeberg-API geprüft: `https://codeberg.org/api/v1/repos/readeck/readeck/tags` liefert `0.22.3` ✅
- `jq empty renovate.json` ✅ · `just validate` ✅

Refs #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)