### PR TITLE
fix(forgejo): set fsGroup 1000 so runner can write .runner to PVC

### DIFF
--- a/apps/base/forgejo/runner-deployment.yaml
+++ b/apps/base/forgejo/runner-deployment.yaml
@@ -17,6 +17,11 @@ spec:
         app.kubernetes.io/name: forgejo-runner
     spec:
       enableServiceLinks: false
+      # The runner image runs as uid/gid 1000, but the iSCSI PVC mounts root-owned.
+      # fsGroup 1000 makes /data group-writable so the runner can persist .runner.
+      # Set only fsGroup (not runAsUser) at pod level — the dind sidecar must stay root.
+      securityContext:
+        fsGroup: 1000
       # CI is best-effort: this pod is the first to be preempted/evicted under
       # node pressure and never preempts other workloads (see runner-priorityclass.yaml).
       priorityClassName: forgejo-runner-low


### PR DESCRIPTION
Follow-up to #292. After deploy the runner crash-looped:

```
Error: Failed to register runner: failed to save runner config: open .runner: permission denied
```

The runner image runs as `uid/gid 1000`, but the `truenas-iscsi` PVC mounts root-owned, so it couldn't create `/data/.runner`. Adds pod-level `securityContext.fsGroup: 1000` to make the data volume group-writable. Deliberately **not** setting `runAsUser` at pod level so the privileged dind sidecar keeps running as root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)