### PR TITLE
fix(monitoring): retarget goloom blackbox probe to goloom.f4mily.net

### DIFF
--- a/apps/base/monitoring/extra-scrapes/blackbox-vmprobe.yaml
+++ b/apps/base/monitoring/extra-scrapes/blackbox-vmprobe.yaml
@@ -32,8 +32,8 @@ spec:
         - https://readeck.f4mily.net
         - https://fitness.f4mily.net
         - https://nc.f4mily.net
+        - https://goloom.f4mily.net/healthz
         # Cluster-internal (cluster.f4mily.net)
-        - https://goloom.cluster.f4mily.net/healthz
         - https://grafana.cluster.f4mily.net/api/health
         - https://metrics.cluster.f4mily.net
         - https://n8n.cluster.f4mily.net

--- a/docs/applications.md
+++ b/docs/applications.md
@@ -74,7 +74,7 @@ here so it is obvious what is **planned** but not deployed:
 | teslamate          | on     | Deployment, Mosquitto, CNPG, teslamate.f4mily.net (/grafana/) |
 | authentik          | on     | HelmRelease, CNPG, login.f4mily.net (production IdP)            |
 | forgejo            | on     | Deployment, NFS, git.f4mily.net (Git + CI + Renovate CronJob), SSH :22/:2222 |
-| goloom             | on     | Deployment, CNPG PostgreSQL, goloom.cluster.f4mily.net |
+| goloom             | on     | Deployment, CNPG PostgreSQL, goloom.f4mily.net |
 | spectrumknx        | on     | StatefulSet + own TimescaleDB, KNX bus monitor, knx.cluster.f4mily.net |
 | pcm                | wip    | ingress only, missing HelmRelease         |
 | workshops          | on     | nginx + git-sync sidecar, static courses from git.f4mily.net/kreativmonkey/workshops, workshop.f4mily.net |


### PR DESCRIPTION
## Was
goloom ist von `goloom.cluster.f4mily.net` auf den öffentlichen Ingress `goloom.f4mily.net` umgezogen (App + Ingress laufen weiter, HTTP 200). Der alte `.cluster.`-Host routet nicht mehr (HTTP 000), wodurch die Blackbox-Probe **dauerhaft fehlschlug**.

## Änderungen
- `apps/base/monitoring/extra-scrapes/blackbox-vmprobe.yaml`: goloom-Target von `goloom.cluster.f4mily.net/healthz` → `goloom.f4mily.net/healthz`, in die Public-Sektion verschoben.
- `docs/applications.md`: App-Katalog auf `goloom.f4mily.net` aktualisiert.

Der gatus-Check wurde bereits upstream in #338 korrigiert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)