### PR TITLE
feat(forgejo): add image-layer and actions/cache caching to runner

### DIFF
--- a/apps/base/forgejo/pvc.yaml
+++ b/apps/base/forgejo/pvc.yaml
@@ -28,6 +28,21 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  name: forgejo-runner-dind
+  namespace: forgejo
+spec:
+  # Persistent Docker storage for the dind sidecar: pulled images (golang, node24,
+  # action images) and build layers survive pod restarts instead of being re-pulled.
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: truenas-iscsi
+  resources:
+    requests:
+      storage: 40Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
   name: renovate-data
   namespace: forgejo
 spec:

--- a/apps/base/forgejo/runner-config.configmap.yaml
+++ b/apps/base/forgejo/runner-config.configmap.yaml
@@ -29,14 +29,22 @@ data:
         - docker:docker://node:20-bookworm
 
     cache:
-      # Disabled: the internal cache server's auto-detected host is not reliably
-      # reachable from job containers running inside dind. Jobs work fine without
-      # it (just no actions/cache). Enable later with an explicit cache.host.
-      enabled: false
+      # Internal cache server for actions/cache (speeds up e.g. setup-go module
+      # and build caches). The cache server listens in the pod network namespace
+      # (shared with dind); job containers reach it via the docker0 bridge gateway.
+      enabled: true
+      # Persist cache data on the runner PVC so it survives pod restarts.
+      dir: /data/actcache
+      # Address job containers use to reach the cache server. With
+      # container.network=bridge below, jobs sit on dind's default bridge whose
+      # gateway (172.17.0.1) routes into the pod netns where the server listens.
+      host: "172.17.0.1"
 
     container:
-      # Auto-create a network per job.
-      network: ""
+      # Use dind's default bridge so the cache-server gateway IP is deterministic
+      # (172.17.0.1). Trade-off vs auto-created per-job networks: no automatic
+      # container-name DNS, which only matters for workflows using `services:`.
+      network: bridge
       # Job containers themselves are not privileged.
       privileged: false
       # Use the dind sidecar reached via DOCKER_HOST.

--- a/apps/base/forgejo/runner-deployment.yaml
+++ b/apps/base/forgejo/runner-deployment.yaml
@@ -22,6 +22,9 @@ spec:
       # Set only fsGroup (not runAsUser) at pod level — the dind sidecar must stay root.
       securityContext:
         fsGroup: 1000
+        # Only chown volumes whose top-level group differs, so the dind PVC
+        # (large image store, root-owned) isn't recursively re-chowned each boot.
+        fsGroupChangePolicy: OnRootMismatch
       # CI is best-effort: this pod is the first to be preempted/evicted under
       # node pressure and never preempts other workloads (see runner-priorityclass.yaml).
       priorityClassName: forgejo-runner-low
@@ -118,8 +121,8 @@ spec:
         - name: runner-config
           configMap:
             name: forgejo-runner-config
-        # Layer/build scratch for dind. sizeLimit guards node ephemeral storage:
-        # the pod is evicted if it grows past this instead of filling the disk.
+        # Persistent Docker image/layer store for dind so pulled images and build
+        # layers are cached across pipeline runs instead of re-pulled every time.
         - name: dind-storage
-          emptyDir:
-            sizeLimit: 20Gi
+          persistentVolumeClaim:
+            claimName: forgejo-runner-dind


### PR DESCRIPTION
Speeds up pipeline runs with two complementary caching layers.

### 1. Persistent dind image/layer store
`dind-storage` moves from `emptyDir` to a **40Gi truenas-iscsi PVC** (`forgejo-runner-dind`). Pulled images (golang, node24, action images) and docker build layers now survive pod restarts instead of being re-pulled every run.

### 2. actions/cache server
- `cache.enabled: true`, `cache.dir: /data/actcache` (persisted on the runner PVC).
- `cache.host: 172.17.0.1` + `container.network: bridge`: the cache server listens in the pod network namespace (shared with dind); job containers on dind's default bridge reach it via the deterministic gateway `172.17.0.1`. Makes `actions/cache` (e.g. `setup-go` module/build cache) work.
- Trade-off of the default bridge: no automatic container-name DNS, which only matters for workflows using `services:`.

### Misc
- `fsGroupChangePolicy: OnRootMismatch` avoids recursively re-chowning the large dind image store on every pod start.

`actions/cache` fails soft, so even if cache networking misbehaves, jobs still succeed. Will verify with a real pipeline run after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)