### PR TITLE
feat(spectrumknx): deploy KNX bus monitor at knx.cluster.f4mily.net

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ talosconfig
 
 # OpenCode session files
 ses_*
+
+# ETS project exports — location-revealing, never commit (upload via SpectrumKNX web UI)
+*.knxproj

--- a/apps/base/gatus/helmrelease.yaml
+++ b/apps/base/gatus/helmrelease.yaml
@@ -332,6 +332,15 @@ spec:
              - "[STATUS] < 400"
              - "[RESPONSE_TIME] < 5000"
 
+        - name: spectrumknx
+          group: automation
+          url: https://knx.cluster.f4mily.net
+          interval: 60s
+          client: *default-dns
+          conditions:
+             - "[STATUS] < 400"
+             - "[RESPONSE_TIME] < 5000"
+
         # ──────────────────────────────────────────────
         #  External: gleiche Endpoints, aber von extern getriggert
         # ──────────────────────────────────────────────

--- a/apps/base/spectrumknx/ingress.yaml
+++ b/apps/base/spectrumknx/ingress.yaml
@@ -1,0 +1,33 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: spectrumknx
+  namespace: spectrumknx
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: SpectrumKNX
+    gethomepage.dev/description: KNX bus monitor
+    gethomepage.dev/group: Smart Home
+    gethomepage.dev/icon: mdi-home-automation
+    gethomepage.dev/pod-selector: app=spectrumknx
+    nginx.org/ssl-redirect: "false"
+    nginx.org/redirect-to-https: "true"
+    # Real-time live monitor streams telegrams over WebSocket.
+    nginx.org/websocket-services: spectrumknx
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - knx.cluster.f4mily.net
+      secretName: wildcard-cluster-f4mily-net-tls
+  rules:
+    - host: knx.cluster.f4mily.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: spectrumknx
+                port:
+                  number: 80

--- a/apps/base/spectrumknx/kustomization.yaml
+++ b/apps/base/spectrumknx/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - spectrumknx-secret.secret.yaml
+  - timescaledb.yaml
+  - statefulset.yaml
+  - ingress.yaml

--- a/apps/base/spectrumknx/namespace.yaml
+++ b/apps/base/spectrumknx/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: spectrumknx
+  labels:
+    app.kubernetes.io/name: spectrumknx
+    app.kubernetes.io/part-of: homelab-apps

