### PR TITLE
docs(storage): document node-local CNPG storage strategy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ You are **Senior Kubernetes System Architect** and **GitOps Automation Engineer*
 - **OS / K8s**: Talos Linux (upstream Kubernetes, resource‑optimized)
 - **GitOps Controller**: FluxCD
 - **Ingress / Networking**: NGINX Ingress Controller with `nginx.org/*` annotations (or Gateway API) + Cilium CNI
-- **Storage**: Democratic CSI (TrueNAS iSCSI) for fast workloads (e.g., databases) and NFS for large media files
+- **Storage**: CNPG databases on **node-local `local-path`** (off the TrueNAS iSCSI SPOF — CNPG replicates at the DB layer); Democratic CSI (TrueNAS iSCSI) for app RWO volumes; NFS for large media. See README "Persistence Strategy".
 - **Database Operator**: CloudNativePG (central PostgreSQL)
 - **VCS / CI‑CD**: GitHub (Leading) + Forgejo (Mirror) + GitHub Runners
 - **Dependency Management**: Renovate
@@ -43,6 +43,7 @@ You are **Senior Kubernetes System Architect** and **GitOps Automation Engineer*
 - Deploy single **CloudNativePG** cluster in `infrastructure/base/database/cnpg/`.
 - For each app needing PostgreSQL, create a dedicated CNPG `Cluster` (or bootstrap job) that provisions its own database and user; no extra DB pod required.
 - Store DB credentials as **SOPS‑encrypted** secrets in `apps/overlays/main/db-secrets/` and inject via ExternalSecrets/SealedSecrets.
+- **Storage = `local-path` (node-local), NOT truenas-iscsi.** Postgres replicates at the DB layer, so node-local is the CNPG-recommended pattern and removes the NAS SPOF. To migrate/recover an instance (a `storageClass` change only affects *new* instances), roll one at a time: delete its pod+PVC → CNPG re-bootstraps via `pg_basebackup` (primary last). Node-local PVs are node-pinned; a node loss is recovered by re-cloning onto a survivor.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,14 @@ Standard tools (Helm charts, Docker images) are managed by Renovate. GitHub is t
 Talos nodes run Cilium CNI. Ingress is handled by the NGINX Ingress Controller. SSL certificates are automated via cert-manager (Let's Encrypt).
 
 ### 3. Persistence Strategy
-* **High Performance (iSCSI):** Used for databases (PostgreSQL, Redis) and application configs via Democratic CSI on TrueNAS. These provide high IOPS and are backed up via Velero.
-* **Mass Storage (NFS):** Used for large media files (Photos, Videos, Books) and large-scale document storage.
+Storage is matched to each workload's **own** replication model — not a one-size-fits-all default.
+
+* **Databases — node-local `local-path` (NOT iSCSI):** CloudNativePG (PostgreSQL) clusters run on per-node `local-path` storage. CNPG replicates at the database layer (3 instances + continuous S3/barman backups), so node-local disks are both faster *and* keep the shared-NAS **single point of failure out of the database path**. This is the CNPG-recommended pattern; the previous setup ran every DB on one TrueNAS iSCSI target, which repeatedly cascaded (a single iSCSI blip → WAL corruption → cluster-wide CNPG outage). Provisioner: `infrastructure/base/storage/local-path-provisioner/`; class `local-path` (non-default).
+  > ⚠️ **Legacy mount path:** the backing data disk is still mounted at `/var/lib/longhorn` (a misleading leftover — Longhorn was never deployed). Grep **`LEGACY-MOUNT-PATH`** for the pending rename to `/var/mnt/local-storage` (already in the IaC, awaiting a Talos `tofu apply`).
+* **App RWO volumes (iSCSI):** Application config/data volumes that have **no app-level replication** use Democratic CSI on TrueNAS (`truenas-iscsi`, the default class), backed up via Velero. (Such volumes are better served by replicated storage — Longhorn — than node-pinned `local-path`; a future improvement.)
+* **Mass Storage (NFS):** Large media files (Photos, Videos, Books) and bulk document storage.
+
+**Migrating a CNPG cluster's storage** — a `storageClass` change applies to **new** instances only. Roll existing instances one at a time (`kubectl -n cnpg-system delete pvc <inst> --wait=false && kubectl -n cnpg-system delete pod <inst>`); CNPG re-bootstraps each via `pg_basebackup`. Wait for `N/N` healthy between steps; do the **primary last** (brief failover).
 
 ### 4. GitOps (FluxCD)
 Flux reconciles the cluster state against the GitHub repository. Changes are applied via PRs to the `main` branch.


### PR DESCRIPTION
Updates the README Persistence Strategy (was outdated — claimed databases run on iSCSI) and AGENTS.md to reflect the migration:

- **CNPG postgres → node-local `local-path`** (CNPG-recommended; removes the TrueNAS iSCSI SPOF from the DB path).
- Documents the **LEGACY-MOUNT-PATH** `/var/lib/longhorn` and pending rename to `/var/mnt/local-storage`.
- Adds the rolling instance-migration recipe (delete pod+PVC → CNPG re-bootstraps via pg_basebackup, primary last).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)