### PR TITLE
fix(monitoring): scope CNPGBackupStale to primary, ignore replica zeros

### DIFF
--- a/apps/base/monitoring/rules/platform-p0-vmrule.yaml
+++ b/apps/base/monitoring/rules/platform-p0-vmrule.yaml
@@ -41,6 +41,8 @@ spec:
             (
               time() - cnpg_collector_last_available_backup_timestamp{namespace="cnpg-system"}
             ) > 50 * 3600
+            and
+              cnpg_collector_last_available_backup_timestamp{namespace="cnpg-system"} > 0
           for: 1h
           labels:
             severity: warning
@@ -48,7 +50,7 @@ spec:
             homelab/owner: platform
           annotations:
             summary: "CNPG-Backup veraltet: {{ $labels.cluster }}"
-            description: "Letztes verfügbares Backup für Cluster {{ $labels.cluster }} ist älter als 48 Stunden."
+            description: "Letztes verfügbares Backup für Cluster {{ $labels.cluster }} ist älter als 50 Stunden."
             runbook_url: "https://git.f4mily.net/homelab/gitops-homelab/blob/main/docs/runbooks/cnpg-backup-stale.md"
 
     - name: homelab.platform.velero


### PR DESCRIPTION
## Symptom
`[FIRING] CNPGBackupStale (4)` for `homelab` — 4 CNPG instance pods.

## Root cause
Backups are actually **healthy** (both clusters: `lastSuccessfulBackup` ~9h ago, `ContinuousArchiving=True`, `LastBackupSucceeded=True`). The alert is a false positive: `cnpg_collector_last_available_backup_timestamp` is exported **per instance**, but only the **primary** runs backups. The 4 **replicas** export `0` (epoch), so `time() - 0` ≈ 56 years > 50h → fires.

The 4 firing pod IPs map exactly to the 4 replica pods (homelab-postgres-2/3, immich-postgres-2/3).

## Fix
Guard the expression with `cnpg_collector_last_available_backup_timestamp{...} > 0` so only the primary's real timestamp is evaluated. A genuinely stale primary backup (non-zero but old) still fires. Also aligned the description text (said 48h) with the actual 50h threshold.

```
(time() - cnpg_collector_last_available_backup_timestamp{namespace="cnpg-system"}) > 50 * 3600
and
  cnpg_collector_last_available_backup_timestamp{namespace="cnpg-system"} > 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)