### PR TITLE
fix(spectrumknx): raise ingress upload limit for knxproj imports

### DIFF
--- a/apps/base/spectrumknx/ingress.yaml
+++ b/apps/base/spectrumknx/ingress.yaml
@@ -14,6 +14,8 @@ metadata:
     nginx.org/redirect-to-https: "true"
     # Real-time live monitor streams telegrams over WebSocket.
     nginx.org/websocket-services: spectrumknx
+    # .knxproj uploads (ETS exports) run ~30MB+; lift the 1MB nginx default.
+    nginx.org/client-max-body-size: "256m"
 spec:
   ingressClassName: nginx
   tls:


### PR DESCRIPTION
Import einer `.knxproj` (~30MB) scheitert im Frontend mit `JSON.parse: unexpected character`. Ursache: F5 NGINX default `client-max-body-size` = 1MB → POST-Upload wird mit HTML-413 abgewiesen, erreicht den Pod nie (App-Log zeigt nur `GET / 200`).

Fix: `nginx.org/client-max-body-size: "256m"` am spectrumknx-Ingress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)