### PR TITLE
chore(spectrumknx): temporary DEBUG logging

### DIFF
--- a/apps/base/spectrumknx/statefulset.yaml
+++ b/apps/base/spectrumknx/statefulset.yaml
@@ -45,7 +45,7 @@ spec:
                   name: spectrumknx-secret
                   key: POSTGRES_PASSWORD
             - name: LOG_LEVEL
-              value: INFO
+              value: DEBUG
             # KNX_PASSWORD / KNX_PROJECT_PATH intentionally unset: the .knxproj
             # is uploaded via the web UI on first start and persisted to /project.
             # Explicit gateway: multicast AUTO-discovery does not cross the


### PR DESCRIPTION
Tunnel-Diagnose: DEBUG-Logs für den xknx Secure-Handshake. Wird danach zurückgesetzt.