### PR TITLE
fix(system-upgrade): pin SUC image to released v0.19.2 (v0.20.0 doesn't exist)

### DIFF
--- a/infrastructure/base/system-upgrade-controller/kustomization.yaml
+++ b/infrastructure/base/system-upgrade-controller/kustomization.yaml
@@ -9,4 +9,9 @@ patches:
   - path: patch-deployment-strategy.yaml
 images:
   - name: rancher/system-upgrade-controller
-    newTag: v0.20.0
+    # renovate: datasource=github-releases depName=rancher/system-upgrade-controller
+    # Must be a published stable tag. v0.20.0 was never released (only v0.20.0-rc.1),
+    # so its image 404s on docker.io — the controller only survived on cached layers
+    # and would fail to reschedule onto a freshly-rebooted (cache-wiped) Talos node
+    # during an upgrade, stalling the rollout. Keep in sync with the manifest ref above.
+    newTag: v0.19.2


### PR DESCRIPTION
## Problem

`infrastructure/base/system-upgrade-controller/kustomization.yaml` pinned the controller image to **v0.20.0** via `images.newTag`. That tag **was never released** — upstream has only `v0.20.0-rc.1`; the latest stable is **v0.19.2** (which is also the manifest `?ref=`).

`docker.io/rancher/system-upgrade-controller:v0.20.0` returns **NotFound**. The controller kept running only because cp1/cp2 had the layer cached in containerd.

## Why it matters now

During the in-flight autonomous Talos **v1.13.5** rollout, each node reboot wipes the containerd cache. When the controller pod had to reschedule onto **cp3** (no cache), it hit `ErrImagePull` (`NotFound`) — which stalls the upgrade **at the controller itself**, since SUC is what orchestrates the per-node jobs.

## Fix

Pin `newTag: v0.19.2` — a published stable tag, pullable on every node, matching the bundled manifests. Added a `renovate:` hint + comment so a future bump can't silently point at a non-existent tag again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)