### PR TITLE
fix(dawarich): resolve OIDC issuer mismatch with Authentik

### DIFF
--- a/apps/base/dawarich/configmap.yaml
+++ b/apps/base/dawarich/configmap.yaml
@@ -27,8 +27,15 @@ data:
   PHOTON_API_USE_HTTPS: "true"
   # --- OIDC SSO via Authentik (client id/secret injected from secret) ---------
   OIDC_PROVIDER_NAME: "Authentik"
-  # Authentik issuer; Dawarich appends /.well-known/openid-configuration itself.
-  OIDC_ISSUER: "https://login.f4mily.net/application/o/dawarich/"
+  # Trailing DOUBLE slash is intentional. Dawarich's OidcConfig.normalize_issuer
+  # does .chomp('/'), which strips exactly ONE trailing slash, leaving
+  # ".../dawarich/". Authentik's discovery document always reports the issuer
+  # WITH a trailing slash, and openid_connect's discovery validates the issuer
+  # by exact string match. A single slash here would be chomped to
+  # ".../dawarich" and fail login with "Issuer mismatch"; the doubled slash
+  # survives the chomp and matches Authentik exactly. (File.join collapses the
+  # extra slash when building the .well-known URL, so discovery still resolves.)
+  OIDC_ISSUER: "https://login.f4mily.net/application/o/dawarich//"
   OIDC_REDIRECT_URI: "https://locate.f4mily.net/users/auth/openid_connect/callback"
   # Auto-provision a Dawarich account on first successful OIDC login.
   OIDC_AUTO_REGISTER: "true"

--- a/apps/base/dawarich/deployment.yaml
+++ b/apps/base/dawarich/deployment.yaml
@@ -20,6 +20,11 @@ spec:
     metadata:
       labels:
         app: dawarich
+      annotations:
+        # Bump when dawarich-env ConfigMap changes — the app reads env via
+        # configMapRef at startup, so a pod-template change is needed to roll
+        # new env (no Reloader in-cluster). Increment on each config edit.
+        config.dawarich/env-revision: "2"
     spec:
       containers:
         # ---------------------------------------------------------------- web


### PR DESCRIPTION
OIDC login fails with **"Authentication provider configuration error"** (`omniauth: Issuer mismatch`).

## Root cause
Dawarich's `OidcConfig.normalize_issuer` calls `.chomp('/')` on `OIDC_ISSUER` → `https://login.f4mily.net/application/o/dawarich` (no slash). Authentik's discovery document always reports `issuer` **with** a trailing slash, and `openid_connect`'s discovery validates by exact string match → mismatch.

## Fix
Doubled trailing slash in `OIDC_ISSUER` (`.../o/dawarich//`): `.chomp('/')` strips one, leaving `.../o/dawarich/` which matches Authentik exactly. `File.join` collapses the extra slash when building the `.well-known` URL, so discovery still resolves (verified against the live Authentik instance).

Confirmed root cause from pod logs:
```
ERROR -- omniauth: (openid_connect) Authentication failure! Issuer mismatch: OpenIDConnect::Discovery::DiscoveryFailed, Issuer mismatch
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)