### PR TITLE
fix(netbird): persist agent state via hostPath (stop identity churn / 504s)

### DIFF
--- a/apps/base/netbird/daemonset.yaml
+++ b/apps/base/netbird/daemonset.yaml
@@ -71,3 +71,17 @@ spec:
               memory: 32Mi
             limits:
               memory: 128Mi
+          volumeMounts:
+            # Persist the netbird identity/state across pod restarts so each node's
+            # peer keeps a STABLE netbird IP + FQDN. Without it, every rollout
+            # (image bump, node reboot, reconcile) re-registers as a NEW peer with
+            # a new IP, breaking external routes through this peer (504 gateway
+            # timeout) and leaving stale peers behind in the management server.
+            - name: state
+              mountPath: /var/lib/netbird
+      volumes:
+        # Per-node hostPath; Talos /var survives reboots and fits a DaemonSet.
+        - name: state
+          hostPath:
+            path: /var/lib/netbird-agent
+            type: DirectoryOrCreate


### PR DESCRIPTION
## Problem
Externe Zugriffe über netbird liefern wiederkehrend **504 Gateway Timeout** nach jedem netbird-Pod-Neustart.

**Ursache:** Die netbird-DaemonSet hat keinen persistenten State — die Identität (`/var/lib/netbird/state.json`, WireGuard-Key + Peer-Identität) liegt im **ephemeren Container-FS**. Jeder Rollout (Image-Bump, Node-Reboot, `flux reconcile`) → **Neu-Registrierung als neuer Peer** mit neuer netbird-IP + FQDN (der IP-Suffix steckt im FQDN, z. B. `talos-cp1-67-132`). Externe Routen/Proxy-Upstreams, die auf die alte Identität zeigen, brechen → 504. Zusätzlich sammeln sich Karteileichen (zuletzt **30 registriert / 10 connected**).

## Fix
Per-Node **`hostPath`** (`/var/lib/netbird-agent`, auf Talos `/var` reboot-fest) gemountet nach `/var/lib/netbird`. Die Peer-Identität überlebt damit Restarts → stabile IP/FQDN → Proxy-Upstream bleibt gültig.

## Nach dem Merge (einmalig)
- Agents registrieren sich **ein letztes Mal** neu (persistiert den State) → kurzer externer Blip.
- Reverse-Proxy-Upstream auf die dann **stabilen** Peer-IPs/FQDNs setzen.
- Im netbird-Dashboard (`netbird.f4mily.net`) die ~20 toten Peers aufräumen.

## Validierung
`kustomize build apps/base/netbird` ✓ · `yamllint` ✓ · Volume/Mount korrekt gerendert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)