### PR TITLE
fix(storage): disable backend-coupled liveness on democratic-csi controller

### DIFF
--- a/infrastructure/base/storage/democratic-csi/helmrelease.yaml
+++ b/infrastructure/base/storage/democratic-csi/helmrelease.yaml
@@ -29,6 +29,15 @@ spec:
         driver: freenas-api-iscsi
       existingConfigSecret: truenas-iscsi-driver-config
     controller:
+      # The chart's controller liveness probe calls the CSI Probe RPC, which
+      # pings the TrueNAS API. Transient TrueNAS API 500s (NAS VM under load /
+      # storage stall) made the otherwise-healthy controller restart-loop (94x)
+      # and page KubePodCrashLoopBackOff. failureThreshold/periodSeconds are
+      # hardcoded in the chart (not tunable), and restarting never fixes the
+      # backend — so disable the backend-coupled liveness. Real process crashes
+      # still exit the container and get restarted by the kubelet normally.
+      livenessProbe:
+        enabled: false
       driver:
         image:
           tag: next


### PR DESCRIPTION
## Problem

`KubePodCrashLoopBackOff`-Notifications für den democratic-csi iSCSI-**Controller**. Der `csi-driver`-Container hatte **94 Restarts** (`exit 15 / SIGTERM`).

Ursache: Die Chart-Liveness-Probe des Controllers ruft die CSI-`Probe`-RPC → die **pingt die TrueNAS-API**. Wenn die TrueNAS-VM kurz unter Last ist, liefert die API für ein paar Minuten **HTTP 500**; nach 3 fehlgeschlagenen Checks (failureThreshold/periodSeconds sind **im Chart hardcodiert**, nicht über Values tunebar) killt der Kubelet den ansonsten gesunden Controller. Ein Neustart fixt das Backend nie → sinnlose Churn + Alert-Lärm.

(Alle TrueNAS-Endpoints antworten aktuell mit 200 — die 500er sind intermittierend, dieselbe NAS-/VM-Instabilität, die wir separat angehen.)

## Fix

`controller.livenessProbe.enabled: false`. Echte Prozess-Crashes beenden den Container weiterhin und werden normal vom Kubelet neu gestartet — nur die backend-gekoppelte Liveness (ein Anti-Pattern) entfällt.

Verifiziert: `nix develop just validate` grün, democratic-csi rendert sauber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)