### PR TITLE
fix(spectrumknx): enable KNX_ROUTE_BACK for NAT'd pod tunneling

### DIFF
--- a/apps/base/spectrumknx/statefulset.yaml
+++ b/apps/base/spectrumknx/statefulset.yaml
@@ -52,6 +52,11 @@ spec:
             # Cilium overlay reliably.
             - name: KNX_GATEWAY_IP
               value: 192.168.10.20
+            # Pod sits behind Cilium masquerade (NAT); without route-back the
+            # client advertises its unroutable pod IP as the tunnel data
+            # endpoint and the gateway can't reach it.
+            - name: KNX_ROUTE_BACK
+              value: "true"
           ports:
             - name: http
               containerPort: 8000


### PR DESCRIPTION
Secure-Tunnel zum Gateway scheitert mit `Tunnel connection could not be established`: der Pod hängt hinter Cilium-Masquerade (NAT), advertised aber seine Pod-IP (10.244.x.x) als Data-Endpoint → Gateway kann sie nicht erreichen. `KNX_ROUTE_BACK=true` lässt das Gateway an die NAT-Quelladresse antworten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)