### PR TITLE
feat(workshops): host static courses at workshop.f4mily.net via git-sync

### DIFF
--- a/apps/base/workshops/configmap.yaml
+++ b/apps/base/workshops/configmap.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: workshops-nginx
+  namespace: workshops
+data:
+  # nginx serves the git-sync working copy. `/git/current` is the symlink
+  # git-sync atomically swaps on every new commit, so content updates are
+  # picked up per-request without restarting nginx.
+  default.conf: |
+    server {
+        listen 80;
+        listen [::]:80;
+        server_name _;
+
+        root /git/current;
+        index index.html;
+
+        # Static workshop sites: serve files / directory indexes, else 404.
+        location / {
+            try_files $uri $uri/ =404;
+        }
+
+        # Liveness/readiness endpoint (independent of synced content).
+        location = /healthz {
+            access_log off;
+            add_header Content-Type text/plain;
+            return 200 "ok\n";
+        }
+    }

--- a/apps/base/workshops/deployment.yaml
+++ b/apps/base/workshops/deployment.yaml
@@ -1,0 +1,98 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: workshops
+  namespace: workshops
+  labels:
+    app: workshops
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: workshops
+  template:
+    metadata:
+      labels:
+        app: workshops
+    spec:
+      securityContext:
+        # git-sync runs as uid/gid 65533; fsGroup makes the shared emptyDir
+        # group-writable so it can check out the repo there.
+        fsGroup: 65533
+      initContainers:
+        # One-time clone so nginx has content before it starts serving.
+        - name: git-sync-init
+          image: registry.k8s.io/git-sync/git-sync:v4.4.0
+          args:
+            - --repo=https://git.f4mily.net/kreativmonkey/workshops.git
+            - --ref=main
+            - --root=/git
+            - --link=current
+            - --depth=1
+            - --one-time
+          volumeMounts:
+            - name: web
+              mountPath: /git
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
+      containers:
+        - name: nginx
+          image: nginx:1.27-alpine
+          ports:
+            - containerPort: 80
+              name: http
+          volumeMounts:
+            - name: web
+              mountPath: /git
+              readOnly: true
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: default.conf
+              readOnly: true
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              memory: 64Mi
+        # Sidecar keeps the working copy in sync with the repo (every 60s).
+        - name: git-sync
+          image: registry.k8s.io/git-sync/git-sync:v4.4.0
+          args:
+            - --repo=https://git.f4mily.net/kreativmonkey/workshops.git
+            - --ref=main
+            - --root=/git
+            - --link=current
+            - --depth=1
+            - --period=60s
+          volumeMounts:
+            - name: web
+              mountPath: /git
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
+      volumes:
+        - name: web
+          emptyDir: {}
+        - name: nginx-config
+          configMap:
+            name: workshops-nginx

--- a/apps/base/workshops/ingress.yaml
+++ b/apps/base/workshops/ingress.yaml
@@ -1,0 +1,33 @@
+# Public HTTPS access (public wildcard TLS).
+# Host + TLS secret are injected by the overlay via replacements
+# (host_workshops / publicTlsSecret); the literals below are defaults.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: workshops
+  namespace: workshops
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: Workshops
+    gethomepage.dev/description: Hands-on Kurse (Forgejo, GitLab, Kubernetes)
+    gethomepage.dev/group: Development
+    gethomepage.dev/icon: mdi-school
+    nginx.org/ssl-redirect: "false"
+    nginx.org/redirect-to-https: "true"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - workshop.f4mily.net
+      secretName: wildcard-f4mily-net-tls
+  rules:
+    - host: workshop.f4mily.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: workshops
+                port:
+                  number: 80

--- a/apps/base/workshops/kustomization.yaml
+++ b/apps/base/workshops/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - configmap.yaml
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml

--- a/apps/base/workshops/namespace.yaml
+++ b/apps/base/workshops/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: workshops
+  labels:
+    app.kubernetes.io/name: workshops
+    app.kubernetes.io/part-of: homelab

--- a/apps/base/workshops/service.yaml
+++ b/apps/base/workshops/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: workshops
+  namespace: workshops
+spec:
+  selector:
+    app: workshops
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+  type: ClusterIP

