### PR TITLE
fix(talos-upgrade): drop exclusive:true to avoid last-node deadlock

### DIFF
--- a/infrastructure/overlays/main/system-upgrade-controller/talos-plan.yaml
+++ b/infrastructure/overlays/main/system-upgrade-controller/talos-plan.yaml
@@ -16,7 +16,11 @@ metadata:
 spec:
   # One node at a time — safe for 3-node stacked control-plane.
   concurrency: 1
-  exclusive: true
+  # No `exclusive: true`: it adds a required pod-anti-affinity against other
+  # `upgrade.cattle.io/exclusive` pods, which deadlocks the last node — the upgrade
+  # job for the node running system-upgrade-controller stays Pending, and that job
+  # is exactly what would drain/relocate the controller (circular). With a single
+  # plan and concurrency 1 the exclusivity is redundant.
   serviceAccountName: system-upgrade
   # 1h timeout: drain (10min) + talosctl upgrade + reboot + node rejoin.
   jobActiveDeadlineSecs: 3600


### PR DESCRIPTION
## Problem
On the v1.13.4 rollout the **last** node (cp1) hung: its upgrade job stayed `Pending` with `didn't satisfy existing pods anti-affinity rules`. `exclusive: true` adds a *required* pod-anti-affinity against other `upgrade.cattle.io/exclusive` pods (topologyKey `hostname`). When the last node to upgrade is the one running `system-upgrade-controller`, the job can't be scheduled there — and that job is exactly what would drain/relocate the controller, so it deadlocks (circular). It only unblocked after manually `kubectl delete pod`-ing the controller to move it off cp1.

## Fix
With a single upgrade plan and `concurrency: 1`, `exclusive` (which coordinates *multiple* exclusive plans per node) is redundant. Dropping it removes the anti-affinity, so the upgrade job schedules onto the controller's node, drains it (evicting the controller) and proceeds — no manual intervention next time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)