### PR TITLE
perf(cnpg): write-smoothing for homelab-postgres on contended shared SSD

### DIFF
--- a/infrastructure/overlays/main/database-clusters/cluster.yaml
+++ b/infrastructure/overlays/main/database-clusters/cluster.yaml
@@ -23,8 +23,17 @@ spec:
       # Shared by many apps (Authentik, TeslaMate, SparkyFitness, …). 50 was exhausted
       # (SparkyFitness alone: owner + app + Better Auth pools up to ~30 per replica).
       max_connections: "100"
-      shared_buffers: 64MB
-      effective_cache_size: 256MB
+      # Write-smoothing while the DB zvols live on a shared (contended) Proxmox SSD with
+      # no dedicated DB SSD yet. A bigger cache cuts read I/O; less frequent, spread-out
+      # checkpoints shrink the FUA/fsync write bursts that stall under cross-VM contention,
+      # exceed the 30s SCSI cmd timeout and surface as -EIO -> Postgres abort -> CNPG
+      # failover cascade. See memory truenas-iscsi-spof-storage-incident; real fix = own SSD.
+      shared_buffers: 256MB
+      effective_cache_size: 768MB
+      max_wal_size: "2GB"
+      min_wal_size: "256MB"
+      checkpoint_timeout: "15min"
+      checkpoint_completion_target: "0.9"
 
   storage:
     storageClass: truenas-iscsi
@@ -33,9 +42,11 @@ spec:
   resources:
     requests:
       cpu: 50m
-      memory: 512Mi
+      # Raised with shared_buffers 64MB->256MB: 256MB SB + up to 100 conns*work_mem made the
+      # old 1Gi limit OOM-prone (see KubePodOOMKilled band-aid #313). 2Gi gives headroom.
+      memory: 768Mi
     limits:
-      memory: 1Gi
+      memory: 2Gi
 
   monitoring:
     # Metrics scraped via apps/base/monitoring/extra-scrapes/cnpg-vmpodscrape.yaml


### PR DESCRIPTION
## Kontext
Die DB-zvols (`FastStorage/ClusterStorage/k8s-volumes`) liegen auf einer Proxmox-SSD, die mit **anderen VMs geteilt** wird; eine dedizierte DB-SSD gibt es noch nicht. Cross-VM-Contention stallt FUA/fsync-Writes über den 30s-SCSI-Command-Timeout → echte Kernel-**WRITE-I/O-Fehler** auf den iSCSI-LUNs (beobachtet 2026-06-28, cp1 `sdh` / cp2 `sdd`) → Postgres bricht ab → **CNPG-Failover-Kaskade** → outline/forgejo (+ workshops git-sync) flappen.

## Interim-Mitigation (echter Fix = dedizierte SSD)
Verkleinert den Write-Footprint und die Read-I/O der DB selbst:
- `shared_buffers` 64MB→**256MB**, `effective_cache_size` 256MB→**768MB** — mehr Cache, weniger Reads auf die contended SSD.
- `max_wal_size` **2GB** / `checkpoint_timeout` **15min** / `checkpoint_completion_target` **0.9** — seltenere, verteilte Checkpoints → kleinere FUA-Write-Bursts, niedrigere Peak-IOPS.
- Memory-Limit 1Gi→**2Gi** (Request 512Mi→768Mi), damit die größeren Buffer ohne OOM passen (vgl. #313).

CNPG wendet das als Rolling-Restart an. **Behebt nicht** die Root-Contention — der Hebel dort ist Proxmox-seitiges I/O-Throttling der anderen VMs.

Ref: memory `truenas-iscsi-spof-storage-incident`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)