### PR TITLE
fix(truenas-exporter): rotate stale TrueNAS API key (401 -> auth)

### DIFF
--- a/apps/overlays/main/truenas-exporter.secret.yaml
+++ b/apps/overlays/main/truenas-exporter.secret.yaml
@@ -5,20 +5,20 @@ metadata:
     namespace: monitoring
 type: Opaque
 stringData:
-    TRUENAS_URL: ENC[AES256_GCM,data:Bv1QylzbiPLNVdNgXhW9pl106N4=,iv:zaJqOLzpwTCbCsVnzOlJuE2hR3IadB0QEhVrdBxDoZ4=,tag:PWtZcNHEL//+t2mhRXodvA==,type:str]
-    TRUENAS_API_KEY: ENC[AES256_GCM,data:WJRM6da238/vCP5JQBMGm2pCiD3ZElavS+CK5DPZwnckyIUIxY7168ixbP8mk0qT2JT3MOJIsEgmu8reFpLXX8wu,iv:NHG8DQkHjY8A1pxlbnpBLvOILVmr+l9slIgnTIpM6IM=,tag:fXHaZOaOCUgsrLD86jzZqw==,type:str]
+    TRUENAS_URL: ENC[AES256_GCM,data:1HLROWVj57+sdbHYEI45aIV4fx8=,iv:zm/nZOzsq9ibPgcq+KyRWLeS+d8qLe5+S1+l0lkziXg=,tag:9NleVfpHO4sFGj3khaSsqw==,type:str]
+    TRUENAS_API_KEY: ENC[AES256_GCM,data:00Q9clGs/wII8avBEuw2PI7y4oT6iY11U8FWhJaNSFdxgp9DUWf4M6s3eNeerKCh9saM5fJhaNhYsUrDD2OOGILQ,iv:Jp02y7GcGDriRUQ1geZ663bz6DycYlfPmPneA2NonG8=,tag:5JUr+b1IgWGjEFLLBQqsQg==,type:str]
 sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUanVxS2pUaWRnMmhHRyti
-            ajZYb0tDZXIwcndhMGxCRE5EalB1c2RicG5RCloxNUthRUl2U1RMeUdJSDRBMmpG
-            Q012QXBPakFIbFVES3h6NHYrd3QxYlUKLS0tIGFaNjFYdFJwb1M4YWVoMW9sNXFn
-            T1BhMVdqNWIwSmw0ME9LdUZNa2ppV3cK+9hycihW7rpPtTi4YA8MPc7pl1TUMEmy
-            nITRWFEvnJDjLUGMO+klw3twqHRdOrpQFeEi3BoJULqflsI27WDD2Q==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxUktXbzVZWWZyNWFkbytN
+            bHZFa3NMZHppeEdBNVdTZjZqVlJUaTZNNzJNCjk1d29BRE4xUUhSMS9oM0w0aHhU
+            K3JKV1NDVUJJVG5uVmc2SENocitqd0kKLS0tIHdmYmVIYnhQQ1FJSWhTQ1hFTzkw
+            NVp5R0lodno4ZnA5Q2g2MGx1OWJlWkkKZLvwsuFm78CK2r55xmc9Al0qUy7pRH33
+            yjHU+wMB/ucczHGSSgkTF46e25wqJiaJ5rv67AmajEReZkr3ajJeTQ==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1u5lcvuuwd4lk7f3xewjk70j75yuh68myr89qkd0e8d44zgyjleeqw03vqs
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-06-23T07:45:31Z"
-    mac: ENC[AES256_GCM,data:171llUxrCI/nix5zxS+j97YzzidiiJgA/5KpNfC+NYq0lLjS1A56NqXZo5qsa4BQQVVP6wp/ljanyhtpC9lkSILzU7O5+G2jk8HIfWqBxrGwxlUv8OX3RBN9W4kifCB3t0SkBwpt8DpKi7ve6D6u1F3hgQgh53KiMPck+mT2g9w=,iv:WZt5S6Oo5gf6uPEUZ75B73B1Wkqw3SwpPngPni2XYXY=,tag:Xozmx3sBOtvlMz9mv2G73A==,type:str]
+    lastmodified: "2026-06-24T13:33:52Z"
+    mac: ENC[AES256_GCM,data:cO/dYU3PKnPINOBlSnAnguiihcSSup+G5Ijwz8LdTrsZ1TSLQ/6Da11oYeTa9Uq9QYndBDn4RYOyP0/5Hjze08oaFeS4MTlTnTTXvz6aNgH3Lst1Jh0C9jUee1CBZWPO3fY3HilbyGemiJfqt/Tad5RSeuu6VeHsqvRLbkPzAnM=,iv:aVKj9xOJzkLjMzp0orMw3Hb2mMSBF5fBUGjuEC/kCGs=,tag:LYulr5NXF1atR6oHTg33Sw==,type:str]
     version: 3.13.1


### PR DESCRIPTION
## Problem
After the probe fix (#324) the pod is stable, but the scrape returned
`HTTP 401 Unauthorized` so `truenas_up` was `0`. The encrypted secret
predates the 25.10 legacy-key purge and still carried the revoked key.

## Fix
Rotate to the current user-linked key already used (and verified working)
by the iSCSI storage driver, re-encrypted via SOPS. No structural changes.

## Verification
After Flux reconciles, `truenas_up` should report `1` and
`truenas_scrape_error` should disappear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)