### PR TITLE
fix(monitoring): valid alert label homelab_owner (was homelab/owner)

### DIFF
--- a/apps/base/monitoring/rules/blackbox-vmrule.yaml
+++ b/apps/base/monitoring/rules/blackbox-vmrule.yaml
@@ -19,7 +19,7 @@ spec:
           labels:
             severity: critical
             cluster: homelab
-            homelab/owner: platform
+            homelab_owner: platform
           annotations:
             summary: "Blackbox-Probe fehlgeschlagen: {{ $labels.instance }}"
             description: "Der Endpunkt {{ $labels.instance }} ist nicht erreichbar oder antwortet mit einem Fehlerstatus. HTTP/SSL-Prüfung fehlgeschlagen."
@@ -30,7 +30,7 @@ spec:
           labels:
             severity: warning
             cluster: homelab
-            homelab/owner: platform
+            homelab_owner: platform
           annotations:
             summary: "SSL-Zertifikat läuft bald ab: {{ $labels.instance }}"
             description: "Das SSL-Zertifikat für {{ $labels.instance }} läuft in weniger als 7 Tagen ab. Läuft ab am {{ $value | humanizeTimestamp }}."

--- a/apps/base/monitoring/rules/platform-p0-vmrule.yaml
+++ b/apps/base/monitoring/rules/platform-p0-vmrule.yaml
@@ -18,7 +18,7 @@ spec:
           labels:
             severity: critical
             cluster: homelab
-            homelab/owner: platform
+            homelab_owner: platform
           annotations:
             summary: "CNPG: keine Metriken in cnpg-system"
             description: "Der CNPG-Exporter liefert seit 5 Minuten keine Daten. Datenbank-Apps können betroffen sein."
@@ -30,7 +30,7 @@ spec:
           labels:
             severity: critical
             cluster: homelab
-            homelab/owner: platform
+            homelab_owner: platform
           annotations:
             summary: "CNPG-Instanz {{ $labels.pod }} offline"
             description: "Pod {{ $labels.pod }} in {{ $labels.namespace }} meldet cnpg_collector_up=0."
@@ -47,7 +47,7 @@ spec:
           labels:
             severity: warning
             cluster: homelab
-            homelab/owner: platform
+            homelab_owner: platform
           annotations:
             summary: "CNPG-Backup veraltet: {{ $labels.cluster }}"
             description: "Letztes verfügbares Backup für Cluster {{ $labels.cluster }} ist älter als 50 Stunden."
@@ -62,7 +62,7 @@ spec:
           labels:
             severity: warning
             cluster: homelab
-            homelab/owner: platform
+            homelab_owner: platform
           annotations:
             summary: "Velero-Backup fehlgeschlagen"
             description: "In der letzten Stunde wurden fehlgeschlagene Velero-Backups gezählt."
@@ -74,7 +74,7 @@ spec:
           labels:
             severity: warning
             cluster: homelab
-            homelab/owner: platform
+            homelab_owner: platform
           annotations:
             summary: "Velero: kein erfolgreiches Backup seit 36h"
             description: "Schedule {{ $labels.schedule }} — letzter Erfolg zu lange her."
@@ -93,7 +93,7 @@ spec:
           labels:
             severity: critical
             cluster: homelab
-            homelab/owner: platform
+            homelab_owner: platform
           annotations:
             summary: "Node {{ $labels.instance }}: Speicher kritisch (<10 % frei)"
             description: "Verfügbarer RAM unter 10 % seit 10 Minuten."
@@ -109,7 +109,7 @@ spec:
           labels:
             severity: critical
             cluster: homelab
-            homelab/owner: platform
+            homelab_owner: platform
           annotations:
             summary: "Node {{ $labels.instance }}: Disk {{ $labels.mountpoint }} <10 % frei"
             description: "Filesystem fast voll — Longhorn/CNPG/VM-Daten prüfen."
@@ -124,7 +124,7 @@ spec:
           labels:
             severity: critical
             cluster: homelab
-            homelab/owner: platform
+            homelab_owner: platform
           annotations:
             summary: "VMAlert scrape down ({{ $labels.job }})"
             description: "Alert-Auswertung ausgefallen — es werden ggf. keine neuen Alerts erzeugt."
@@ -136,7 +136,7 @@ spec:
           labels:
             severity: critical
             cluster: homelab
-            homelab/owner: platform
+            homelab_owner: platform
           annotations:
             summary: "Alertmanager scrape down ({{ $labels.job }})"
             description: "Benachrichtigungen nach ntfy werden nicht zugestellt."
@@ -150,7 +150,7 @@ spec:
           labels:
             severity: critical
             cluster: homelab
-            homelab/owner: platform
+            homelab_owner: platform
             homelab/auto_triage: "true"
           annotations:
             summary: "ntfy-bridge nicht verfügbar"

--- a/apps/base/monitoring/rules/workload-remediation-vmrule.yaml
+++ b/apps/base/monitoring/rules/workload-remediation-vmrule.yaml
@@ -19,7 +19,7 @@ spec:
           labels:
             severity: critical
             cluster: homelab
-            homelab/owner: platform
+            homelab_owner: platform
             homelab_auto_remediate: "true"
           annotations:
             summary: "OOMKilled: {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }})"
@@ -32,7 +32,7 @@ spec:
           labels:
             severity: critical
             cluster: homelab
-            homelab/owner: platform
+            homelab_owner: platform
             homelab_auto_remediate: "true"
           annotations:
             summary: "CrashLoopBackOff: {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }})"


### PR DESCRIPTION
## Problem

Die Alert-`labels:` der Plattform-VMRules trugen `homelab/owner: platform`. Ein `/` ist in einem PromQL-/Metric-Label-Namen ungültig:

- VictoriaMetrics lehnte die `ALERTS_FOR_STATE`-Restore-Queries mit **HTTP 422** ab (`labelFilterExpr: unexpected token "/"`) → Alert-State-Restore bei jedem vmalert-Neustart kaputt.
- Die Alertmanager-Route für **n8n-KI-Triage** matcht auf `homelab_owner="platform"` (bereits Underscore) → hat durch den Slash-Mismatch **nie gegriffen**. Die severity-basierten ntfy-Routes haben weiter funktioniert.

Aufgefallen bei der Analyse der CNPG-Failover-Kaskade (TrueNAS-iSCSI-I/O-Fehler) heute früh — `CNPGClusterInstanceDown`/`CNPGClusterOffline` konnten ihren State nicht korrekt halten.

## Fix

Alert-Label umbenannt `homelab/owner` → `homelab_owner` in den 3 VMRules (passt zum AM-Matcher und zur bestehenden `homelab_auto_remediate`-Konvention). Die `metadata.labels` `homelab/owner` (gültiges k8s-Label) bleiben unverändert.

Verifiziert: `kubectl kustomize apps/overlays/main/monitoring-rules` baut sauber; 14 Alert-Labels jetzt `homelab_owner`, verbleibende 3 `homelab/owner` sind nur metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)