### PR TITLE
feat(forgejo): enable Actions runner with resource hardening

### DIFF
--- a/apps/base/forgejo/kustomization.yaml
+++ b/apps/base/forgejo/kustomization.yaml
@@ -6,8 +6,11 @@ resources:
   - deployment.yaml
   - redis.yaml
   - comments-tmpl.configmap.yaml
-  # Runner: enable after SOPS-encrypting forgejo-runner-register.secret.yaml (see docs/migrations.md#5-first-time-deploy-fresh-app).
-  # - runner-deployment.yaml
+  # Forgejo Actions runner (see docs/migrations/forgejo-docker-to-kubernetes.md#phase-4).
+  - runner-priorityclass.yaml
+  - runner-config.configmap.yaml
+  - runner-register.secret.yaml
+  - runner-deployment.yaml
   - service.yaml
   - ingress.yaml
   - transportserver.yaml

--- a/apps/base/forgejo/runner-config.configmap.yaml
+++ b/apps/base/forgejo/runner-config.configmap.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: forgejo-runner-config
+  namespace: forgejo
+data:
+  config.yaml: |
+    log:
+      level: info
+      job_level: info
+
+    runner:
+      # Registration state lives on the PVC (mounted at /data, the image WORKDIR).
+      file: /data/.runner
+      # Concurrent jobs. The aggregate resource ceiling is enforced by the dind
+      # sidecar limits in runner-deployment.yaml, so this can be >1 safely;
+      # raise/lower together with the dind cpu/memory limits.
+      capacity: 3
+      # Per-job hard timeout (Forgejo instance also caps at 3h by default).
+      timeout: 1h
+      # Grace period for running jobs on shutdown; keep <= the pod's
+      # terminationGracePeriodSeconds (130s).
+      shutdown_timeout: 2m
+      fetch_timeout: 5s
+      fetch_interval: 2s
+      report_interval: 1s
+      # Must match RUNNER_LABELS in runner-deployment.yaml.
+      labels:
+        - docker:docker://node:20-bookworm
+
+    cache:
+      # Disabled: the internal cache server's auto-detected host is not reliably
+      # reachable from job containers running inside dind. Jobs work fine without
+      # it (just no actions/cache). Enable later with an explicit cache.host.
+      enabled: false
+
+    container:
+      # Auto-create a network per job.
+      network: ""
+      # Job containers themselves are not privileged.
+      privileged: false
+      # Use the dind sidecar reached via DOCKER_HOST.
+      docker_host: "-"
+      # No host volumes may be bind-mounted into job containers.
+      valid_volumes: []
+      force_pull: false

--- a/apps/base/forgejo/runner-deployment.yaml
+++ b/apps/base/forgejo/runner-deployment.yaml
@@ -17,10 +17,35 @@ spec:
         app.kubernetes.io/name: forgejo-runner
     spec:
       enableServiceLinks: false
+      # CI is best-effort: this pod is the first to be preempted/evicted under
+      # node pressure and never preempts other workloads (see runner-priorityclass.yaml).
+      priorityClassName: forgejo-runner-low
+      # Allow in-flight jobs a short window to finish on rollout/restart
+      # (must be >= runner.shutdown_timeout in config.yaml).
+      terminationGracePeriodSeconds: 130
       containers:
         - name: runner
           # renovate: datasource=docker depName=data.forgejo.org/forgejo/runner versioning=semver
           image: data.forgejo.org/forgejo/runner:6.4.0
+          # The image CMD is only `/bin/forgejo-runner` (prints help and exits),
+          # so we drive registration + daemon ourselves. Registration is idempotent:
+          # it only runs when /data/.runner (on the PVC) is absent.
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              if [ ! -f /data/.runner ]; then
+                echo "No .runner file found - registering runner with Forgejo..."
+                forgejo-runner register --no-interactive \
+                  --instance "$GITEA_INSTANCE_URL" \
+                  --token "$GITEA_RUNNER_REGISTRATION_TOKEN" \
+                  --name "$RUNNER_NAME" \
+                  --labels "$RUNNER_LABELS"
+              fi
+              # Give the dind sidecar a moment to accept connections
+              # (blessed pattern from the upstream docker-compose example).
+              sleep 5
+              exec forgejo-runner daemon --config /config/config.yaml
           env:
             - name: DOCKER_HOST
               value: tcp://127.0.0.1:2375
@@ -31,15 +56,26 @@ spec:
                 secretKeyRef:
                   name: forgejo-runner-register
                   key: token
+            - name: RUNNER_NAME
+              value: talos-cluster
+            # Must match runner.labels in runner-config.configmap.yaml.
+            - name: RUNNER_LABELS
+              value: docker:docker://node:20-bookworm
           volumeMounts:
             - name: runner-data
               mountPath: /data
+            - name: runner-config
+              mountPath: /config
+              readOnly: true
+          # Orchestrator only — the actual job workloads run inside the dind
+          # sidecar and are bounded by *its* limits, not these.
           resources:
             requests:
-              cpu: 50m
+              cpu: 100m
               memory: 128Mi
             limits:
