### PR TITLE
docs(readme): fix remaining iSCSI-for-DB references

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ This repository is the **Single Source of Truth** for my Kubernetes homelab. It 
 | **Secrets** | [SOPS](https://github.com/getsops/sops) + [age](https://github.com/FiloSottile/age) | Encrypted GitOps secrets (In-repo encryption) |
 | **OS & K8s** | [Talos Linux](https://www.talos.dev/) | Immutable, RAM-based, API-managed OS |
 | **GitOps** | [FluxCD](https://fluxcd.io/) | Reconciles Git state to Cluster state |
-| **Storage (Fast)** | TrueNAS iSCSI (democratic-csi) | RWO block storage for DBs/State |
+| **Storage (DB)** | node-local `local-path` | Per-node disks for CloudNativePG (off the iSCSI SPOF; CNPG replicates at the DB layer) |
+| **Storage (Fast)** | TrueNAS iSCSI (democratic-csi) | RWO block storage for app state/config |
 | **Storage (Mass)** | NFS (External NAS) | Persistent storage for media and archives |
 | **Networking** | Nginx Ingress / [ExternalDNS](https://github.com/kubernetes-sigs/external-dns) | Ingress control and Cloudflare DNS sync |
 | **Security** | [cert-manager](https://github.com/cert-manager/cert-manager) | Automated TLS via Let's Encrypt (DNS-01) |
@@ -84,7 +85,7 @@ Flux reconciles the cluster state against the GitHub repository. Changes are app
 │   └── main/                # Production cluster config
 ├── infrastructure/          # Cluster-wide components
 │   ├── base/                # Shared sources
-│   │   ├── storage/         # iSCSI (democratic-csi) + NFS PVs
+│   │   ├── storage/         # local-path (CNPG) + iSCSI (democratic-csi) + NFS PVs
 │   │   ├── database/        # CloudNativePG operator
 │   │   └── ...
 │   └── overlays/main/       # Cluster patches & secrets


### PR DESCRIPTION
Follow-up to #365: the Infrastructure Overview table and directory tree still listed iSCSI as DB storage, contradicting the updated Persistence Strategy section. Aligns them with node-local `local-path`. Docs-only.