### PR TITLE
fix(monitoring): group EndpointDown alerts per instance, not as one list

### DIFF
--- a/apps/base/monitoring/vm-k8s-stack/helmrelease.yaml
+++ b/apps/base/monitoring/vm-k8s-stack/helmrelease.yaml
@@ -150,6 +150,23 @@ spec:
                 - alertname="NtfyBridgeDown"
               receiver: ntfy-emergency
               repeat_interval: 3h
+            # Blackbox EndpointDown: notify per endpoint, not as one bundled list.
+            # The root group_by lacks `instance`, so every simultaneously-failing probe
+            # otherwise collapses into a single ntfy message (whole blast radius instead of
+            # the one URL that is down). These two routes mirror the platform fan-out below
+            # (n8n-triage + ntfy-monitoring, critical repeat 6h) but grouped by instance, and
+            # MUST stay before the generic severity routes so the alert is consumed here and
+            # does not fall through (which would re-send it with the bundled grouping).
+            - matchers:
+                - alertname="EndpointDown"
+              group_by: ["alertname", "instance"]
+              receiver: n8n-triage
+              continue: true
+            - matchers:
+                - alertname="EndpointDown"
+              group_by: ["alertname", "instance"]
+              receiver: ntfy-monitoring
+              repeat_interval: 6h
             # n8n KI-Triage: Alertmanager → n8n → LLM → Telegram (requires alertmanager-n8n-webhook secret)
             # GitOps auto-PR (webhook/vmalert) is opt-in — see docs/integrations/alerting-n8n-gitops-remediation.md
             - matchers:


### PR DESCRIPTION
## Problem
Bei einem Ausfall kommt **eine Notification mit der ganzen Liste** ausgefallener Endpunkte statt einer pro betroffenem Endpunkt.

Ursache ist **nicht** die VMRule (die ist mit `probe_success==0` + `{{ $labels.instance }}` pro Endpunkt korrekt), sondern das Alertmanager-Grouping:

```yaml
group_by: ["alertname", "namespace", "severity", "cluster"]
```

Alle `EndpointDown`-Alerts teilen diese vier Labels; das unterscheidende `instance` (die URL) fehlt → alle fallen in **eine** Gruppe → **eine** ntfy-Nachricht mit dem kompletten Blast-Radius. Bei einer Storage-/CNPG-Kaskade gehen viele Public-Apps gleichzeitig auf 5xx → genau das beobachtete Symptom.

## Fix
Zwei dedizierte `EndpointDown`-Child-Routes **vor** den generischen Severity-Routes:
- spiegeln den bestehenden Platform-Fan-out (`n8n-triage` + `ntfy-monitoring`, critical repeat 6h)
- aber `group_by: ["alertname", "instance"]` → **eine Notification pro Endpunkt**
- die zweite Route hat kein `continue` → der Alert wird hier konsumiert und nicht erneut über das gebündelte Grouping verschickt

Andere Alerts (Node/Pod/etc.) bleiben unverändert.

## Verifikation
Routen-Reihenfolge + Fan-out lokal geprüft: EndpointDown → `n8n-triage` (continue) **und** `ntfy-monitoring` (break), beide per-instance; kein Durchfallen auf Route 3–5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)