--- a/apps/overlays/main/cluster-config.yaml
+++ b/apps/overlays/main/cluster-config.yaml
@@ -69,6 +69,7 @@ data:
   url_readeck: https://readeck.f4mily.net
   host_sparkyfitness: fitness.f4mily.net
   url_sparkyfitness: https://fitness.f4mily.net
+  host_workshops: workshop.f4mily.net
 
   # Cluster-internal apps (covered by *.cluster.f4mily.net wildcard):
   host_goloom: goloom.cluster.f4mily.net

--- a/apps/overlays/main/kustomization.yaml
+++ b/apps/overlays/main/kustomization.yaml
@@ -61,6 +61,7 @@ resources:
   - ../../base/teslamate
   - ../../base/dawarich
   - ../../base/goloom
+  - ../../base/workshops
   # - ../../base/pcm                 # wip: ingress only, no workload
 
   # --- Standalone workloads (already-deployed) --------------------------
@@ -334,6 +335,16 @@ replacements:
   - source:
       kind: ConfigMap
       name: homelab-cluster-config
+      fieldPath: data.host_workshops
+    targets:
+      - select: {kind: Ingress, name: workshops}
+        fieldPaths:
+          - spec.rules.0.host
+          - spec.tls.0.hosts.0
+
+  - source:
+      kind: ConfigMap
+      name: homelab-cluster-config
       fieldPath: data.publicTlsSecret
     targets:
       - select: {kind: Ingress, name: outline}
@@ -369,6 +380,8 @@ replacements:
       - select: {kind: Ingress, name: nextcloud}
         fieldPaths: [spec.tls.0.secretName]
       - select: {kind: Ingress, name: tandoor}
+        fieldPaths: [spec.tls.0.secretName]
+      - select: {kind: Ingress, name: workshops}
         fieldPaths: [spec.tls.0.secretName]
 
   - source:

--- a/docs/applications.md
+++ b/docs/applications.md
@@ -77,6 +77,7 @@ here so it is obvious what is **planned** but not deployed:
 | goloom             | on     | Deployment, CNPG PostgreSQL, goloom.cluster.f4mily.net |
 | spectrumknx        | on     | StatefulSet + own TimescaleDB, KNX bus monitor, knx.cluster.f4mily.net |
 | pcm                | wip    | ingress only, missing HelmRelease         |
+| workshops          | on     | nginx + git-sync sidecar, static courses from git.f4mily.net/kreativmonkey/workshops, workshop.f4mily.net |
 
 ## 2. The config file (`apps/overlays/main/cluster-config.yaml`)
 


### PR DESCRIPTION
## Was

Hostet die drei statischen Workshop-Sites (forgejo-pipeline, gitlab-pipeline, kubernetes) unter **workshop.f4mily.net**.

## Wie

- **nginx + git-sync**: Ein nginx-Pod serviert eine git-sync-Arbeitskopie von `git.f4mily.net/kreativmonkey/workshops`. Init-Container klont einmalig (Inhalt vor erstem Request da), Sidecar synct alle 60s. nginx serviert den atomar getauschten `/git/current`-Symlink → Content-Updates ohne Redeploy (einfach in den Workshop-Repo pushen).
- **Landing-Page**: `index.html` im Workshop-Repo mit Navigation zu den drei Kursen.
- **URL-Layout**: ein Host + Subpfade (`/forgejo-pipeline/`, `/gitlab-pipeline/`, `/kubernetes/`) — deckt das bestehende `*.f4mily.net`-Wildcard-Cert ab, kein neues Zertifikat nötig.
- Verdrahtung wie üblich: `host_workshops` in `cluster-config.yaml`, Host/TLS-Replacements in der Overlay-Kustomization, `gethomepage.dev`-Annotations fürs Dashboard, Zeile in `docs/applications.md`.

## Verifiziert

`nix develop --command just validate` läuft sauber (0 Invalid, 0 Errors). Ingress rendert mit `workshop.f4mily.net` + `wildcard-f4mily-net-tls`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)