### PR TITLE
feat(monitoring): TrueNAS SCALE exporter + alerts

### DIFF
--- a/apps/base/monitoring/extra-scrapes/kustomization.yaml
+++ b/apps/base/monitoring/extra-scrapes/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - cnpg-vmpodscrape.yaml
   - blackbox-vmprobe.yaml
   - blackbox-vmprobe-tandoor.yaml
+  - truenas-exporter-vmservicescrape.yaml

--- a/apps/base/monitoring/extra-scrapes/truenas-exporter-vmservicescrape.yaml
+++ b/apps/base/monitoring/extra-scrapes/truenas-exporter-vmservicescrape.yaml
@@ -1,0 +1,16 @@
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMServiceScrape
+metadata:
+  name: truenas-exporter
+  namespace: monitoring
+  labels:
+    release: victoriametrics
+spec:
+  endpoints:
+    - interval: 60s
+      scrapeTimeout: 30s
+      path: /metrics
+      port: metrics
+  selector:
+    matchLabels:
+      app: truenas-exporter

--- a/apps/base/monitoring/rules/kustomization.yaml
+++ b/apps/base/monitoring/rules/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - platform-p0-vmrule.yaml
   - workload-remediation-vmrule.yaml
   - blackbox-vmrule.yaml
+  - truenas-vmrule.yaml

--- a/apps/base/monitoring/rules/truenas-vmrule.yaml
+++ b/apps/base/monitoring/rules/truenas-vmrule.yaml
@@ -1,0 +1,106 @@
+# TrueNAS SCALE alerts (metrics from the in-cluster truenas-exporter).
+# The `homelab_owner: platform` alert label routes to ntfy + n8n triage.
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMRule
+metadata:
+  name: homelab-truenas
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/part-of: homelab-monitoring
+    homelab/owner: platform
+spec:
+  groups:
+    - name: homelab.platform.truenas
+      interval: 30s
+      rules:
+        - alert: TruenasExporterDown
+          # Exporter cannot reach the TrueNAS API (or is not scrapeable).
+          expr: |
+            truenas_up == 0 or absent(truenas_up)
+          for: 5m
+          labels:
+            severity: critical
+            cluster: homelab
+            homelab_owner: platform
+          annotations:
+            summary: "TrueNAS-Exporter/API nicht erreichbar"
+            description: "truenas_up=0 oder keine Metriken seit 5 Minuten. Storage-Backend (iSCSI für CNPG & Co.) nicht überwacht — bei Wiederholung der I/O-Störung blind."
+
+        - alert: TruenasPoolUnhealthy
+          expr: truenas_pool_healthy == 0
+          for: 5m
+          labels:
+            severity: critical
+            cluster: homelab
+            homelab_owner: platform
+          annotations:
+            summary: "TrueNAS-Pool {{ $labels.pool }} nicht healthy"
+            description: "ZFS-Pool {{ $labels.pool }} meldet healthy=0. Datenbank-/App-Volumes (iSCSI) können betroffen sein."
+
+        - alert: TruenasPoolIOErrors
+          # read/write/checksum error counters are normally 0; any nonzero is notable.
+          expr: |
+            (truenas_pool_read_errors + truenas_pool_write_errors + truenas_pool_checksum_errors) > 0
+          for: 5m
+          labels:
+            severity: warning
+            cluster: homelab
+            homelab_owner: platform
+          annotations:
+            summary: "TrueNAS-Pool {{ $labels.pool }}: ZFS-I/O-Fehler"
+            description: "Pool {{ $labels.pool }} zeigt read/write/checksum-Fehler > 0. Disk/vdev oder Transport prüfen (zpool status -v)."
+
+        - alert: TruenasScrubErrors
+          expr: truenas_pool_scan_errors > 0
+          for: 5m
+          labels:
+            severity: warning
+            cluster: homelab
+            homelab_owner: platform
+          annotations:
+            summary: "TrueNAS-Pool {{ $labels.pool }}: Scrub-Fehler"
+            description: "Letzter Scrub von Pool {{ $labels.pool }} meldet {{ $value }} Fehler."
+
+        - alert: TruenasPoolCapacityHigh
+          expr: truenas_pool_capacity_ratio > 0.85
+          for: 30m
+          labels:
+            severity: warning
+            cluster: homelab
+            homelab_owner: platform
+          annotations:
+            summary: "TrueNAS-Pool {{ $labels.pool }} > 85% voll"
+            description: "Pool {{ $labels.pool }} ist zu {{ $value | humanizePercentage }} belegt. ZFS-Performance leidet bei hoher Auslastung (relevant für iSCSI-Latenz)."
+
+        - alert: TruenasPoolCapacityCritical
+          expr: truenas_pool_capacity_ratio > 0.90
+          for: 10m
+          labels:
+            severity: critical
+            cluster: homelab
+            homelab_owner: platform
+          annotations:
+            summary: "TrueNAS-Pool {{ $labels.pool }} > 90% voll"
+            description: "Pool {{ $labels.pool }} ist zu {{ $value | humanizePercentage }} belegt — dringend aufräumen/erweitern."
+
+        - alert: TruenasAlertActiveCritical
+          expr: truenas_alerts_active{level="CRITICAL"} > 0
+          for: 5m
+          labels:
+            severity: critical
+            cluster: homelab
+            homelab_owner: platform
+          annotations:
+            summary: "TrueNAS meldet {{ $value }} kritische Alert(s)"
+            description: "Das TrueNAS-System hat aktive CRITICAL-Alerts. In der TrueNAS-UI (Alerts) nachsehen."
+
+        - alert: TruenasAlertActiveWarning
+          expr: truenas_alerts_active{level="WARNING"} > 0
+          for: 15m
+          labels:
+            severity: warning
+            cluster: homelab
+            homelab_owner: platform
+          annotations:
+            summary: "TrueNAS meldet {{ $value }} Warning-Alert(s)"
+            description: "Das TrueNAS-System hat aktive WARNING-Alerts. In der TrueNAS-UI (Alerts) nachsehen."

