### PR TITLE
chore(spectrumknx): revert log level to INFO

### DIFF
--- a/apps/base/spectrumknx/statefulset.yaml
+++ b/apps/base/spectrumknx/statefulset.yaml
@@ -45,7 +45,7 @@ spec:
                   name: spectrumknx-secret
                   key: POSTGRES_PASSWORD
             - name: LOG_LEVEL
-              value: DEBUG
+              value: INFO
             # KNX_PASSWORD / KNX_PROJECT_PATH intentionally unset: the .knxproj
             # is uploaded via the web UI on first start and persisted to /project.
             # Explicit gateway: multicast AUTO-discovery does not cross the


### PR DESCRIPTION
KNX-Tunnel steht (1.1.251 / user 2), Telegramme laufen. DEBUG zurück auf INFO.