### PR TITLE
feat(dawarich): migrate postgres storage to local-path

### DIFF
--- a/infrastructure/overlays/main/database-clusters/dawarich-postgres/cluster.yaml
+++ b/infrastructure/overlays/main/database-clusters/dawarich-postgres/cluster.yaml
@@ -36,7 +36,11 @@ spec:
       effective_cache_size: 512MB
 
   storage:
-    storageClass: truenas-iscsi
+    # Node-local storage: CNPG replicates at the DB layer, so local-path is faster
+    # and removes the truenas-iscsi single-point-of-failure from the DB path. The
+    # storageClass only applies to NEW instances — existing iscsi PVCs are migrated
+    # by rolling instance replacement (delete pod+PVC -> CNPG re-bootstraps locally).
+    storageClass: local-path
     size: 10Gi
 
   resources:


### PR DESCRIPTION
Switches `dawarich-postgres` `storageClass: truenas-iscsi → local-path` — first CNPG cluster onto the new node-local provisioner (#362).

**Why:** CNPG replicates at the DB layer, so node-local storage is faster *and* removes the truenas-iscsi single-point-of-failure from the database path (root cause of the recurring CNPG incidents).

**Note:** `storageClass` applies to **new** instances only. After merge + reconcile, existing iscsi PVCs are migrated by **rolling instance replacement** (delete pod+PVC → CNPG re-bootstraps locally via `pg_basebackup`, primary switched over last). Primary stays online → no downtime. dawarich chosen first as the smallest/lowest-risk cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)