--- a/apps/base/truenas-exporter/configmap.yaml
+++ b/apps/base/truenas-exporter/configmap.yaml
@@ -1,0 +1,135 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: truenas-exporter-script
+  namespace: monitoring
+data:
+  # Minimal stdlib-only TrueNAS SCALE Prometheus exporter.
+  # Queries the REST API v2.0 (verified against TrueNAS SCALE 25.10) and
+  # exposes /metrics. No third-party deps, runs on a stock python image.
+  exporter.py: |
+    #!/usr/bin/env python3
+    """Minimal TrueNAS SCALE Prometheus exporter (Python stdlib only)."""
+    import json
+    import os
+    import time
+    import urllib.request
+    from http.server import BaseHTTPRequestHandler, HTTPServer
+
+    URL = os.environ.get("TRUENAS_URL", "http://192.168.10.94").rstrip("/")
+    API_KEY = os.environ.get("TRUENAS_API_KEY", "")
+    PORT = int(os.environ.get("LISTEN_PORT", "9849"))
+    TIMEOUT = float(os.environ.get("TRUENAS_TIMEOUT", "15"))
+
+
+    def _api(path):
+        req = urllib.request.Request(
+            URL + "/api/v2.0/" + path,
+            headers={"Authorization": "Bearer " + API_KEY},
+        )
+        with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:
+            return json.load(resp)
+
+
+    def _esc(v):
+        return str(v).replace("\\", "\\\\").replace('"', '\\"')
+
+
+    def _num(v):
+        # TrueNAS 25.10 returns several numeric fields as strings.
+        try:
+            return float(v)
+        except (TypeError, ValueError):
+            return 0.0
+
+
+    def _walk(node, acc):
+        st = node.get("stats") or {}
+        acc[0] += _num(st.get("read_errors"))
+        acc[1] += _num(st.get("write_errors"))
+        acc[2] += _num(st.get("checksum_errors"))
+        for child in node.get("children") or []:
+            _walk(child, acc)
+
+
+    def collect():
+        out = []
+
+        def m(name, value, **labels):
+            if labels:
+                lbl = ",".join('%s="%s"' % (k, _esc(v)) for k, v in labels.items())
+                out.append("%s{%s} %s" % (name, lbl, value))
+            else:
+                out.append("%s %s" % (name, value))
+
+        start = time.time()
+        up = 1
+        pools, alerts = [], []
+        try:
+            pools = _api("pool")
+            alerts = _api("alert/list")
+        except Exception as exc:  # noqa: BLE001
+            up = 0
+            m("truenas_scrape_error", 1, error=str(exc)[:120])
+
+        m("truenas_up", up)
+
+        for p in pools:
+            name = p.get("name", "unknown")
+            size = _num(p.get("size"))
+            alloc = _num(p.get("allocated"))
+            m("truenas_pool_healthy", 1 if p.get("healthy") else 0, pool=name)
+            m("truenas_pool_status", 1, pool=name, status=p.get("status", "UNKNOWN"))
+            m("truenas_pool_size_bytes", size, pool=name)
+            m("truenas_pool_allocated_bytes", alloc, pool=name)
+            m("truenas_pool_free_bytes", _num(p.get("free")), pool=name)
+            m("truenas_pool_capacity_ratio", (alloc / size) if size else 0, pool=name)
+            m("truenas_pool_fragmentation_ratio", _num(p.get("fragmentation")) / 100.0, pool=name)
+            scan = p.get("scan") or {}
+            m("truenas_pool_scan_errors", _num(scan.get("errors")), pool=name)
+            m("truenas_pool_scan_state", 1, pool=name,
+              state=scan.get("state", "NONE"), function=scan.get("function", "NONE"))
+            acc = [0, 0, 0]
+            top = p.get("topology") or {}
+            for grp in ("data", "cache", "log", "special", "dedup", "spare"):
+                for vdev in top.get(grp) or []:
+                    _walk(vdev, acc)
+            m("truenas_pool_read_errors", acc[0], pool=name)
+            m("truenas_pool_write_errors", acc[1], pool=name)
+            m("truenas_pool_checksum_errors", acc[2], pool=name)
+
+        counts = {}
+        for a in alerts:
+            if a.get("dismissed"):
+                continue
+            lvl = a.get("level", "UNKNOWN")
+            counts[lvl] = counts.get(lvl, 0) + 1
+        for lvl in set(list(counts.keys()) + ["INFO", "WARNING", "CRITICAL"]):
+            m("truenas_alerts_active", counts.get(lvl, 0), level=lvl)
+
+        m("truenas_scrape_duration_seconds", round(time.time() - start, 4))
+        return "\n".join(out) + "\n"
+
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            if self.path.split("?")[0] != "/metrics":
+                self.send_response(404)
+                self.end_headers()
+                return
+            try:
+                body = collect().encode()
+            except Exception:  # noqa: BLE001
+                body = b"truenas_up 0\n"
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain; version=0.0.4")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *args):
+            pass
+
+
+    if __name__ == "__main__":
+        HTTPServer(("", PORT), Handler).serve_forever()

