### PR TITLE
fix(truenas-exporter): stop probe killing healthy pod (CrashLoop)

### DIFF
--- a/apps/base/truenas-exporter/deployment.yaml
+++ b/apps/base/truenas-exporter/deployment.yaml
@@ -31,6 +31,10 @@ spec:
           env:
             - name: LISTEN_PORT
               value: "9849"
+            - name: TRUENAS_TIMEOUT
+              # Bound the two sequential API calls so a full scrape (2x) stays
+              # well under the probe timeoutSeconds below.
+              value: "8"
             - name: TRUENAS_URL
               valueFrom:
                 secretKeyRef:
@@ -55,13 +59,20 @@ spec:
               path: /metrics
               port: metrics
             initialDelaySeconds: 10
-            periodSeconds: 30
+            periodSeconds: 60
+            # The exporter is single-threaded and blocks on synchronous TrueNAS
+            # API calls per scrape; timeoutSeconds must exceed a full scrape
+            # (2 x TRUENAS_TIMEOUT) or the probe kills a healthy pod.
+            timeoutSeconds: 20
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /metrics
               port: metrics
             initialDelaySeconds: 5
-            periodSeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 20
+            failureThreshold: 3
           resources:
             requests:
               cpu: 10m


### PR DESCRIPTION
## Problem
`truenas-exporter` was in CrashLoopBackOff with 220 restarts.

Root cause: the probes omitted `timeoutSeconds`, falling back to the 1s
default. Each scrape makes two sequential, blocking API calls on a
single-threaded stdlib HTTP server and takes >1s, so every probe timed out
and liveness killed a healthy pod. Logs were a wall of `BrokenPipeError`
(probe closing the socket before the response was written) — not an app
crash, not an auth error.

## Fix
- `timeoutSeconds: 20` on both probes (must exceed a full scrape).
- Bound the API timeout so a full scrape stays under the probe timeout.
- Relax `periodSeconds` to 60/30; set explicit `failureThreshold: 3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)