### PR TITLE
feat(nextcloud): upgrade to 34.0.0 (consistent, all refs)

### DIFF
--- a/apps/base/nextcloud/helmrelease.yaml
+++ b/apps/base/nextcloud/helmrelease.yaml
@@ -45,10 +45,12 @@ spec:
     global:
       security:
         allowInsecureImages: true
-    # PVC has data from 33.0.4.1 — must match to avoid downgrade error.
+    # Major upgrade 33 -> 34 (one major step, no skipping). Keep in lockstep with
+    # the occ-* init containers below; the tag must never be below the PVC's data
+    # version to avoid a downgrade error.
     # renovate: datasource=docker depName=docker.io/library/nextcloud
     image:
-      tag: 33.0.5
+      tag: 34.0.0
     ingress:
       enabled: false
     service:
@@ -169,7 +171,7 @@ spec:
 
         # renovate: datasource=docker depName=docker.io/library/nextcloud
         - name: occ-db-sync
-          image: docker.io/library/nextcloud:33.0.5-apache
+          image: docker.io/library/nextcloud:34.0.0-apache
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
@@ -322,7 +324,7 @@ spec:
 
         # renovate: datasource=docker depName=docker.io/library/nextcloud
         - name: occ-oidc-setup
-          image: docker.io/library/nextcloud:33.0.5-apache
+          image: docker.io/library/nextcloud:34.0.0-apache
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
@@ -377,7 +379,7 @@ spec:
 
         # renovate: datasource=docker depName=docker.io/library/nextcloud
         - name: occ-collab-setup
-          image: docker.io/library/nextcloud:33.0.5-apache
+          image: docker.io/library/nextcloud:34.0.0-apache
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000


### PR DESCRIPTION
## Zweck

Ersetzt den inkonsistenten Renovate-PR #258 (bumpte nur die `occ-*` Init-Container, nicht das Haupt-Image). Hier alle **4** Nextcloud-Refs gemeinsam: Haupt-`image.tag` + occ-db-sync/occ-oidc-setup/occ-collab-setup auf `34.0.0` / `34.0.0-apache`.

## ⚠️ DRAFT — bewusst noch nicht mergebereit

- Nextcloud 34 "Hub 26 Spring" erschien **2026-06-09** (~6 Tage alt), bisher nur `34.0.0`, kein Patch.
- Community meldet bereits "Frequent Nextcloud 34 update issues".
- Major-Upgrade = **DB-Migration auf Production**. Bei Merge fährt Flux das live aus.

**Empfehlung:** soaken bis `34.0.1+`, vorher Upgrade-Notes v34 + App-Kompatibilität prüfen. **Vor Merge: Backup verifizieren** (CNPG Barman + Velero), Wartungsfenster wählen.

## Pre-Merge-Checkliste

- [ ] 34.0.1+ verfügbar oder bewusste Entscheidung für 34.0.0
- [ ] v34 Release-/Upgrade-Notes gelesen
- [ ] DB-Backup frisch und wiederherstellbar
- [ ] Nextcloud-Apps 34-kompatibel (Collabora / Whiteboard / AppAPI)

## Verifikation (Code)

- `just validate` ✅ · yamllint ✅ · alle 4 Refs konsistent `34.0.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
