### PR TITLE
feat(cnpg): migrate immich + homelab postgres to local-path

### DIFF
--- a/infrastructure/overlays/main/database-clusters/cluster.yaml
+++ b/infrastructure/overlays/main/database-clusters/cluster.yaml
@@ -36,7 +36,11 @@ spec:
       checkpoint_completion_target: "0.9"
 
   storage:
-    storageClass: truenas-iscsi
+    # Node-local storage (see local-path-provisioner): CNPG replicates at the DB
+    # layer, so local-path is faster and removes the truenas-iscsi SPOF from the DB
+    # path. storageClass applies to NEW instances; existing iscsi PVCs are migrated
+    # by rolling instance replacement (delete pod+PVC -> CNPG re-bootstraps locally).
+    storageClass: local-path
     size: 10Gi
 
   resources:

--- a/infrastructure/overlays/main/database-clusters/immich-postgres/cluster.yaml
+++ b/infrastructure/overlays/main/database-clusters/immich-postgres/cluster.yaml
@@ -28,7 +28,11 @@ spec:
       effective_cache_size: 512MB
 
   storage:
-    storageClass: truenas-iscsi
+    # Node-local storage (see local-path-provisioner): CNPG replicates at the DB
+    # layer, so local-path is faster and removes the truenas-iscsi SPOF from the DB
+    # path. storageClass applies to NEW instances; existing iscsi PVCs are migrated
+    # by rolling instance replacement (delete pod+PVC -> CNPG re-bootstraps locally).
+    storageClass: local-path
     size: 10Gi
 
   resources:


### PR DESCRIPTION
Follows dawarich (#363): switches immich-postgres and homelab-postgres `storageClass: truenas-iscsi -> local-path`. CNPG replicates at the DB layer, so node-local storage removes the truenas-iscsi SPOF from the DB path.

storageClass applies to new instances only; existing iscsi PVCs migrated by rolling instance replacement after merge (immich first, then homelab — the critical shared DB — last, with verification between).

🤖 Generated with [Claude Code](https://claude.com/claude-code)