### PR TITLE
chore(homepage): move spectrumknx to Tools, outline to Office

### DIFF
--- a/apps/base/outline/ingress.yaml
+++ b/apps/base/outline/ingress.yaml
@@ -8,7 +8,7 @@ metadata:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/name: Outline
     gethomepage.dev/description: Knowledge base & wiki
-    gethomepage.dev/group: Documents
+    gethomepage.dev/group: Office
     gethomepage.dev/icon: outline.png
     gethomepage.dev/app: outline
     nginx.org/ssl-redirect: "false"

--- a/apps/base/spectrumknx/ingress.yaml
+++ b/apps/base/spectrumknx/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
     gethomepage.dev/enabled: "true"
     gethomepage.dev/name: SpectrumKNX
     gethomepage.dev/description: KNX bus monitor
-    gethomepage.dev/group: Smart Home
+    gethomepage.dev/group: Tools
     gethomepage.dev/icon: mdi-home-automation
     gethomepage.dev/pod-selector: app=spectrumknx
     nginx.org/ssl-redirect: "false"


### PR DESCRIPTION
Homepage-Gruppen verschoben:
- SpectrumKNX: Smart Home → **Tools**
- Outline: Documents → **Office**

Nur `gethomepage.dev/group` Annotation an den jeweiligen Ingressen. Direkter Push auf main von Branch-Protection abgelehnt → PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)