--- a/apps/base/truenas-exporter/deployment.yaml
+++ b/apps/base/truenas-exporter/deployment.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: truenas-exporter
+  namespace: monitoring
+  labels:
+    app: truenas-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: truenas-exporter
+  template:
+    metadata:
+      labels:
+        app: truenas-exporter
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: exporter
+          image: python:3.13-slim
+          command: ["python3", "/app/exporter.py"]
+          ports:
+            - containerPort: 9849
+              name: metrics
+          env:
+            - name: LISTEN_PORT
+              value: "9849"
+            - name: TRUENAS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: truenas-exporter-credentials
+                  key: TRUENAS_URL
+            - name: TRUENAS_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: truenas-exporter-credentials
+                  key: TRUENAS_API_KEY
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: script
+              mountPath: /app
+              readOnly: true
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: 5
+            periodSeconds: 15
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
+      volumes:
+        - name: script
+          configMap:
+            name: truenas-exporter-script

--- a/apps/base/truenas-exporter/kustomization.yaml
+++ b/apps/base/truenas-exporter/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - configmap.yaml
+  - deployment.yaml
+  - service.yaml

--- a/apps/base/truenas-exporter/service.yaml
+++ b/apps/base/truenas-exporter/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: truenas-exporter
+  namespace: monitoring
+  labels:
+    app: truenas-exporter
+spec:
+  selector:
+    app: truenas-exporter
+  ports:
+    - name: metrics
+      port: 9849
+      targetPort: metrics
+      protocol: TCP
+  type: ClusterIP

--- a/apps/overlays/main/kustomization.yaml
+++ b/apps/overlays/main/kustomization.yaml
@@ -53,6 +53,8 @@ resources:
   # - ../../base/speedtest-tracker   # wip: ingress only, no workload
   - ../../base/watchyourlan
   - ../../base/gatus
+  - ../../base/truenas-exporter
+  - truenas-exporter.secret.yaml
 
   # --- Smart Home -------------------------------------------------------
   - ../../base/spectrumknx

