### PR TITLE
feat(external-dns): update hetzner webhook to v1.0.0

### DIFF
--- a/infrastructure/base/network/external-dns/helmrelease.yaml
+++ b/infrastructure/base/network/external-dns/helmrelease.yaml
@@ -20,15 +20,15 @@ spec:
       webhook:
         image:
           repository: ghcr.io/mconfalonieri/external-dns-hetzner-webhook
-          tag: v0.12.1
+          tag: v1.0.0
         env:
           - name: HETZNER_API_KEY
             valueFrom:
               secretKeyRef:
                 name: hetzner-api-token
                 key: api-token
-          - name: USE_CLOUD_API
-            value: "true"
+          # USE_CLOUD_API dropped: v1.0.0 removed the legacy DNS provider,
+          # the Cloud API is now the only supported provider.
         livenessProbe:
           httpGet:
             path: /health


### PR DESCRIPTION
## Änderung

`external-dns-hetzner-webhook` `v0.12.1 → v1.0.0`.

## Kompatibilität geprüft

- v1.0.0 entfernt den **Legacy-DNS-Provider** (von Hetzner eingestellt); Cloud-API ist jetzt einzige/Default-Option.
- Setup lief bereits mit `USE_CLOUD_API: "true"` → **funktional identisch**, kein Verhaltenswechsel.
- `USE_CLOUD_API` ist nun obsolet → entfernt.
- `HETZNER_API_KEY` / Webhook-Setup unverändert.

## Verifikation

- `just validate` ✅ · yamllint ✅
- Nach Merge prüfen: external-dns-Pod Ready, `/health` ok, DNS-Records werden weiter synct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)