### PR TITLE
fix(spectrumknx): request free tunnel slot 1.1.255

### DIFF
--- a/apps/base/spectrumknx/statefulset.yaml
+++ b/apps/base/spectrumknx/statefulset.yaml
@@ -61,6 +61,11 @@ spec:
             # secure cannot establish a session.
             - name: KNX_CONNECTION_TYPE
               value: TUNNELING_TCP_SECURE
+            # Request a specific free tunnel slot; without it the gateway
+            # assigns the secure user's bound slot (1.1.253), which is occupied
+            # → E_NO_MORE_CONNECTIONS despite other slots being free.
+            - name: KNX_INDIVIDUAL_ADDRESS
+              value: 1.1.255
           ports:
             - name: http
               containerPort: 8000


### PR DESCRIPTION
Gateway weist ohne explizite Adresse den belegten Slot 1.1.253 zu → E_NO_MORE_CONNECTIONS. Fordere freien Slot 1.1.255 an.