### PR TITLE
chore(renovate): short soak + automerge for fast-moving deps (searxng, self)

### DIFF
--- a/apps/base/searxng/deployment.yaml
+++ b/apps/base/searxng/deployment.yaml
@@ -28,7 +28,6 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: bootstrap-config
-          # renovate: datasource=docker depName=docker.io/searxng/searxng versioning=loose
           image: docker.io/searxng/searxng:2026.6.15-cf1410af8
           imagePullPolicy: IfNotPresent
           command:
@@ -55,7 +54,6 @@ spec:
               readOnly: true
       containers:
         - name: searxng
-          # renovate: datasource=docker depName=docker.io/searxng/searxng versioning=loose
           image: docker.io/searxng/searxng:2026.6.15-cf1410af8
           imagePullPolicy: IfNotPresent
           env:

--- a/renovate.json
+++ b/renovate.json
@@ -331,6 +331,37 @@
       "automerge": true,
       "automergeType": "pr",
       "platformAutomerge": true
+    },
+    {
+      "description": "searxng: rolling release (multiple CalVer+hash tags per day) — short soak + automerge so PRs don't perpetually backlog. Managed by the kubernetes manager (image: in deployment.yaml); no marker needed.",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "docker.io/searxng/searxng"
+      ],
+      "versioning": "loose",
+      "groupName": "searxng",
+      "groupSlug": "searxng",
+      "minimumReleaseAge": "2 days",
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true
+    },
+    {
+      "description": "Renovate self-update: several releases per day — short soak + automerge so PRs don't perpetually backlog",
+      "matchDepNames": [
+        "renovate"
+      ],
+      "matchFileNames": [
+        "apps/base/renovate/**"
+      ],
+      "groupName": "renovate",
+      "groupSlug": "renovate",
+      "minimumReleaseAge": "2 days",
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true
     }
   ],
   "prHourlyLimit": 2,


### PR DESCRIPTION
## Why

`#310` (searxng) and `#304` (Renovate self-update) perpetually showed **14 / 26 "pending" versions**. Root cause is not a bug: `minimumReleaseAge: "7 days"` is a deliberate soak, but both packages release **multiple times per day** (searxng rolling CalVer+hash tags; Renovate ~3–4 releases/day). 7 days × high cadence = a permanent two-digit backlog of manual-merge PRs that never clears.

## Changes

- **Dedicated `packageRule` per package**: `minimumReleaseAge: 2 days` + `automerge`, each in its own PR group (`searxng`, `renovate`), overriding the broad 7-day grouped rules.
- **Drop redundant `# renovate:` markers** on `apps/base/searxng/deployment.yaml` — the `kubernetes` manager already extracts the `image:` line, so the markers caused double management (custom.regex *and* kubernetes groups). `versioning=loose` now comes from the packageRule.

## Effect

- Soak 7→2 days catches up most pending versions immediately.
- `automerge` clears the backlog automatically once soaked — no more lingering manual PRs; both stay close to head.

Validated with `renovate-config-validator`: `Config validated successfully`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)