### PR TITLE
fix(cnpg): require hard pod anti-affinity + failoverDelay for clean node drains

### DIFF
--- a/infrastructure/overlays/main/database-clusters/cluster.yaml
+++ b/infrastructure/overlays/main/database-clusters/cluster.yaml
@@ -42,7 +42,16 @@ spec:
     enablePodMonitor: false
 
   affinity:
-    podAntiAffinityType: preferred
+    # required (hard): exactly one instance per node across the 3 Talos nodes. A node
+    # drain (autonomous Talos/SUC upgrade) then only ever evicts ONE instance of this
+    # cluster — a single clean switchover instead of a cascading failover storm.
+    # Trade-off: while a node is down/cordoned the 3rd instance stays Pending (2/3 HA)
+    # until it returns — expected and safe.
+    podAntiAffinityType: required
+
+  # Ride out transient primary blips (e.g. node-reboot network flap) for 30s before
+  # failing over, instead of reacting instantly (default 0).
+  failoverDelay: 30
 
   env:
     - name: AWS_DEFAULT_REGION

--- a/infrastructure/overlays/main/database-clusters/immich-postgres/cluster.yaml
+++ b/infrastructure/overlays/main/database-clusters/immich-postgres/cluster.yaml
@@ -42,6 +42,17 @@ spec:
     # Metrics scraped via apps/base/monitoring/extra-scrapes/cnpg-vmpodscrape.yaml
     enablePodMonitor: false
 
+  affinity:
+    # required (hard): exactly one instance per node across the 3 Talos nodes. A node
+    # drain (autonomous Talos/SUC upgrade) then only ever evicts ONE instance of this
+    # cluster — a single clean switchover instead of a cascading failover storm.
+    # Default was "preferred" (soft), which let 2 instances co-locate on one node.
+    podAntiAffinityType: required
+
+  # Ride out transient primary blips (e.g. node-reboot network flap) for 30s before
+  # failing over, instead of reacting instantly (default 0).
+  failoverDelay: 30
+
   env:
     - name: AWS_DEFAULT_REGION
       value: garage


### PR DESCRIPTION
## Root cause (2026-06-20 CNPG failover storm)
With `podAntiAffinityType: preferred` (soft), **4 of 6 postgres instances — including both primaries — co-located on `talos-cp3`** (cp1 hosted none). When the autonomous Talos/SUC upgrade drained cp3, two instances per cluster were evicted at once → cascading switchover storm → ~15 min of DB instability that rippled to every DB-backed app (Authentik, forgejo, nextcloud, teslamate, …), and left `homelab-postgres-1` WAL-ahead in a rewind loop.

## Fix
Both clusters → `podAntiAffinityType: required`: exactly one instance per node (3 instances / 3 nodes). A node drain then evicts only **one** instance per cluster — a single clean switchover, the other two stay up.

**Autonomous Talos upgrades keep working with no manual intervention:** the CNPG primary-PDB (`allowedDisruptions: 0`) forces CNPG to switch the primary off the draining node before eviction, well within the SUC drain timeout (600s). `force: true` on the SUC drain does not bypass PDBs.

Also `failoverDelay: 30` to ride out transient node-reboot network blips instead of failing over instantly (default 0).

## Apply note
Reconciling triggers a **one-time, controlled rolling rebalance** (one replica per cluster moves cp3 → cp1), one instance at a time respecting PDBs. Best done while the cluster is stable.

Follow-up (separate, safe): fresh base backup to establish a clean recovery point on the current timeline (item C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)