### PR TITLE
chore(teslamate): resync grafana to 4.0.1 + group both images in lockstep

### DIFF
--- a/apps/base/teslamate/deployment-grafana.yaml
+++ b/apps/base/teslamate/deployment-grafana.yaml
@@ -24,7 +24,8 @@ spec:
       containers:
         - name: grafana
           # renovate: datasource=docker depName=docker.io/teslamate/grafana
-          image: docker.io/teslamate/grafana:3.1.0
+          # Pinned in lockstep with the teslamate app image (same version tag); bump both together.
+          image: docker.io/teslamate/grafana:4.0.1
           imagePullPolicy: Always
           ports:
             - containerPort: 3000

--- a/apps/base/teslamate/deployment.yaml
+++ b/apps/base/teslamate/deployment.yaml
@@ -25,6 +25,7 @@ spec:
         - name: teslamate
           # Pin version (DB already on 4.x migrations); bump via Renovate, not :latest.
           # v4.0.0: fixes Owner-API 403 (fleet-api) — TeslaMate #5384/#5391. Major upgrade, DB migrated.
+          # renovate: datasource=docker depName=docker.io/teslamate/teslamate
           image: docker.io/teslamate/teslamate:4.0.1
           imagePullPolicy: IfNotPresent
           ports:

--- a/renovate.json
+++ b/renovate.json
@@ -377,6 +377,20 @@
       "groupSlug": "nextcloud",
       "minimumReleaseAge": "7 days",
       "automerge": false
+    },
+    {
+      "description": "Teslamate: the app image (docker.io/teslamate/teslamate) and the dashboards image (docker.io/teslamate/grafana) ship in lockstep with identical version tags. Bump them together so the Grafana dashboards never drift from the app's DB schema (same coupling rationale as immich). Manual merge, major upgrades one at a time.",
+      "matchFileNames": [
+        "apps/base/teslamate/**"
+      ],
+      "matchPackageNames": [
+        "docker.io/teslamate/teslamate",
+        "docker.io/teslamate/grafana"
+      ],
+      "groupName": "teslamate",
+      "groupSlug": "teslamate",
+      "minimumReleaseAge": "7 days",
+      "automerge": false
     }
   ],
   "prHourlyLimit": 2,


### PR DESCRIPTION
## Context

TeslaMate ships the app and the dashboards image with **identical version tags** (`teslamate/teslamate:X.Y.Z` + `teslamate/grafana:X.Y.Z`; the official compose uses `:latest` for both). They must move together — Grafana dashboards are built against the app's DB schema.

Here they had **drifted**: the app was already on `4.0.1`, but `teslamate/grafana` was stuck on `3.1.0`. Root cause: the app image had **no `# renovate:` marker**, so Renovate never tracked it, while grafana was tracked separately and lagged.

## Verification (in the teslamate project)

- Latest release = **v4.0.1**; `3.1.0`/`4.0.0`/`4.0.1` exist for both images.
- v4.0.0's breaking change is the **ARMv7 drop + Owner-API 403 fix**, **not** a Grafana/dashboard schema break — the v4.0.0 "Dashboards" section is empty.
- → `teslamate/grafana:4.0.1` is the dashboards image built for app 4.0.1. Bumping it is the **due re-sync**, not a risky upgrade.

## Changes

- Add the `# renovate:` marker to the teslamate **app** image so Renovate tracks it.
- Bump `teslamate/grafana` `3.1.0 → 4.0.1` to match the running app.
- Add a `teslamate` `packageRule` grouping both images so they always bump together in one manual, soaked PR (same pattern as immich / nextcloud).

Validated with `renovate-config-validator`: `Config validated successfully`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)