### PR TITLE
fix(talos-upgrade): use node IP as endpoint, not the apid Unix socket

### DIFF
--- a/infrastructure/overlays/main/system-upgrade-controller/talos-plan.yaml
+++ b/infrastructure/overlays/main/system-upgrade-controller/talos-plan.yaml
@@ -48,12 +48,14 @@ spec:
   upgrade:
     # Direct /talosctl binary: talosctl image is scratch-based (no shell).
     # $(SYSTEM_UPGRADE_PLAN_LATEST_VERSION) expanded by K8s, not shell.
-    # Connects to the local node's apid over the host Unix socket and authenticates
-    # via mTLS using the talosconfig secret (--insecure / maintenance API only works
-    # pre-boot, never on a running node).
-    # Authenticated mode (unlike --insecure) needs an explicit -n target: the
-    # talosconfig has no `nodes`, so pass the node's own IP via NODE_IP (downward
-    # API status.hostIP; the job runs hostNetwork=true on the target node).
+    # Connects to the node's own apid over TCP and authenticates via mTLS using the
+    # talosconfig secret (--insecure / maintenance API only works pre-boot, never on
+    # a running node).
+    # The job runs hostNetwork=true on the target node, so NODE_IP (downward API
+    # status.hostIP) is the local apid. We use it for BOTH the endpoint (-e) and the
+    # target node (-n): the apid serving cert is valid for the node IP, but not for
+    # "localhost" — so the Unix socket endpoint fails TLS verification in this
+    # authenticated mode (it only worked with --insecure, which skips it).
     # Keep schematic ID in sync with homelab-infrastructure/talos/cluster.auto.tfvars
     # renovate: datasource=github-releases depName=siderolabs/talos versioning=semver
     image: ghcr.io/siderolabs/talosctl:v1.13.4
@@ -67,7 +69,7 @@ spec:
     args:
       - --talosconfig=/var/run/secrets/talos.dev/talosconfig
       - -e
-      - unix:///host/system/run/apid/apid.sock
+      - $(NODE_IP)
       - -n
       - $(NODE_IP)
       - upgrade
@@ -77,8 +79,3 @@ spec:
       - --timeout=15m
     securityContext:
       privileged: true
-    volumes:
-      # apid socket: Talos API on the host node (mTLS auth via the talosconfig secret).
-      - name: apid-sock
-        source: /system/run/apid
-        destination: /host/system/run/apid


### PR DESCRIPTION
## Problem
After the `-n` fix (#269) the upgrade job got past "nodes are not set" but failed the TLS handshake:

```
tls: failed to verify certificate: x509: certificate is valid for talos-cp3, not localhost
```

talosctl verifies the apid **serving** cert against `localhost` when the endpoint is the Unix socket, but the cert is issued for the node hostname/IP. `--insecure` skipped this verification, so it only surfaced once we switched to authenticated mTLS.

## Fix
The job runs `hostNetwork: true` on the target node, so use the node's own IP over TCP for the endpoint (`-e $(NODE_IP)`) — the serving cert **is** valid for that IP (verified: `talosctl -e <ip> -n <ip> version` succeeds with the talosconfig). Drops the now-unused apid socket volume.

Third and final piece of the #268 → #269 → this chain to make the automatic Talos upgrade complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)