### PR TITLE
fix(dawarich): scale postgres to 2 instances for drain-safe upgrades

### DIFF
--- a/apps/base/monitoring/extra-scrapes/blackbox-vmprobe.yaml
+++ b/apps/base/monitoring/extra-scrapes/blackbox-vmprobe.yaml
@@ -32,8 +32,8 @@ spec:
         - https://readeck.f4mily.net
         - https://fitness.f4mily.net
         - https://nc.f4mily.net
+        - https://goloom.f4mily.net/healthz
         # Cluster-internal (cluster.f4mily.net)
-        - https://goloom.cluster.f4mily.net/healthz
         - https://grafana.cluster.f4mily.net/api/health
         - https://metrics.cluster.f4mily.net
         - https://n8n.cluster.f4mily.net

--- a/docs/applications.md
+++ b/docs/applications.md
@@ -74,7 +74,7 @@ here so it is obvious what is **planned** but not deployed:
 | teslamate          | on     | Deployment, Mosquitto, CNPG, teslamate.f4mily.net (/grafana/) |
 | authentik          | on     | HelmRelease, CNPG, login.f4mily.net (production IdP)            |
 | forgejo            | on     | Deployment, NFS, git.f4mily.net (Git + CI + Renovate CronJob), SSH :22/:2222 |
-| goloom             | on     | Deployment, CNPG PostgreSQL, goloom.cluster.f4mily.net |
+| goloom             | on     | Deployment, CNPG PostgreSQL, goloom.f4mily.net |
 | spectrumknx        | on     | StatefulSet + own TimescaleDB, KNX bus monitor, knx.cluster.f4mily.net |
 | pcm                | wip    | ingress only, missing HelmRelease         |
 | workshops          | on     | nginx + git-sync sidecar, static courses from git.f4mily.net/kreativmonkey/workshops, workshop.f4mily.net |

--- a/infrastructure/overlays/main/database-clusters/dawarich-postgres/cluster.yaml
+++ b/infrastructure/overlays/main/database-clusters/dawarich-postgres/cluster.yaml
@@ -15,7 +15,19 @@ spec:
   description: "Dawarich PostgreSQL with PostGIS"
   # renovate: datasource=docker depName=ghcr.io/cloudnative-pg/postgis versioning=loose
   imageName: ghcr.io/cloudnative-pg/postgis:17.10-3.6.4-system-trixie
-  instances: 1
+  # 2 instances so a node drain (autonomous Talos/SUC upgrade) has a failover target.
+  # A single-instance cluster has none — its primary PDB blocks every drain of its node,
+  # which stalled the v1.13.5 rollout until cp1 hung on jobActiveDeadlineSecs.
+  instances: 2
+
+  affinity:
+    # required (hard): one instance per node, so a drain only ever evicts ONE instance —
+    # a clean switchover instead of co-located both going down. Mirrors immich-postgres.
+    podAntiAffinityType: required
+
+  # Ride out transient primary blips (e.g. node-reboot network flap) for 30s before
+  # failing over, instead of reacting instantly (default 0).
+  failoverDelay: 30
 
   postgresql:
     parameters:


### PR DESCRIPTION
## Problem

`dawarich-postgres` runs `instances: 1`. A single-instance CNPG cluster has **no failover target**, so its primary PDB (`minAvailable=1` → `ALLOWED DISRUPTIONS=0`) blocks **every** drain of the node it sits on.

This stalled the autonomous Talos **v1.13.5** rollout: the System-Upgrade-Controller job on `talos-cp1` could never drain `dawarich-postgres-1`, ran into `jobActiveDeadlineSecs: 3600` → `DeadlineExceeded`, and left cp1 cordoned on v1.13.4. Same failure class as `docs/learnings/talos-automatic-upgrade-suc-auth.md`.

## Change

- `instances: 1 → 2` — gives the cluster a failover target so a node drain switches the primary over cleanly.
- `affinity.podAntiAffinityType: required` — one instance per node (mirrors `immich-postgres`), so a drain only ever evicts one.
- `failoverDelay: 30` — ride out transient node-reboot blips.

Cost: ~10Gi extra iSCSI for the replica.

## Why dawarich keeps its own cluster (not migrated to `homelab-postgres`)

dawarich needs **PostGIS** (verified live: `pg_extension` → `plpgsql, postgis`), which the shared `homelab-postgres` does not ship — it runs the vanilla `cloudnative-pg/postgresql:18.4` image. Same rationale as immich (vector extensions). Migrating would mean putting all 10 shared-DB apps on the PostGIS image and downgrading PG 18 → 17. Not worth it.

## Rollout note

After merge + Flux reconcile, a second `dawarich-postgres` instance bootstraps via `pg_basebackup`. Then SUC (currently paused) can be re-enabled and the v1.13.5 upgrade rolls through all three nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)