--- a/apps/overlays/main/truenas-exporter.secret.yaml
+++ b/apps/overlays/main/truenas-exporter.secret.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: truenas-exporter-credentials
+    namespace: monitoring
+type: Opaque
+stringData:
+    TRUENAS_URL: ENC[AES256_GCM,data:Bv1QylzbiPLNVdNgXhW9pl106N4=,iv:zaJqOLzpwTCbCsVnzOlJuE2hR3IadB0QEhVrdBxDoZ4=,tag:PWtZcNHEL//+t2mhRXodvA==,type:str]
+    TRUENAS_API_KEY: ENC[AES256_GCM,data:WJRM6da238/vCP5JQBMGm2pCiD3ZElavS+CK5DPZwnckyIUIxY7168ixbP8mk0qT2JT3MOJIsEgmu8reFpLXX8wu,iv:NHG8DQkHjY8A1pxlbnpBLvOILVmr+l9slIgnTIpM6IM=,tag:fXHaZOaOCUgsrLD86jzZqw==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUanVxS2pUaWRnMmhHRyti
+            ajZYb0tDZXIwcndhMGxCRE5EalB1c2RicG5RCloxNUthRUl2U1RMeUdJSDRBMmpG
+            Q012QXBPakFIbFVES3h6NHYrd3QxYlUKLS0tIGFaNjFYdFJwb1M4YWVoMW9sNXFn
+            T1BhMVdqNWIwSmw0ME9LdUZNa2ppV3cK+9hycihW7rpPtTi4YA8MPc7pl1TUMEmy
+            nITRWFEvnJDjLUGMO+klw3twqHRdOrpQFeEi3BoJULqflsI27WDD2Q==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1u5lcvuuwd4lk7f3xewjk70j75yuh68myr89qkd0e8d44zgyjleeqw03vqs
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-23T07:45:31Z"
+    mac: ENC[AES256_GCM,data:171llUxrCI/nix5zxS+j97YzzidiiJgA/5KpNfC+NYq0lLjS1A56NqXZo5qsa4BQQVVP6wp/ljanyhtpC9lkSILzU7O5+G2jk8HIfWqBxrGwxlUv8OX3RBN9W4kifCB3t0SkBwpt8DpKi7ve6D6u1F3hgQgh53KiMPck+mT2g9w=,iv:WZt5S6Oo5gf6uPEUZ75B73B1Wkqw3SwpPngPni2XYXY=,tag:Xozmx3sBOtvlMz9mv2G73A==,type:str]
+    version: 3.13.1


### PR DESCRIPTION
## Warum

Der TrueNAS-Vorfall vom 23.06. (iSCSI-I/O-Fehler → CNPG-Failover-Kaskade) war **nur über Kernel-Logs** zuzuordnen, weil es **null NAS-seitige Sichtbarkeit** im VictoriaMetrics-Stack gab. Das schließt diese Lücke.

## Was

- **truenas-exporter** — minimaler **stdlib-only** Python-Exporter (kein Dritt-Image, läuft via ConfigMap-Skript auf `python:3.13-slim`). Fragt die TrueNAS REST-API v2.0 ab (**verifiziert gegen SCALE 25.10**) und exportiert:
  - Pool: `healthy`, `status`, Größe/Belegung/`capacity_ratio`, Fragmentierung
  - **ZFS read/write/checksum-Fehlerzähler** (aggregiert über die Topology), Scrub-Fehler
  - Aktive TrueNAS-Alerts nach Level
- **API-Key** als sops-verschlüsseltes Secret im Overlay.
- **VMServiceScrape** (`release: victoriametrics`) + **VMRule** mit dem jetzt funktionierenden `homelab_owner=platform`-Label → Routing zu ntfy + n8n-Triage.

## Verifiziert

Der Exporter wurde **lokal gegen die echte 25.10-Box** getestet (fand u.a. dass `fragmentation`/`size` als Strings kommen → abgehärtet). `nix develop just validate` grün (yamllint + kustomize + kubeconform). Beide Pools, Kapazität, Fehlerzähler, Alerts liefern valides Prometheus-Output.

## Alerts

`TruenasExporterDown`, `TruenasPoolUnhealthy`, `TruenasPoolIOErrors`, `TruenasScrubErrors`, `TruenasPoolCapacityHigh/Critical`, `TruenasAlertActiveCritical/Warning`.

## Hinweis / Follow-up

SCALE 25.10 läuft als **VM** (QEMU-Disks) und meldet Pools healthy → die iSCSI-Fehler waren **Transport/Latenz**, nicht ZFS-Datenfehler. Ein ergänzender **cluster-seitiger iSCSI-Latenz-Alert** ist der geplante nächste Schritt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)