### PR TITLE
feat(dawarich): deploy location tracker with PostGIS, OIDC & monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ This cluster runs a variety of self-hosted applications. Uptime is monitored via
 | **goloom** | Automation | ![Uptime](https://status.cluster.f4mily.net/api/v1/endpoints/automation_goloom/uptimes/30d/badge.svg) |
 | [**SpectrumKNX**](https://github.com/martinhoefling/SpectrumKNX) | Smart Home | ![Uptime](https://status.cluster.f4mily.net/api/v1/endpoints/automation_spectrumknx/uptimes/30d/badge.svg) |
 | [**teslamate**](https://github.com/adriankumpf/teslamate) | Car Tracking | ![Uptime](https://status.cluster.f4mily.net/api/v1/endpoints/observability_teslamate/uptimes/30d/badge.svg) |
+| [**dawarich**](https://dawarich.app/) | Location Tracking | ![Uptime](https://status.cluster.f4mily.net/api/v1/endpoints/application_dawarich/uptimes/30d/badge.svg) |
 | [**watchyourlan**](https://github.com/aceberg/WatchYourLAN) | Network | ![Uptime](https://status.cluster.f4mily.net/api/v1/endpoints/observability_watchyourlan/uptimes/30d/badge.svg) |
 | [**homer**](https://github.com/bastienwirtz/homer) | Dashboard | ![Uptime](https://status.cluster.f4mily.net/api/v1/endpoints/observability_homer/uptimes/30d/badge.svg) |
 | [**grafana**](https://grafana.com/) | Observability | ![Uptime](https://status.cluster.f4mily.net/api/v1/endpoints/observability_grafana/uptimes/30d/badge.svg) |

--- a/apps/base/authentik/blueprints/dawarich-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/dawarich-oauth.configmap.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authentik-dawarich-blueprint
+  namespace: authentik
+  labels:
+    app.kubernetes.io/part-of: authentik
+data:
+  dawarich.yaml: |
+    version: 1
+    metadata:
+      name: Homelab Dawarich OIDC
+      labels:
+        blueprints.goauthentik.io/description: OAuth2 provider and application for Dawarich location tracker
+    entries:
+      - model: authentik_providers_oauth2.oauth2provider
+        id: dawarich-provider
+        identifiers:
+          client_id: homelab-dawarich
+        attrs:
+          name: Provider for Dawarich
+          client_type: confidential
+          client_id: homelab-dawarich
+          client_secret: R01i/8ia9OuVzhkw5870CCmYKqnAx4JMm4TffR/I/Nw=
+          grant_types:
+            - authorization_code
+            - refresh_token
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-explicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+          encryption_key: null
+          redirect_uris:
+            - matching_mode: strict
+              url: https://locate.f4mily.net/users/auth/openid_connect/callback
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+      - model: authentik_core.application
+        identifiers:
+          slug: dawarich
+        attrs:
+          name: Dawarich
+          slug: dawarich
+          provider: !KeyOf dawarich-provider
+          launch_url: https://locate.f4mily.net
+          meta_launch_url: https://locate.f4mily.net
+          icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/dawarich.svg

--- a/apps/base/authentik/helmrelease.yaml
+++ b/apps/base/authentik/helmrelease.yaml
@@ -66,6 +66,7 @@ spec:
         - authentik-paperless-blueprint
         - authentik-gatus-blueprint
         - authentik-linkding-blueprint
+        - authentik-dawarich-blueprint
     server:
       ingress:
         enabled: false

--- a/apps/base/authentik/kustomization.yaml
+++ b/apps/base/authentik/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - blueprints/paperless-oauth.configmap.yaml
   - blueprints/gatus-oauth.configmap.yaml
   - blueprints/linkding-oauth.configmap.yaml
+  - blueprints/dawarich-oauth.configmap.yaml
   - media-pvc.yaml
   - helmrelease.yaml
   - ingress.yaml

--- a/apps/base/dawarich/configmap.yaml
+++ b/apps/base/dawarich/configmap.yaml
@@ -1,0 +1,37 @@
+# Non-secret runtime config shared by the app + sidekiq containers.
+# Secrets (DB credentials, SECRET_KEY_BASE) are injected separately via secretKeyRef.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dawarich-env
+  namespace: dawarich
+data:
+  RAILS_ENV: "production"
+  # Hostname is also enforced on the Ingress via the cluster-config replacement.
+  APPLICATION_HOST: "locate.f4mily.net"
+  APPLICATION_HOSTS: "locate.f4mily.net,localhost,127.0.0.1,::1"
+  APPLICATION_PROTOCOL: "https"
+  TIME_ZONE: "Europe/Berlin"
+  REDIS_URL: "redis://dawarich-valkey:6379/0"
+  DATABASE_HOST: "dawarich-postgres-rw.cnpg-system.svc.cluster.local"
+  DATABASE_PORT: "5432"
+  DATABASE_NAME: "dawarich"
+  RAILS_LOG_TO_STDOUT: "true"
+  SELF_HOSTED: "true"
+  STORE_GEODATA: "true"
+  PROMETHEUS_EXPORTER_ENABLED: "false"
+  RAILS_MIN_THREADS: "5"
+  RAILS_MAX_THREADS: "10"
+  # Reverse geocoding via Komoot's public Photon (self-host later if rate-limited).
+  PHOTON_API_HOST: "photon.komoot.io"
+  PHOTON_API_USE_HTTPS: "true"
+  # --- OIDC SSO via Authentik (client id/secret injected from secret) ---------
+  OIDC_PROVIDER_NAME: "Authentik"
+  # Authentik issuer; Dawarich appends /.well-known/openid-configuration itself.
+  OIDC_ISSUER: "https://login.f4mily.net/application/o/dawarich/"
+  OIDC_REDIRECT_URI: "https://locate.f4mily.net/users/auth/openid_connect/callback"
+  # Auto-provision a Dawarich account on first successful OIDC login.
+  OIDC_AUTO_REGISTER: "true"
+  # Keep the built-in email/password login working (admin bootstrap); only new
+  # self-service email registration is disabled.
+  ALLOW_EMAIL_PASSWORD_REGISTRATION: "false"

--- a/apps/base/dawarich/dawarich-app.secret.yaml
+++ b/apps/base/dawarich/dawarich-app.secret.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+data:
+    SECRET_KEY_BASE: ENC[AES256_GCM,data:L5U0Ruq3x+AWC8IqUkE8UUS9mLegflSrziFHihIKOTqcF5+L0bvEOyJikImPeWI91DFbeRJStJ11zMGUHJl5FGisbgwZNE7RmVbXxwxQakecZVe21ZOvzQnYXa6H3LJCBXXsLWUaFKf5Gq1CxWOImuot5jhCkYR2EyNNHX2j+3/zfXXvgt0NxPlbtcxreZrEYDIu1DdJwAFddcRAPxBDsqrG8hjy7rL61JGI9w==,iv:fcMWJKQfY535vJjRprnx0QzfGCv/WMxm68E4eRSjW6Q=,tag:9Eh0reM1QrHiM4ETrmbqcQ==,type:str]
+kind: Secret
+metadata:
+    name: dawarich-app
+    namespace: dawarich
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4cXpWb1BZUmNNSzBkOWhR
+            ZkZGaDNjRWRZZ0Z0eEhLUTlPR2h1ZDRQSkNFCllxNDlJR1NRR1RLMGxQWVIwYlhu
+            QVROYk9LUUxSMFU1R0RkWm1NU2RKcEkKLS0tIFc3SkU0cnRQU29NcVJqUTQxWVRZ
+            c1RTbVovRFFLR3dXaG9FUkQ3MjhzeXcKOCfMgC1WyxsqWpWGRAChCMAscBK2ybd6
+            LSRzsiGl7qJVwtF/etxvnl237BuSpX0zYE810lfhyYljvkC0ysXu9Q==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1u5lcvuuwd4lk7f3xewjk70j75yuh68myr89qkd0e8d44zgyjleeqw03vqs
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-21T18:44:24Z"
+    mac: ENC[AES256_GCM,data:pSJV2RWnO4twr4AbgPkAeCZQnedP9t5liEcYmbqHSC9AtkVMAjE+ZFYD+E0HU+7nzJLwUm9p5YHK/Qv1wcwOFZEKi/tC5IzKqeKa6AJKL1Y/Y6gqZ64F7yI2ueR6ifZoY9UctDQ6igCXNnAOGWRnN3s40j8Dkc6IHM8XFc0OdG0=,iv:NRrVV2L7FAiM1CvgGEFz4X4XxmHRxS5aKWroE8+AO1Y=,tag:yfFs6u55JKjRoj4ZGmCv7Q==,type:str]
+    version: 3.13.1

--- a/apps/base/dawarich/dawarich-app.secret.yaml.template
+++ b/apps/base/dawarich/dawarich-app.secret.yaml.template
@@ -1,0 +1,8 @@
+# Dawarich Rails SECRET_KEY_BASE (SOPS). Required; encrypts sessions/cookies.
+# Keep this value stable across upgrades — rotating it invalidates all sessions.
+#
+#   cd apps/base/dawarich
+#   just sops-create dawarich-app dawarich \
+#     SECRET_KEY_BASE="$(openssl rand -hex 64)"
+#
+# Then add dawarich-app.secret.yaml to kustomization.yaml (already referenced).

--- a/apps/base/dawarich/dawarich-authentik-oauth.secret.yaml
+++ b/apps/base/dawarich/dawarich-authentik-oauth.secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+data:
+    client-id: ENC[AES256_GCM,data:RwCLW+oONKfmI9QgzsAUyVRWDvogeHuq,iv:qMqpUm4DuI7H+/VRAm3O3S9Y6AbVtFSklJP+kzIliPA=,tag:Grx4qj5yXzsL2/s0P0WEbw==,type:str]
+    client-secret: ENC[AES256_GCM,data:Vt04kCMB5haAH8tff1UzQOfRgplRvPdZ6O84cxm4/rh+EHyIapblgbpHy91Xm5oEnm4Iv/3TuyIWh7Fs,iv:QiYiqUSb4PsAtetJi2JD2pBQxTZ6C60DJniIeCz6yL0=,tag:Q8isy4O2qFcxomfrqyX9Gg==,type:str]
+kind: Secret
+metadata:
+    name: dawarich-authentik-oauth
+    namespace: dawarich
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2N1pGaTdoYWFIQnRKOWwy
+            cDQwYnZQeHFsVFdjTjQ4MzBzWTh6TktXc2lvCjhXbUhvQlAvTUhTTFJsMHEvbnI4
+            RytLeWRweTNHc1lhUzk5ZDJubU9hL0kKLS0tIHE4UXFSbFpVcmlKeW5GQjF6ZkhJ
+            VGdoVmZiV1NiVkJad1RlL1R1bkRBbTAKCzQM9MSbBOAMOiO0SV6kOmF1U4KQgi48
+            LSDgTyRxsTABu2cINVbd2a993W0i/Wtux2qHCz0f5izIEUsPcQ3ABg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1u5lcvuuwd4lk7f3xewjk70j75yuh68myr89qkd0e8d44zgyjleeqw03vqs
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-21T18:53:13Z"
+    mac: ENC[AES256_GCM,data:o7sc8l3RxN/TXXR2UDmbd+G0jEcjlcf8FpirOUAWY+OTETNc/C+2XfEEhNETz5Al6v1f0hZWCUpN5ecwFiaS6Bd0cCPUwnE4P1hY5AaKbjR4wMpo8GvG1AEt110DcWH4RRoA1RporQmE0MjFMi/tiEQorx731Vp1Mx+Nw/d8l0s=,iv:EVAhAWkNOy1PXJ+ugMvgPBvvr8Ph3Z93r/f/Ve04uMo=,tag:EHWbp9H7fZvHVH3zjwkeGw==,type:str]
+    version: 3.13.1

--- a/apps/base/dawarich/dawarich-authentik-oauth.secret.yaml.template
+++ b/apps/base/dawarich/dawarich-authentik-oauth.secret.yaml.template
@@ -1,0 +1,11 @@
+# Dawarich ↔ Authentik OIDC client credentials (SOPS).
+# client-secret MUST match the value in the Authentik blueprint
+# apps/base/authentik/blueprints/dawarich-oauth.configmap.yaml.
+#
+#   cd apps/base/dawarich
+#   just sops-create dawarich-authentik-oauth dawarich \
+#     client-id="homelab-dawarich" \
+#     client-secret="<same value as in the blueprint>"
+#
+# Redirect URI registered in Authentik:
+#   https://locate.f4mily.net/users/auth/openid_connect/callback

--- a/apps/base/dawarich/deployment.yaml
+++ b/apps/base/dawarich/deployment.yaml
@@ -1,0 +1,160 @@
+# Single pod with two containers (web app + Sidekiq worker), mirroring the
+# upstream k8s guide. Both share the RWO PVCs, so they MUST co-locate in one
+# pod. strategy: Recreate avoids two pods racing for the same iSCSI volumes
+# during rollouts.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dawarich
+  namespace: dawarich
+  labels:
+    app: dawarich
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: dawarich
+  template:
+    metadata:
+      labels:
+        app: dawarich
+    spec:
+      containers:
+        # ---------------------------------------------------------------- web
+        - name: dawarich-app
+          # renovate: datasource=docker depName=freikin/dawarich versioning=semver
+          image: freikin/dawarich:1.8.1
+          imagePullPolicy: IfNotPresent
+          command: ["web-entrypoint.sh"]
+          args: ["bin/rails", "server", "-p", "3000", "-b", "::"]
+          envFrom:
+            - configMapRef:
+                name: dawarich-env
+          env:
+            - name: DATABASE_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: homelab-postgres-dawarich
+                  key: username
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: homelab-postgres-dawarich
+                  key: password
+            - name: SECRET_KEY_BASE
+              valueFrom:
+                secretKeyRef:
+                  name: dawarich-app
+                  key: SECRET_KEY_BASE
+            - name: OIDC_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: dawarich-authentik-oauth
+                  key: client-id
+            - name: OIDC_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: dawarich-authentik-oauth
+                  key: client-secret
+          ports:
+            - containerPort: 3000
+              name: http
+          volumeMounts:
+            - name: public
+              mountPath: /var/app/public
+            - name: watched
+              mountPath: /var/app/tmp/imports/watched
+            - name: storage
+              mountPath: /var/app/storage
+          livenessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: http
+            initialDelaySeconds: 90
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+          resources:
+            requests:
+              cpu: 250m
+              memory: 1Gi
+            limits:
+              memory: 3Gi
+        # ------------------------------------------------------------ sidekiq
+        - name: dawarich-sidekiq
+          # renovate: datasource=docker depName=freikin/dawarich versioning=semver
+          image: freikin/dawarich:1.8.1
+          imagePullPolicy: IfNotPresent
+          command: ["sidekiq-entrypoint.sh"]
+          args: ["bundle", "exec", "sidekiq"]
+          envFrom:
+            - configMapRef:
+                name: dawarich-env
+          env:
+            - name: DATABASE_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: homelab-postgres-dawarich
+                  key: username
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: homelab-postgres-dawarich
+                  key: password
+            - name: SECRET_KEY_BASE
+              valueFrom:
+                secretKeyRef:
+                  name: dawarich-app
+                  key: SECRET_KEY_BASE
+            - name: OIDC_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: dawarich-authentik-oauth
+                  key: client-id
+            - name: OIDC_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: dawarich-authentik-oauth
+                  key: client-secret
+            - name: BACKGROUND_PROCESSING_CONCURRENCY
+              value: "10"
+          volumeMounts:
+            - name: public
+              mountPath: /var/app/public
+            - name: watched
+              mountPath: /var/app/tmp/imports/watched
+            - name: storage
+              mountPath: /var/app/storage
+          livenessProbe:
+            exec:
+              command: ["sh", "-c", "pgrep -f sidekiq"]
+            initialDelaySeconds: 90
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 5
+          resources:
+            requests:
+              cpu: 250m
+              memory: 1Gi
+            limits:
+              memory: 3Gi
+      volumes:
+        - name: public
+          persistentVolumeClaim:
+            claimName: dawarich-public
+        - name: watched
+          persistentVolumeClaim:
+            claimName: dawarich-watched
+        - name: storage
+          persistentVolumeClaim:
+            claimName: dawarich-storage

--- a/apps/base/dawarich/ingress.yaml
+++ b/apps/base/dawarich/ingress.yaml
@@ -1,0 +1,35 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: dawarich
+  namespace: dawarich
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: Dawarich
+    gethomepage.dev/description: Location history tracking
+    gethomepage.dev/href: "https://locate.f4mily.net/"
+    gethomepage.dev/group: Tools
+    gethomepage.dev/icon: dawarich.png
+    gethomepage.dev/app: dawarich
+    gethomepage.dev/pod-selector: app=dawarich
+    nginx.org/ssl-redirect: "false"
+    nginx.org/redirect-to-https: "true"
+    # Large GPS/import uploads (Google Takeout, GPX, etc.)
+    nginx.org/client-max-body-size: "1000m"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - locate.f4mily.net
+      secretName: wildcard-f4mily-net-tls
+  rules:
+    - host: locate.f4mily.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: dawarich
+                port:
+                  number: 3000

--- a/apps/base/dawarich/kustomization.yaml
+++ b/apps/base/dawarich/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - configmap.yaml
+  - dawarich-app.secret.yaml
+  - dawarich-authentik-oauth.secret.yaml
+  - valkey.yaml
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml

--- a/apps/base/dawarich/namespace.yaml
+++ b/apps/base/dawarich/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dawarich
+  labels:
+    app.kubernetes.io/name: dawarich
+    app.kubernetes.io/part-of: homelab-apps

--- a/apps/base/dawarich/pvc.yaml
+++ b/apps/base/dawarich/pvc.yaml
@@ -1,0 +1,43 @@
+# Shared between the app and sidekiq containers (same pod → RWO on TrueNAS iSCSI is fine).
+#   public  → generated map tiles / assets served by Rails
+#   watched → directory Sidekiq watches for auto-imports (/var/app/tmp/imports/watched)
+#   storage → ActiveStorage uploads (imports, exports)
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dawarich-public
+  namespace: dawarich
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: truenas-iscsi
+  resources:
+    requests:
+      storage: 2Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dawarich-watched
+  namespace: dawarich
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: truenas-iscsi
+  resources:
+    requests:
+      storage: 2Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dawarich-storage
+  namespace: dawarich
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: truenas-iscsi
+  resources:
+    requests:
+      storage: 10Gi

--- a/apps/base/dawarich/service.yaml
+++ b/apps/base/dawarich/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dawarich
+  namespace: dawarich
+  labels:
+    service: dawarich
+spec:
+  selector:
+    app: dawarich
+  ports:
+    - name: http
+      protocol: TCP
+      port: 3000
+      targetPort: http

--- a/apps/base/dawarich/valkey.yaml
+++ b/apps/base/dawarich/valkey.yaml
@@ -1,0 +1,73 @@
+# Redis-compatible cache + Sidekiq queue backend for Dawarich.
+# Valkey is a drop-in Redis replacement; Dawarich talks to it via REDIS_URL.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dawarich-valkey
+  namespace: dawarich
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dawarich-valkey
+  template:
+    metadata:
+      labels:
+        app: dawarich-valkey
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: valkey
+          image: docker.io/valkey/valkey:9.1.0-alpine
+          imagePullPolicy: IfNotPresent
+          args:
+            - valkey-server
+            - --save
+            - "900"
+            - "1"
+            - --appendonly
+            - "no"
+          ports:
+            - containerPort: 6379
+              name: valkey
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          livenessProbe:
+            tcpSocket:
+              port: valkey
+            initialDelaySeconds: 5
+            periodSeconds: 15
+          readinessProbe:
+            tcpSocket:
+              port: valkey
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 5m
+              memory: 32Mi
+            limits:
+              memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dawarich-valkey
+  namespace: dawarich
+spec:
+  selector:
+    app: dawarich-valkey
+  ports:
+    - name: valkey
+      port: 6379
+      targetPort: valkey
+      protocol: TCP
+  type: ClusterIP

--- a/apps/base/gatus/helmrelease.yaml
+++ b/apps/base/gatus/helmrelease.yaml
@@ -218,6 +218,16 @@ spec:
              - "[STATUS] < 400"
              - "[RESPONSE_TIME] < 5000"
 
+        - name: dawarich
+          group: application
+          url: https://locate.f4mily.net/api/v1/health
+          interval: 60s
+          client: *default-dns
+          conditions:
+             - "[STATUS] == 200"
+             - "[BODY].status == ok"
+             - "[RESPONSE_TIME] < 5000"
+
         - name: teslamate
           group: observability
           url: https://teslamate.f4mily.net

--- a/apps/overlays/main/cluster-config.yaml
+++ b/apps/overlays/main/cluster-config.yaml
@@ -58,6 +58,7 @@ data:
   url_searxng: https://search.f4mily.net/
   host_teslamate: teslamate.f4mily.net
   url_teslamate_grafana: https://teslamate.f4mily.net/grafana/
+  host_dawarich: locate.f4mily.net
   host_tandoor: rezepte.f4mily.net
   # Public URL (scheme required for Django CSRF_TRUSTED_ORIGINS behind TLS ingress).
   # Include legacy recipes hostname for bookmarks still using the old Docker URL.

--- a/apps/overlays/main/databases/dawarich.yaml
+++ b/apps/overlays/main/databases/dawarich.yaml
@@ -1,0 +1,14 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  # Name matches secret homelab-postgres-dawarich in namespace dawarich.
+  name: homelab-postgres-dawarich
+  namespace: cnpg-system
+spec:
+  name: dawarich
+  owner: dawarich
+  cluster:
+    name: dawarich-postgres
+  extensions:
+    - name: postgis
+      ensure: present

--- a/apps/overlays/main/databases/kustomization.yaml
+++ b/apps/overlays/main/databases/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - forgejo.yaml
   - sparkyfitness.yaml
   - outline.yaml
+  - dawarich.yaml

--- a/apps/overlays/main/db-secrets/dawarich-db-credentials.secret.yaml
+++ b/apps/overlays/main/db-secrets/dawarich-db-credentials.secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+data:
+    password: ENC[AES256_GCM,data:WzxjUaTUaEC6okwDhYZbGnLhQeubPxR8pgFIO4a1VTXUCN6u+vVmx/leRP0RfD5gzIVGxAldLsResFmuUqlqbYXIPaZNYEECzlINFZqUbP6PpFgQPtFYOg==,iv:o9xgXbExK/V6AnSxrBLT3SXyszSRGA03FfJnCepv7tA=,tag:3b3w3nGCBRyZ3W3Cz7Y+nA==,type:str]
+    username: ENC[AES256_GCM,data:rIMHHojQGNJW6z1z,iv:v6vhHb6GyLOXaxblKjpM6QKfybUBEMjb8DZrx2We1BA=,tag:dFbJ1J+fqmcwo79lWyUVsQ==,type:str]
+kind: Secret
+metadata:
+    name: dawarich-db-credentials
+    namespace: cnpg-system
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAraXhrYzlWZUJLVmV6d1JU
+            RXczdUF2cDFqRzBobWRXYlJuUFQ3WkVPMFhBCjg1YURGMldhVzBqWDRTR2VJajA0
+            TEdzNmVwNWJOMTVGaDhLT0hGNHNCSnMKLS0tIDArSUNEZS84ODQ3eEZlYzlKTmda
+            WkhMRWRpRDd0QnBMYmpoTDFjOHlKL0EKEO4nMeT//uRMf4rO0IXUvAAcW/gnL/Zs
+            7mGrDr8OUQeM1U0YTRvIsRkxUfHexDuo36Fn9dRQOgnY+Bi794gkwg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1u5lcvuuwd4lk7f3xewjk70j75yuh68myr89qkd0e8d44zgyjleeqw03vqs
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-21T18:44:39Z"
+    mac: ENC[AES256_GCM,data:2Jc7EwSrbvUi5xkx0NLyBXsVn2XLPwL4sXR1cdEgTmUvrduegKphU0ah06cGD3qwaQY88umlKwuVRHso12MDmmC59DgZdrM/3J31NhkhvyNFcE0x2722fHeWdHaPCYhMRA7yaX1IuN/SZeJhwRODc3Nxz6NVnNXg4gj3Hj9XzRg=,iv:yJb201mhNgLmsBxRpnTRbBHb6OhCL4zIIUr6JxqhJ+4=,tag:fnhmUNhQiFHd3PmwSo5B0w==,type:str]
+    version: 3.13.1

--- a/apps/overlays/main/db-secrets/kustomization.yaml
+++ b/apps/overlays/main/db-secrets/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   # - linkwarden-db-credentials.secret.yaml
   - tandoor-db-credentials.secret.yaml
   - outline-db-credentials.secret.yaml
+  - dawarich-db-credentials.secret.yaml
 patches:
   - target:
       kind: Secret
@@ -125,3 +126,13 @@ patches:
       - op: replace
         path: /metadata/namespace
         value: sparkyfitness
+  - target:
+      kind: Secret
+      name: dawarich-db-credentials
+    patch: |
+      - op: replace
+        path: /metadata/name
+        value: homelab-postgres-dawarich
+      - op: replace
+        path: /metadata/namespace
+        value: dawarich

--- a/apps/overlays/main/kustomization.yaml
+++ b/apps/overlays/main/kustomization.yaml
@@ -59,6 +59,7 @@ resources:
 
   # --- Development / Misc -----------------------------------------------
   - ../../base/teslamate
+  - ../../base/dawarich
   - ../../base/goloom
   # - ../../base/pcm                 # wip: ingress only, no workload
 
@@ -323,6 +324,16 @@ replacements:
   - source:
       kind: ConfigMap
       name: homelab-cluster-config
+      fieldPath: data.host_dawarich
+    targets:
+      - select: {kind: Ingress, name: dawarich}
+        fieldPaths:
+          - spec.rules.0.host
+          - spec.tls.0.hosts.0
+
+  - source:
+      kind: ConfigMap
+      name: homelab-cluster-config
       fieldPath: data.publicTlsSecret
     targets:
       - select: {kind: Ingress, name: outline}
@@ -350,6 +361,8 @@ replacements:
       - select: {kind: Ingress, name: immich}
         fieldPaths: [spec.tls.0.secretName]
       - select: {kind: Ingress, name: teslamate}
+        fieldPaths: [spec.tls.0.secretName]
+      - select: {kind: Ingress, name: dawarich}
         fieldPaths: [spec.tls.0.secretName]
       - select: {kind: Ingress, name: authentik}
         fieldPaths: [spec.tls.0.secretName]

--- a/infrastructure/overlays/main/database-clusters/credentials/dawarich-db-credentials.secret.yaml
+++ b/infrastructure/overlays/main/database-clusters/credentials/dawarich-db-credentials.secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+data:
+    password: ENC[AES256_GCM,data:WzxjUaTUaEC6okwDhYZbGnLhQeubPxR8pgFIO4a1VTXUCN6u+vVmx/leRP0RfD5gzIVGxAldLsResFmuUqlqbYXIPaZNYEECzlINFZqUbP6PpFgQPtFYOg==,iv:o9xgXbExK/V6AnSxrBLT3SXyszSRGA03FfJnCepv7tA=,tag:3b3w3nGCBRyZ3W3Cz7Y+nA==,type:str]
+    username: ENC[AES256_GCM,data:rIMHHojQGNJW6z1z,iv:v6vhHb6GyLOXaxblKjpM6QKfybUBEMjb8DZrx2We1BA=,tag:dFbJ1J+fqmcwo79lWyUVsQ==,type:str]
+kind: Secret
+metadata:
+    name: dawarich-db-credentials
+    namespace: cnpg-system
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAraXhrYzlWZUJLVmV6d1JU
+            RXczdUF2cDFqRzBobWRXYlJuUFQ3WkVPMFhBCjg1YURGMldhVzBqWDRTR2VJajA0
+            TEdzNmVwNWJOMTVGaDhLT0hGNHNCSnMKLS0tIDArSUNEZS84ODQ3eEZlYzlKTmda
+            WkhMRWRpRDd0QnBMYmpoTDFjOHlKL0EKEO4nMeT//uRMf4rO0IXUvAAcW/gnL/Zs
+            7mGrDr8OUQeM1U0YTRvIsRkxUfHexDuo36Fn9dRQOgnY+Bi794gkwg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1u5lcvuuwd4lk7f3xewjk70j75yuh68myr89qkd0e8d44zgyjleeqw03vqs
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-21T18:44:39Z"
+    mac: ENC[AES256_GCM,data:2Jc7EwSrbvUi5xkx0NLyBXsVn2XLPwL4sXR1cdEgTmUvrduegKphU0ah06cGD3qwaQY88umlKwuVRHso12MDmmC59DgZdrM/3J31NhkhvyNFcE0x2722fHeWdHaPCYhMRA7yaX1IuN/SZeJhwRODc3Nxz6NVnNXg4gj3Hj9XzRg=,iv:yJb201mhNgLmsBxRpnTRbBHb6OhCL4zIIUr6JxqhJ+4=,tag:fnhmUNhQiFHd3PmwSo5B0w==,type:str]
+    version: 3.13.1

--- a/infrastructure/overlays/main/database-clusters/credentials/kustomization.yaml
+++ b/infrastructure/overlays/main/database-clusters/credentials/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
   - sparkyfitness-db-credentials.secret.yaml
   - sparkyfitness-app-db-credentials.secret.yaml
   - outline-db-credentials.secret.yaml
+  - dawarich-db-credentials.secret.yaml

--- a/infrastructure/overlays/main/database-clusters/dawarich-postgres/cluster.yaml
+++ b/infrastructure/overlays/main/database-clusters/dawarich-postgres/cluster.yaml
@@ -1,0 +1,72 @@
+# Dedicated PostgreSQL for Dawarich — requires the PostGIS extension, which the
+# stock CNPG image (homelab-postgres) does not ship. Mirrors the immich-postgres
+# pattern. Image: CNPG operand build of PostgreSQL 17 + PostGIS 3.5.
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: dawarich-postgres
+  namespace: cnpg-system
+  labels:
+    app.kubernetes.io/name: dawarich-postgres
+    app.kubernetes.io/managed-by: cnpg
+  annotations:
+    kustomize.toolkit.fluxcd.io/depends-on: helm.toolkit.fluxcd.io/HelmRelease/cnpg-system/cnpg
+spec:
+  description: "Dawarich PostgreSQL with PostGIS"
+  # renovate: datasource=docker depName=ghcr.io/cloudnative-pg/postgis versioning=loose
+  imageName: ghcr.io/cloudnative-pg/postgis:17-3.5
+  instances: 1
+
+  postgresql:
+    parameters:
+      max_connections: "100"
+      shared_buffers: 256MB
+      effective_cache_size: 512MB
+
+  storage:
+    storageClass: truenas-iscsi
+    size: 10Gi
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+    limits:
+      memory: 2Gi
+
+  monitoring:
+    # Metrics scraped via apps/base/monitoring/extra-scrapes/cnpg-vmpodscrape.yaml
+    enablePodMonitor: false
+
+  env:
+    - name: AWS_DEFAULT_REGION
+      value: garage
+    - name: AWS_REGION
+      value: garage
+
+  backup:
+    barmanObjectStore:
+      destinationPath: s3://cnpg-backups/dawarich-postgres
+      endpointURL: http://192.168.10.94:30188
+      serverName: dawarich-postgres
+      s3Credentials:
+        accessKeyId:
+          name: cnpg-barman-s3-credentials
+          key: ACCESS_KEY_ID
+        secretAccessKey:
+          name: cnpg-barman-s3-credentials
+          key: ACCESS_SECRET_KEY
+      wal:
+        compression: gzip
+        maxParallel: 4
+      data:
+        compression: gzip
+    retentionPolicy: 30d
+
+  managed:
+    roles:
+      - name: dawarich
+        ensure: present
+        login: true
+        passwordSecret:
+          name: dawarich-db-credentials

--- a/infrastructure/overlays/main/database-clusters/dawarich-postgres/kustomization.yaml
+++ b/infrastructure/overlays/main/database-clusters/dawarich-postgres/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cluster.yaml
+  - scheduled-backup.yaml

--- a/infrastructure/overlays/main/database-clusters/dawarich-postgres/scheduled-backup.yaml
+++ b/infrastructure/overlays/main/database-clusters/dawarich-postgres/scheduled-backup.yaml
@@ -1,0 +1,12 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: dawarich-postgres-daily
+  namespace: cnpg-system
+spec:
+  schedule: "0 50 2 * * *"
+  backupOwnerReference: cluster
+  cluster:
+    name: dawarich-postgres
+  method: barmanObjectStore
+  target: prefer-standby

--- a/infrastructure/overlays/main/database-clusters/kustomization.yaml
+++ b/infrastructure/overlays/main/database-clusters/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - cluster.yaml
   - immich-postgres
+  - dawarich-postgres
   - scheduled-backup.yaml
   - barman-s3-credentials.secret.yaml
   - credentials


### PR DESCRIPTION
Self-hosted [Dawarich](https://dawarich.app/) 1.8.1 — location history tracking — at **https://locate.f4mily.net**.

## What's included
- **App**: single pod (web + sidekiq) sharing RWO PVCs (`public`/`watched`/`storage`); **Valkey** for cache + Sidekiq queue
- **Database**: dedicated **CNPG PostGIS** cluster (`postgis:17-3.5`) with the `postgis` extension, S3 barman backup + daily `ScheduledBackup` — mirrors the `immich-postgres` pattern (stock `homelab-postgres` has no PostGIS)
- **OIDC SSO** via Authentik: blueprint (provider + application), `OIDC_AUTO_REGISTER` so accounts are created on first Authentik login; built-in email/password login retained for admin bootstrap
- **Monitoring**: Gatus health endpoint (`/api/v1/health` + body assertion) and README catalog row
- **Secrets** (`SECRET_KEY_BASE`, DB credentials, OIDC client) SOPS-encrypted

## Validation
- `kustomize build` (apps + infra overlays) ✅
- `yamllint` (all repo dirs) ✅
- `just validate` (CI stages 1–2) ✅

## Notes
- Reverse geocoding uses Komoot's public Photon for now (self-host later if rate-limited)
- Branch was rebased onto latest `main`; unrelated local forgejo-runner working changes were excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)