### PR TITLE
feat(storage): add local-path-provisioner for node-local CNPG storage

### DIFF
--- a/infrastructure/base/storage/kustomization.yaml
+++ b/infrastructure/base/storage/kustomization.yaml
@@ -2,5 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - democratic-csi
+  - local-path-provisioner
   - nfs-storageclass.yaml
   - pv-nfs.yaml

--- a/infrastructure/base/storage/local-path-provisioner/configmap.yaml
+++ b/infrastructure/base/storage/local-path-provisioner/configmap.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-path-config
+  namespace: local-path-storage
+data:
+  # ===========================================================================
+  # LEGACY-MOUNT-PATH — grep this marker when renaming the node data-disk mount.
+  #
+  # The node data disk is currently mounted at /var/lib/longhorn (a misleading
+  # leftover name — Longhorn was never deployed). The real rename target is
+  # /var/mnt/local-storage; it already lives in the IaC
+  # (homelab-infrastructure terraform-module v0.3.0, env homelab-kube
+  # cluster.auto.tfvars: default_data_disks), but the running Talos mount has not
+  # been switched yet (needs a rolling `tofu apply` / node reboot).
+  #
+  # WHEN the Talos mount is renamed to /var/mnt/local-storage, update the `paths`
+  # below to /var/mnt/local-storage/local-path (and migrate existing PVs).
+  # ===========================================================================
+  config.json: |-
+    {
+      "nodePathMap": [
+        {
+          "node": "DEFAULT_PATH_FOR_NON_LISTED_NODES",
+          "paths": ["/var/lib/longhorn/local-path"]
+        }
+      ]
+    }
+  setup: |-
+    #!/bin/sh
+    set -eu
+    mkdir -m 0777 -p "$VOL_DIR"
+  teardown: |-
+    #!/bin/sh
+    set -eu
+    rm -rf "$VOL_DIR"
+  helperPod.yaml: |-
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: helper-pod
+    spec:
+      priorityClassName: system-node-critical
+      tolerations:
+        - key: node.kubernetes.io/disk-pressure
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        # renovate: datasource=docker depName=docker.io/library/busybox
+        - name: helper-pod
+          image: docker.io/library/busybox:1.37.0
+          imagePullPolicy: IfNotPresent

--- a/infrastructure/base/storage/local-path-provisioner/deployment.yaml
+++ b/infrastructure/base/storage/local-path-provisioner/deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: local-path-provisioner
+  namespace: local-path-storage
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: local-path-provisioner
+  template:
+    metadata:
+      labels:
+        app: local-path-provisioner
+    spec:
+      serviceAccountName: local-path-provisioner-service-account
+      containers:
+        # renovate: datasource=github-releases depName=rancher/local-path-provisioner
+        - name: local-path-provisioner
+          image: docker.io/rancher/local-path-provisioner:v0.0.36
+          imagePullPolicy: IfNotPresent
+          command:
+            - local-path-provisioner
+            - start
+            - --config
+            - /etc/config/config.json
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/config/
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONFIG_MOUNT_PATH
+              value: /etc/config/
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
+      volumes:
+        - name: config-volume
+          configMap:
+            name: local-path-config

--- a/infrastructure/base/storage/local-path-provisioner/kustomization.yaml
+++ b/infrastructure/base/storage/local-path-provisioner/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - rbac.yaml
+  - configmap.yaml
+  - deployment.yaml
+  - storageclass.yaml

--- a/infrastructure/base/storage/local-path-provisioner/namespace.yaml
+++ b/infrastructure/base/storage/local-path-provisioner/namespace.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: local-path-storage
+  labels:
+    # The helper pod bind-mounts a hostPath to create/remove per-volume dirs on
+    # the node's data disk, so the namespace must permit privileged/hostPath pods.
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/audit: privileged

--- a/infrastructure/base/storage/local-path-provisioner/rbac.yaml
+++ b/infrastructure/base/storage/local-path-provisioner/rbac.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: local-path-provisioner-service-account
+  namespace: local-path-storage
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: local-path-provisioner-role
+rules:
+  - apiGroups: [""]
+    resources: ["nodes", "persistentvolumeclaims", "configmaps", "pods", "pods/log"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "patch", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["create", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: local-path-provisioner-bind
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: local-path-provisioner-role
+subjects:
+  - kind: ServiceAccount
+    name: local-path-provisioner-service-account
+    namespace: local-path-storage

--- a/infrastructure/base/storage/local-path-provisioner/storageclass.yaml
+++ b/infrastructure/base/storage/local-path-provisioner/storageclass.yaml
@@ -1,0 +1,16 @@
+# Node-local storage backed by each node's data disk. Primary consumer: CNPG
+# (Postgres replicates at the DB layer, so node-local beats networked storage and
+# removes the truenas-iscsi single-point-of-failure from the database path).
+#
+# Backing path is the LEGACY-MOUNT-PATH /var/lib/longhorn/local-path — see
+# configmap.yaml. Not the default class (truenas-iscsi stays default); opt in via
+# storageClassName: local-path.
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-path
+provisioner: rancher.io/local-path
+# Bind only once a pod is scheduled, so the PV lands on the node that runs it.
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+allowVolumeExpansion: false


### PR DESCRIPTION
Deploys **rancher/local-path-provisioner v0.0.36** as a new non-default StorageClass `local-path`, backed by each node's local data disk.

## Why
Move CNPG Postgres off the **truenas-iscsi single-point-of-failure**. Postgres replicates at the DB layer (3 instances), so node-local storage is faster *and* removes the shared-NAS dependency from the database path. This directly addresses the recurring iSCSI/CNPG incidents.

## What
`infrastructure/base/storage/local-path-provisioner/` (picked up by the `infra-storage` Flux kustomization):
- `StorageClass local-path` — `WaitForFirstConsumer`, `reclaimPolicy: Delete`, **not** default (truenas-iscsi stays default; opt in via `storageClassName: local-path`).
- Namespace `local-path-storage` with `pod-security: privileged` (the helper pod bind-mounts a hostPath).
- RBAC + Deployment (hardened securityContext on the provisioner) + ConfigMap.

## Legacy mount path ⚠️
Backing path is `/var/lib/longhorn/local-path`. The node disk is still mounted at the misleading `/var/lib/longhorn` (Longhorn was never deployed). The rename to `/var/mnt/local-storage` already lives in the IaC (`terraform-module` v0.3.0 / `homelab-kube` `default_data_disks`) but the running Talos mount hasn't been switched yet. **Grep `LEGACY-MOUNT-PATH`** to update the path after the Talos mount is renamed via `tofu apply`.

## Validation
`kubectl kustomize` builds clean for the component, `base/storage`, and full `base`. Images verified on Docker Hub.

## Next
Once merged + reconciled (StorageClass present, provisioner Running), migrate CNPG cluster-by-cluster (dawarich → immich → homelab) to `storageClassName: local-path`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)