--- a/apps/base/spectrumknx/spectrumknx-secret.secret.yaml
+++ b/apps/base/spectrumknx/spectrumknx-secret.secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: spectrumknx-secret
+    namespace: spectrumknx
+type: Opaque
+stringData:
+    POSTGRES_PASSWORD: ENC[AES256_GCM,data:41NN70iyTZouvzbPb6rRBE3ULi6tTV2oOvxWgX3gNw==,iv:pNy/X4coFh4HznuIA9R4ft/p5XAm65mUx2vfOjep9RQ=,tag:eyuSPLpgS2N1zr69AI1SEw==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA3OUk3dVNUdkVpejlPWmpj
+            QlIzaEVCa1lhNkQ2Wm9waWNGbUtqbDQzY2dzCmx4U1hLazZKM0NjTXZzQVFsTXVS
+            YlZnbVBadTRCeDlUNVg2VE5sMVpMd0UKLS0tIE1jMDZZaFNrWkRIUDRvaEtVWHNs
+            Y3EwdGVlNkFaTHhLTDFGU3VUUDgxa3MKH6EbSIPmDwBY55ua7jKD4cVaRTkEjLtU
+            O6ZTmdsrEvES7A9t+ulAXIQ+oDtw3EFcZWN4ZIueNJS66OnhAcieyg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1u5lcvuuwd4lk7f3xewjk70j75yuh68myr89qkd0e8d44zgyjleeqw03vqs
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-18T20:42:44Z"
+    mac: ENC[AES256_GCM,data:V0c1HaHy/r6/4598i9cRsZZ8U9Orj7oWoTGlEfrk/w8cZRNSW8bjGBa3ovpv8KMIjXnj3EYS3b22uw61jwr4HVL2d2Lnf8fSTyGauRIHS2NpbNYoZL2zoKIu/6SnMx+U4DLjj7zF1xaJm/6tDo/e5wBM9ynE5PCxZhTQbAUQr3k=,iv:FJJwMMZtuq17rHF5o+vWDpqQ//pUGvssSc8wwOxdb7M=,tag:/JS2IQDDWNrwSB/jt/k+Bg==,type:str]
+    version: 3.13.1

--- a/apps/base/spectrumknx/spectrumknx-secret.secret.yaml.template
+++ b/apps/base/spectrumknx/spectrumknx-secret.secret.yaml.template
@@ -1,0 +1,21 @@
+# SpectrumKNX DB password (shared by the timescaledb StatefulSet and backend).
+#
+# Unencrypted shape reference. The real values live in the SOPS-encrypted
+# spectrumknx-secret.secret.yaml (encrypted_regex covers stringData).
+#
+# Re-create / rotate:
+#   cd apps/base/spectrumknx
+#   cp spectrumknx-secret.secret.yaml.template spectrumknx-secret.secret.yaml
+#   # edit POSTGRES_PASSWORD, then:
+#   just sops-encrypt spectrumknx-secret.secret.yaml
+#
+# KNX_PASSWORD is not stored here: the .knxproj is uploaded via the web UI and
+# its decryption password is entered there on first start.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: spectrumknx-secret
+  namespace: spectrumknx
+type: Opaque
+stringData:
+  POSTGRES_PASSWORD: CHANGE_ME

--- a/apps/base/spectrumknx/statefulset.yaml
+++ b/apps/base/spectrumknx/statefulset.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: spectrumknx
+  namespace: spectrumknx
+spec:
+  selector:
+    app: spectrumknx
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8000
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: spectrumknx
+  namespace: spectrumknx
+spec:
+  serviceName: spectrumknx
+  replicas: 1
+  selector:
+    matchLabels:
+      app: spectrumknx
+  template:
+    metadata:
+      labels:
+        app: spectrumknx
+    spec:
+      containers:
+        - name: spectrumknx
+          image: ghcr.io/martinhoefling/spectrumknx:latest
+          env:
+            - name: POSTGRES_USER
+              value: knxuser
+            - name: POSTGRES_DB
+              value: knx_analyzer
+            - name: POSTGRES_HOST
+              value: spectrumknx-timescaledb
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: spectrumknx-secret
+                  key: POSTGRES_PASSWORD
+            - name: LOG_LEVEL
+              value: INFO
+            # KNX_PASSWORD / KNX_PROJECT_PATH intentionally unset: the .knxproj
+            # is uploaded via the web UI on first start and persisted to /project.
+            # AUTO scans the LAN for a KNXnet/IP gateway. If multicast discovery
+            # fails across the Cilium overlay, set an explicit gateway IP here.
+            - name: KNX_GATEWAY_IP
+              value: AUTO
+          ports:
+            - name: http
+              containerPort: 8000
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8000
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8000
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 512Mi
+          volumeMounts:
+            - name: project-data
+              mountPath: /project
+  volumeClaimTemplates:
+    - metadata:
+        name: project-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: truenas-iscsi
+        resources:
+          requests:
+            storage: 1Gi

--- a/apps/base/spectrumknx/timescaledb.yaml
+++ b/apps/base/spectrumknx/timescaledb.yaml
@@ -1,0 +1,79 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: spectrumknx-timescaledb
+  namespace: spectrumknx
+spec:
+  # Headless service — stable DNS for the single StatefulSet replica.
+  clusterIP: None
+  selector:
+    app: spectrumknx-timescaledb
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: spectrumknx-timescaledb
+  namespace: spectrumknx
+spec:
+  serviceName: spectrumknx-timescaledb
+  replicas: 1
+  selector:
+    matchLabels:
+      app: spectrumknx-timescaledb
+  template:
+    metadata:
+      labels:
+        app: spectrumknx-timescaledb
+    spec:
+      securityContext:
+        # postgres user gid in the timescaledb image
+        fsGroup: 999
+      containers:
+        - name: timescaledb
+          # TimescaleDB extension required by SpectrumKNX (hypertables); stock
+          # CNPG postgres image lacks it, so this app keeps its own DB.
+          # Tag pinned by Renovate customManager / manual bump.
+          image: timescale/timescaledb:latest-pg16
+          env:
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+            - name: POSTGRES_USER
+              value: knxuser
+            - name: POSTGRES_DB
+              value: knx_analyzer
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: spectrumknx-secret
+                  key: POSTGRES_PASSWORD
+          ports:
+            - name: postgres
+              containerPort: 5432
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "knxuser", "-d", "knx_analyzer"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 1Gi
+          volumeMounts:
+            - name: timescale-data
+              mountPath: /var/lib/postgresql/data
+  volumeClaimTemplates:
+    - metadata:
+        name: timescale-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: truenas-iscsi
+        resources:
+          requests:
+            storage: 10Gi

--- a/apps/overlays/main/cluster-config.yaml
+++ b/apps/overlays/main/cluster-config.yaml
@@ -82,6 +82,7 @@ data:
   host_unifi_controller: unifi-controller.cluster.f4mily.net
   host_watchyourlan: watchyourlan.cluster.f4mily.net
   host_gatus: status.cluster.f4mily.net
+  host_spectrumknx: knx.cluster.f4mily.net
 
   # Full base URL for n8n production webhooks (trailing slash required by n8n)
   url_n8n_webhook: https://n8n.cluster.f4mily.net/

--- a/apps/overlays/main/kustomization.yaml
+++ b/apps/overlays/main/kustomization.yaml
@@ -54,6 +54,9 @@ resources:
   - ../../base/watchyourlan
   - ../../base/gatus
 
+  # --- Smart Home -------------------------------------------------------
+  - ../../base/spectrumknx
+
   # --- Development / Misc -----------------------------------------------
   - ../../base/teslamate
   - ../../base/goloom
@@ -310,6 +313,16 @@ replacements:
   - source:
       kind: ConfigMap
       name: homelab-cluster-config
+      fieldPath: data.host_spectrumknx
+    targets:
+      - select: {kind: Ingress, name: spectrumknx}
+        fieldPaths:
+          - spec.rules.0.host
+          - spec.tls.0.hosts.0
+
+  - source:
+      kind: ConfigMap
+      name: homelab-cluster-config
       fieldPath: data.publicTlsSecret
     targets:
       - select: {kind: Ingress, name: outline}
@@ -361,4 +374,6 @@ replacements:
       - select: {kind: Ingress, name: watchyourlan}
         fieldPaths: [spec.tls.0.secretName]
       - select: {kind: Ingress, name: gatus}
+        fieldPaths: [spec.tls.0.secretName]
+      - select: {kind: Ingress, name: spectrumknx}
         fieldPaths: [spec.tls.0.secretName]

--- a/docs/applications.md
+++ b/docs/applications.md
@@ -75,6 +75,7 @@ here so it is obvious what is **planned** but not deployed:
 | authentik          | on     | HelmRelease, CNPG, login.f4mily.net (production IdP)            |
 | forgejo            | on     | Deployment, NFS, git.f4mily.net (Git + CI + Renovate CronJob), SSH :22/:2222 |
 | goloom             | on     | Deployment, CNPG PostgreSQL, goloom.cluster.f4mily.net |
+| spectrumknx        | on     | StatefulSet + own TimescaleDB, KNX bus monitor, knx.cluster.f4mily.net |
 | pcm                | wip    | ingress only, missing HelmRelease         |
 
 ## 2. The config file (`apps/overlays/main/cluster-config.yaml`)


### PR DESCRIPTION
## Was

Deployt [SpectrumKNX](https://github.com/martinhoefling/SpectrumKNX) (KNX-Bus-Monitor) auf den Cluster unter `knx.cluster.f4mily.net`.

## Komponenten

- `apps/base/spectrumknx/` — StatefulSet (FastAPI Backend, Port 8000) + eigene **TimescaleDB** StatefulSet, Services, Ingress, SOPS-Secret.
- TimescaleDB bleibt app-lokal: das Hypertable-Extension fehlt im Standard-CNPG-Postgres-Image.
- Storage: `truenas-iscsi` via `volumeClaimTemplates` (DB 10Gi, Projekt-Volume 1Gi).
- `.knxproj` wird über die **Web-UI hochgeladen** (`KNX_PASSWORD`/`KNX_PROJECT_PATH` unset) → keine standort-verratende Datei im Git; `*.knxproj` ist gitignored.
- `KNX_GATEWAY_IP=AUTO` (LAN-Scan); falls Multicast über das Cilium-Overlay scheitert, explizite IP setzen.
- Ingress: WebSocket-Support (`nginx.org/websocket-services`) für den Live-Monitor, Homepage-Discovery-Labels (Gruppe **Smart Home**).

## Integration

- **Gatus**: Endpoint `spectrumknx` (Gruppe `automation`) in `apps/base/gatus/helmrelease.yaml`.
- **Homepage**: `gethomepage.dev/*` Annotations am Ingress.
- `cluster-config.yaml` + overlay-`replacements` für Host/TLS.
- `docs/applications.md` Katalog aktualisiert.

## Offen

⚠️ Ingress ist aktuell **ohne Auth** (nur internes `cluster.f4mily.net` Wildcard, wie homer/watchyourlan). Authentik-Schutz folgt separat: dieser Cluster nutzt Open-Source F5 NGINX Ingress, dessen OIDC/JWT-Policy NGINX-Plus-only ist → echtes forward-auth braucht cluster-weites `enable-snippets` + Authentik proxy-provider/embedded-outpost.

## Nach dem Merge

- ETS-Projekt via Web-UI hochladen.
- Ggf. `KNX_GATEWAY_IP` auf feste IP setzen, falls AUTO-Discovery nicht greift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)