-              memory: 1Gi
+              cpu: "1"
+              memory: 512Mi
         - name: dind
           # renovate: datasource=docker depName=docker.io/library/docker
           image: docker.io/library/docker:27-dind
@@ -51,9 +87,25 @@ spec:
           volumeMounts:
             - name: dind-storage
               mountPath: /var/lib/docker
+          # This is the real cap on all CI jobs combined: every job container the
+          # runner starts is nested in this container's cgroup. Sized to use spare
+          # node capacity (nodes are 3-6 vCPU / 16Gi) without starving the cluster.
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: "2"
+              memory: 4Gi
       volumes:
         - name: runner-data
           persistentVolumeClaim:
             claimName: forgejo-runner-data
+        - name: runner-config
+          configMap:
+            name: forgejo-runner-config
+        # Layer/build scratch for dind. sizeLimit guards node ephemeral storage:
+        # the pod is evicted if it grows past this instead of filling the disk.
         - name: dind-storage
-          emptyDir: {}
+          emptyDir:
+            sizeLimit: 20Gi

--- a/apps/base/forgejo/runner-priorityclass.yaml
+++ b/apps/base/forgejo/runner-priorityclass.yaml
@@ -1,0 +1,11 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: forgejo-runner-low
+# Negative value: lower than the default (0) used by normal workloads, so the
+# scheduler/kubelet evicts CI runner pods before anything else under node
+# pressure. preemptionPolicy Never ensures this pod never evicts others.
+value: -100
+preemptionPolicy: Never
+globalDefault: false
+description: "Best-effort priority for Forgejo CI runners: first to be preempted, never preempts."

--- a/apps/base/forgejo/runner-register.secret.yaml
+++ b/apps/base/forgejo/runner-register.secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: forgejo-runner-register
+    namespace: forgejo
+type: Opaque
+stringData:
+    token: ENC[AES256_GCM,data:oUEbYtfDmpJpu0Vv9bKoPKzP6K/LihSpqo9vzWB+mT2kyMC3jl+FRw==,iv:Gg7BenXzhK54myzbqa2do2tY/WOjSAukhx3QkIABzyo=,tag:x79SmRWC8FSY4oB7MBOZ1g==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGcUtZblJoQjlLVExPWmUx
+            a3N4WldXVjVwT0M5Q21wRjhSdzNPNFRiMHlRCkp3RGY2RjNhaWVKdkt2ekpGMnJ6
+            UzJneVljVUtXOXpqbk9ncFFlUmwzZVEKLS0tIFkxU2tZOUExUlJlQmo1YlU3TEJ5
+            KzgwWnF4WjBhZmJmUmxQZFBhaFpUOWMKQwwMeL/qlVjaygYZjf1yTo4sjs974ytX
+            jSwTfpfiO/dMCF1RgTcaSIrW8lwg4nRE76xRcCMCTsq2UkhvqEOilw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1u5lcvuuwd4lk7f3xewjk70j75yuh68myr89qkd0e8d44zgyjleeqw03vqs
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-19T22:26:16Z"
+    mac: ENC[AES256_GCM,data:8mPGh664DOpEjBSHX1oyoSoYHQawmf4nMT8xt8qsr/TMrOj9QiwE6DdrxrVcYE0dHi8L9txHf1pJT5DQ4xCMjQGtnFoH/xJRhFgCp0gRjWz0aoZB/l+wKsnjVfy9G6Y45W85dSIa+eyL2VzM8/B8lcV+lmfw0kERkT0DTuOnSro=,iv:h3C5adYuDiS3kHwy+udMGpRJ4tc4qTtl/7ThYQZtKrc=,tag:B/Gg1sv7WnWTf7Xg+ZaUng==,type:str]
+    version: 3.13.1


### PR DESCRIPTION
## What

Enables the Forgejo Actions runner on the cluster and hardens it so CI uses spare node capacity without overloading or crashing the cluster.

### Fixes a broken deployment
`runner-deployment.yaml` was non-functional: the image CMD is only `/bin/forgejo-runner` (prints help and exits), so it never registered nor started the daemon, and the registration token was consumed by nothing. Now drives `register` (idempotent — gated on `/data/.runner` on the PVC) → `daemon --config`.

### Resource safety (nodes are 3–6 vCPU / 16Gi)
- **dind sidecar limits `2 CPU` / `4Gi`** — the real cap on all jobs combined (they run nested in dind's cgroup); previously unbounded.
- **`runner.capacity: 3`** — parallel jobs, bounded by the dind limits above.
- **`forgejo-runner-low` PriorityClass** (`-100`, `preemptionPolicy: Never`) — runner is evicted first under node pressure and never preempts other workloads.
- **dind emptyDir `sizeLimit: 20Gi`** — guards node ephemeral storage.
- Internal cache server left disabled (auto-detected host isn't reliably reachable from job containers inside dind; jobs work fine without it).

### Secret
Registration token provisioned as a SOPS-encrypted secret (`runner-register.secret.yaml`), so it's deployable on merge with no manual step.

## Verification
- `kubectl kustomize apps/base/forgejo` ✅
- `kubectl kustomize apps/overlays/main` ✅

After merge + reconcile, the runner should appear in Forgejo → Administration → Actions → Runners as `talos-cluster` (label `docker`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)