### PR TITLE
fix(goloom): image tag v0.1.3 + serve at goloom.f4mily.net

### DIFF
--- a/apps/base/goloom/helmrelease.yaml
+++ b/apps/base/goloom/helmrelease.yaml
@@ -55,8 +55,8 @@ spec:
 
     # --- Application configuration (non-secret) -----------------------------
     config:
-      publicBaseUrl: https://goloom.cluster.f4mily.net
-      allowedOrigins: https://goloom.cluster.f4mily.net
+      publicBaseUrl: https://goloom.f4mily.net
+      allowedOrigins: https://goloom.f4mily.net
       appEnv: production
       logLevel: info
       logFormat: json
@@ -91,7 +91,7 @@ spec:
       - name: MASTODON_DEFAULT_SCOPES
         value: read,write
       - name: MASTODON_REDIRECT_URI
-        value: https://goloom.cluster.f4mily.net/v1/oauth/mastodon/callback
+        value: https://goloom.f4mily.net/v1/oauth/mastodon/callback
       - name: OPENAI_BASE_URL
         value: https://opencode.ai
       - name: OPENAI_API_KEY

--- a/apps/base/goloom/helmrelease.yaml
+++ b/apps/base/goloom/helmrelease.yaml
@@ -26,11 +26,12 @@ spec:
   values:
     # Official image. The chart at tag v0.1.3 still pins appVersion 0.1.2, so we
     # pin the image explicitly to the matching app release and let Renovate bump
-    # it from the GitHub releases of the Goloom repo.
+    # it from the GitHub releases of the Goloom repo. GHCR tags are v-prefixed
+    # (v0.1.3); the chart's appVersion default (0.1.2, no "v") does not exist.
     image:
       repository: ghcr.io/goloom-app/goloom
-      # renovate: datasource=github-releases depName=Goloom-App/goloom extractVersion=^v(?<version>.+)$
-      tag: "0.1.3"
+      # renovate: datasource=github-releases depName=Goloom-App/goloom
+      tag: "v0.1.3"
       pullPolicy: IfNotPresent
 
     replicaCount: 1

--- a/apps/base/goloom/ingress.yaml
+++ b/apps/base/goloom/ingress.yaml
@@ -9,17 +9,17 @@ metadata:
     gethomepage.dev/description: Goloom
     gethomepage.dev/group: Tools
     gethomepage.dev/icon: mdi-view-dashboard
-    # TLS: wildcard-cluster-f4mily-net-tls via reflector (cert-manager namespace)
+    # TLS: wildcard-f4mily-net-tls via reflector (cert-manager namespace)
     nginx.org/ssl-redirect: "false"
     nginx.org/redirect-to-https: "true"
 spec:
   ingressClassName: nginx
   tls:
     - hosts:
-        - goloom.cluster.f4mily.net
-      secretName: wildcard-cluster-f4mily-net-tls
+        - goloom.f4mily.net
+      secretName: wildcard-f4mily-net-tls
   rules:
-    - host: goloom.cluster.f4mily.net
+    - host: goloom.f4mily.net
       http:
         paths:
           - path: /

--- a/apps/overlays/main/cluster-config.yaml
+++ b/apps/overlays/main/cluster-config.yaml
@@ -72,7 +72,7 @@ data:
   host_workshops: workshop.f4mily.net
 
   # Cluster-internal apps (covered by *.cluster.f4mily.net wildcard):
-  host_goloom: goloom.cluster.f4mily.net
+  host_goloom: goloom.f4mily.net
   host_nextcloud: nc.f4mily.net
   url_nextcloud: https://nc.f4mily.net
   host_homer: homer.cluster.f4mily.net

--- a/apps/overlays/main/kustomization.yaml
+++ b/apps/overlays/main/kustomization.yaml
@@ -385,14 +385,14 @@ replacements:
         fieldPaths: [spec.tls.0.secretName]
       - select: {kind: Ingress, name: workshops}
         fieldPaths: [spec.tls.0.secretName]
+      - select: {kind: Ingress, name: goloom}
+        fieldPaths: [spec.tls.0.secretName]
 
   - source:
       kind: ConfigMap
       name: homelab-cluster-config
       fieldPath: data.clusterTlsSecret
     targets:
-      - select: {kind: Ingress, name: goloom}
-        fieldPaths: [spec.tls.0.secretName]
       - select: {kind: Ingress, name: grafana}
         fieldPaths: [spec.tls.0.secretName]
       - select: {kind: Ingress, name: victoria-metrics}


### PR DESCRIPTION
Follow-up zu #335. Behebt zwei Punkte am gerade gemergten Goloom-Deploy:

## 1. ImagePullBackOff → Image-Tag `v0.1.3`
GHCR publiziert **v-prefixed** Tags (`v0.1.1/v0.1.2/v0.1.3`); `0.1.3` existiert nicht → der Pod hing in `ImagePullBackOff`. Tag auf `v0.1.3` gepinnt, Renovate-Marker ohne `extractVersion` (currentValue matcht das github-release direkt).

## 2. Public-Host `goloom.f4mily.net`
DNS für `goloom.f4mily.net` zeigt jetzt auf den Cluster-Ingress. App auf den **Prod-Host** statt `goloom.cluster.f4mily.net` umgestellt → die bestehenden **OIDC/Mastodon-Redirect-URIs bleiben gültig** (kein Authentik/Mastodon-Umbau nötig).

- ingress: Host + TLS → `goloom.f4mily.net` / `wildcard-f4mily-net-tls`
- helmrelease: `publicBaseUrl`/`allowedOrigins`/`MASTODON_REDIRECT_URI` → `goloom.f4mily.net`
- overlay: goloom-Ingress in den `publicTlsSecret`-Block verschoben
- cluster-config: `host_goloom` → `goloom.f4mily.net`

## Validierung
`helm template` → `ghcr.io/goloom-app/goloom:v0.1.3` ✓ · `kustomize build` Overlay ✓ · `yamllint` ✓

Nach Merge: Flux reconcile → Pod zieht das Image, App startet. Anschließend folgt der Daten-Restore (DB + Media).

🤖 Generated with [Claude Code](https://claude.com/claude-code)