### PR TITLE
fix(dawarich): make health probes work with force_ssl

### DIFF
--- a/apps/base/dawarich/deployment.yaml
+++ b/apps/base/dawarich/deployment.yaml
@@ -68,11 +68,29 @@ spec:
               mountPath: /var/app/tmp/imports/watched
             - name: storage
               mountPath: /var/app/storage
+          # APPLICATION_PROTOCOL=https sets Rails config.force_ssl, which 301-redirects
+          # plain HTTP to https:// — the kubelet then does a TLS handshake against the
+          # plain-HTTP Puma ("SSL connection to non-SSL Puma") and the probe fails. The
+          # X-Forwarded-Proto header makes Rails treat the probe as already-secure → 200.
+          # startupProbe gates liveness during the (slow) first-boot DB migration.
+          startupProbe:
+            httpGet:
+              path: /api/v1/health
+              port: http
+              httpHeaders:
+                - name: X-Forwarded-Proto
+                  value: https
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 60
           livenessProbe:
             httpGet:
               path: /api/v1/health
               port: http
-            initialDelaySeconds: 90
+              httpHeaders:
+                - name: X-Forwarded-Proto
+                  value: https
             periodSeconds: 15
             timeoutSeconds: 5
             failureThreshold: 5
@@ -80,7 +98,9 @@ spec:
             httpGet:
               path: /api/v1/health
               port: http
-            initialDelaySeconds: 30
+              httpHeaders:
+                - name: X-Forwarded-Proto
+                  value: https
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 5


### PR DESCRIPTION
The Dawarich web container crash-loops on first deploy.

## Root cause
`APPLICATION_PROTOCOL=https` sets Rails `config.force_ssl` ([source](https://github.com/Freika/dawarich/blob/master/config/environments/production.rb)). Plain-HTTP kubelet probes get a `301` redirect to `https://<podIP>:3000`, the kubelet follows it with a TLS handshake against the plain-HTTP Puma → `http: server gave HTTP response to HTTPS client` / `Are you trying to open an SSL connection to a non-SSL Puma?`, liveness kills the container mid-migration.

## Fix
- Probes send `X-Forwarded-Proto: https` → Rails treats them as already-secure (`200`, no redirect)
- Added a `startupProbe` (failureThreshold 60 × 10s) so liveness doesn't fire during the slow first-boot PostGIS migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)