### PR TITLE
fix(forgejo): bump runner to 12.11.1 for node24 action support

### DIFF
--- a/apps/base/forgejo/runner-deployment.yaml
+++ b/apps/base/forgejo/runner-deployment.yaml
@@ -31,7 +31,8 @@ spec:
       containers:
         - name: runner
           # renovate: datasource=docker depName=data.forgejo.org/forgejo/runner versioning=semver
-          image: data.forgejo.org/forgejo/runner:6.4.0
+          # >= 12.10.2 required for node24 JS actions (e.g. actions/checkout@v7).
+          image: data.forgejo.org/forgejo/runner:12.11.1
           # The image CMD is only `/bin/forgejo-runner` (prints help and exits),
           # so we drive registration + daemon ourselves. Registration is idempotent:
           # it only runs when /data/.runner (on the PVC) is absent.


### PR DESCRIPTION
Follow-up to #292/#293/#294. The runner is online and picks up jobs, but jobs using node24 JS actions fail:

```
The runs.using key in action.yml must be one of: [composite docker node12 node16 node20 go sh], got node24
```

Runner `6.4.0`'s embedded act engine only goes up to node20. node24 support landed in `12.10.2`; this bumps to the current release `12.11.1`. Image verified compatible (same uid/gid 1000, same `/bin/forgejo-runner` CMD, `wget` present), so the existing command / fsGroup / dind-wait logic is unchanged. Existing `.runner` registration on the PVC is reused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)