### PR TITLE
chore(goloom): gatus internal check → goloom.f4mily.net; link repo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This cluster runs a variety of self-hosted applications. Uptime is monitored via
 | [**tandoor**](https://tandoor.dev/) | Recipes | ![Uptime](https://status.cluster.f4mily.net/api/v1/endpoints/application_tandoor/uptimes/30d/badge.svg) |
 | [**SparkyFitness**](https://github.com/codewithcj/SparkyFitness) | Fitness | ![Uptime](https://status.cluster.f4mily.net/api/v1/endpoints/application_fitness/uptimes/30d/badge.svg) |
 | [**n8n**](https://n8n.io/) | Automation | ![Uptime](https://status.cluster.f4mily.net/api/v1/endpoints/automation_n8n/uptimes/30d/badge.svg) |
-| **goloom** | Automation | ![Uptime](https://status.cluster.f4mily.net/api/v1/endpoints/automation_goloom/uptimes/30d/badge.svg) |
+| [**goloom**](https://github.com/Goloom-App/goloom) | Automation | ![Uptime](https://status.cluster.f4mily.net/api/v1/endpoints/automation_goloom/uptimes/30d/badge.svg) |
 | [**SpectrumKNX**](https://github.com/martinhoefling/SpectrumKNX) | Smart Home | ![Uptime](https://status.cluster.f4mily.net/api/v1/endpoints/automation_spectrumknx/uptimes/30d/badge.svg) |
 | [**teslamate**](https://github.com/adriankumpf/teslamate) | Car Tracking | ![Uptime](https://status.cluster.f4mily.net/api/v1/endpoints/observability_teslamate/uptimes/30d/badge.svg) |
 | [**dawarich**](https://dawarich.app/) | Location Tracking | ![Uptime](https://status.cluster.f4mily.net/api/v1/endpoints/application_dawarich/uptimes/30d/badge.svg) |

--- a/apps/base/gatus/helmrelease.yaml
+++ b/apps/base/gatus/helmrelease.yaml
@@ -306,7 +306,7 @@ spec:
 
         - name: goloom
           group: automation
-          url: https://goloom.cluster.f4mily.net/healthz
+          url: https://goloom.f4mily.net/healthz
           interval: 60s
           client: *default-dns
           conditions:


### PR DESCRIPTION
Kleinkram nach dem goloom-Umzug auf den Public-Host (#336):

- **gatus**: Der interne `automation`-Check zeigte noch auf `goloom.cluster.f4mily.net/healthz` — das serviced der Ingress seit #336 nicht mehr. Auf `https://goloom.f4mily.net/healthz` umgestellt (der `external`-Check nutzte das schon).
- **README**: goloom-Eintrag auf das GitHub-Repo `Goloom-App/goloom` verlinkt (wie die übrigen Katalog-Einträge).

Validiert: `yamllint` + `kustomize build apps/base/gatus` ✓.

> Direkt-Push auf `main` war vom Branch-Protection-Ruleset abgelehnt (PR + `validate`-Check Pflicht) — daher dieser PR; kann durchgewunken werden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)