### PR TITLE
fix(spectrumknx): use TUNNELING_TCP_SECURE for KNX Secure

### DIFF
--- a/apps/base/spectrumknx/statefulset.yaml
+++ b/apps/base/spectrumknx/statefulset.yaml
@@ -57,6 +57,10 @@ spec:
             # endpoint and the gateway can't reach it.
             - name: KNX_ROUTE_BACK
               value: "true"
+            # KNX IP Secure tunneling is TCP-based per spec; UDP TUNNELING +
+            # secure cannot establish a session.
+            - name: KNX_CONNECTION_TYPE
+              value: TUNNELING_TCP_SECURE
           ports:
             - name: http
               containerPort: 8000


### PR DESCRIPTION
Tunnel scheitert weiter trotz route-back. KNX IP Secure Tunneling ist laut Spezifikation TCP-basiert; die App versuchte UDP `TUNNELING` mit `secure=yes` — unmöglich. Connection-Type explizit auf `TUNNELING_TCP_SECURE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)