### PR TITLE
chore(renovate): group all Nextcloud refs into one PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -244,14 +244,15 @@
       "automerge": false
     },
     {
-      "description": "Group all flux Helm chart bumps (except kite / sparkyfitness)",
+      "description": "Group all flux Helm chart bumps (except kite / sparkyfitness / nextcloud)",
       "matchManagers": [
         "flux"
       ],
       "matchFileNames": [
         "!apps/base/kite/**",
         "!apps/base/authentik/**",
-        "!apps/base/sparkyfitness/**"
+        "!apps/base/sparkyfitness/**",
+        "!apps/base/nextcloud/**"
       ],
       "groupName": "flux helm releases",
       "groupSlug": "flux-helm-releases",
@@ -362,6 +363,20 @@
       "automerge": true,
       "automergeType": "pr",
       "platformAutomerge": true
+    },
+    {
+      "description": "Nextcloud: keep the Helm chart, the app image, and the occ-* init-container images in ONE PR. They share a single major version — a partial bump (e.g. occ init containers ahead of the app image) corrupts the data directory and trips Nextcloud's downgrade/skip-major guard. The refs are detected by helm-values AND the custom.regex markers; this rule (last, so it overrides the broad groups) collapses them into a single 'nextcloud' PR. Major upgrades stay manual and one major at a time.",
+      "matchFileNames": [
+        "apps/base/nextcloud/**"
+      ],
+      "matchPackageNames": [
+        "docker.io/library/nextcloud",
+        "nextcloud"
+      ],
+      "groupName": "nextcloud",
+      "groupSlug": "nextcloud",
+      "minimumReleaseAge": "7 days",
+      "automerge": false
     }
   ],
   "prHourlyLimit": 2,


### PR DESCRIPTION
## Problem

A single Nextcloud `33.0.5 → 34.0.0` upgrade was scattered across **three** Renovate PRs:
- **#290** — app image `values.image.tag` (+ unrelated teslamate/grafana)
- **#308** & **#309** — the three `occ-*` init-container images (identical diffs, different groups)

All four refs live in `apps/base/nextcloud/helmrelease.yaml` but are detected by **two managers** (`helm-values` *and* the custom.regex markers) and fell into different groups → fragmentation.

This is dangerous: a partial bump (e.g. occ init containers on 34 while the app image is still 33) corrupts the data directory and trips Nextcloud's skip-major / downgrade guard. The refs must always move together, one major at a time.

## Fix

Add a dedicated, **last-position** `nextcloud` `packageRule` (`matchFileNames` + `matchPackageNames`) that overrides the broad `helm-values` / `custom.regex` / `flux` groups and collapses the Helm chart, the app image and all `occ-*` images into **one** manual, 7-day-soaked PR. Mirrors the existing `sparkyfitness` / `authentik` grouping pattern. Also excludes `apps/base/nextcloud/**` from the broad flux group.

Validated with `renovate-config-validator`: `Config validated successfully`.

Once merged, Renovate will recreate #290/#308/#309 as a single `nextcloud` PR (and the teslamate/grafana bump splits back out into its own PR, where it belongs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)