### PR TITLE
fix(monitoring): stop sticky KubePodOOMKilled re-alerting

### DIFF
--- a/apps/base/forgejo/runner-deployment.yaml
+++ b/apps/base/forgejo/runner-deployment.yaml
@@ -85,14 +85,16 @@ spec:
               mountPath: /config
               readOnly: true
           # Orchestrator only — the actual job workloads run inside the dind
-          # sidecar and are bounded by *its* limits, not these.
+          # sidecar and are bounded by *its* limits, not these. Idle usage is
+          # ~15Mi; headroom is for log/output buffering spikes when dind jobs
+          # stall (e.g. the 2026-06-23 storage hiccup OOM-killed it at 512Mi).
           resources:
             requests:
               cpu: 100m
               memory: 128Mi
             limits:
               cpu: "1"
-              memory: 512Mi
+              memory: 768Mi
         - name: dind
           # renovate: datasource=docker depName=docker.io/library/docker
           image: docker.io/library/docker:27-dind

--- a/apps/base/monitoring/rules/workload-remediation-vmrule.yaml
+++ b/apps/base/monitoring/rules/workload-remediation-vmrule.yaml
@@ -14,7 +14,14 @@ spec:
       interval: 30s
       rules:
         - alert: KubePodOOMKilled
-          expr: kube_pod_container_status_last_terminated_reason{reason="OOMKilled"} == 1
+          # Fire only on a *recent* OOM (a restart in the last 15m). The
+          # last_terminated_reason series stays "OOMKilled" until the pod is
+          # recreated, so without the changes() guard a single one-off OOM
+          # alerts forever and keeps re-notifying.
+          expr: |
+            kube_pod_container_status_last_terminated_reason{reason="OOMKilled"} == 1
+            and on (namespace, pod, container)
+            changes(kube_pod_container_status_restarts_total[15m]) > 0
           for: 1m
           labels:
             severity: critical


### PR DESCRIPTION
## Problem

Dauer-Notifications für `KubePodOOMKilled`, obwohl nichts crasht. Ursache: der Alert feuert auf `kube_pod_container_status_last_terminated_reason{reason="OOMKilled"} == 1` — diese Serie bleibt **dauerhaft 1**, bis der Pod neu erstellt wird. Ein **einmaliger** OOM (forgejo-runner, gestern 22:11 im Storage-Störungsfenster, seitdem stabil bei 13Mi/512Mi) hält den Alert also **endlos am Feuern** und re-notifiziert pro `repeat_interval`.

Verstärkt durch #306: nachdem das `homelab_owner`-Label repariert war, greift zusätzlich die n8n/Telegram-Route → mehr Kanäle für denselben alten Alert.

## Fix

- **`KubePodOOMKilled`**: Guard mit `changes(kube_pod_container_status_restarts_total[15m]) > 0` → feuert nur bei *frischem* OOM und löst sich nach Stabilisierung selbst auf. Echte wiederkehrende OOMs (Restarts steigen weiter) feuern weiterhin korrekt.
- **forgejo-runner**: Orchestrator-Limit `512Mi → 768Mi` (Idle ~15Mi; Headroom fürs Log-Buffering, wenn dind-Jobs auf Storage stallen).

`nix develop just validate` grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)