### PR TITLE
feat(security): enforce PodSecurity baseline on all app namespaces

### DIFF
--- a/apps/base/authentik/namespace.yaml
+++ b/apps/base/authentik/namespace.yaml
@@ -5,3 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: authentik
     app.kubernetes.io/part-of: homelab-apps
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/apps/base/backrest/namespace.yaml
+++ b/apps/base/backrest/namespace.yaml
@@ -5,3 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: backrest
     app.kubernetes.io/part-of: homelab-apps
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/apps/base/dawarich/namespace.yaml
+++ b/apps/base/dawarich/namespace.yaml
@@ -5,3 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: dawarich
     app.kubernetes.io/part-of: homelab-apps
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/apps/base/gatus/namespace.yaml
+++ b/apps/base/gatus/namespace.yaml
@@ -5,3 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: gatus
     app.kubernetes.io/part-of: homelab-monitoring
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/apps/base/goloom/namespace.yaml
+++ b/apps/base/goloom/namespace.yaml
@@ -5,3 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: goloom
     app.kubernetes.io/part-of: homelab-apps
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/apps/base/homepage/namespace.yaml
+++ b/apps/base/homepage/namespace.yaml
@@ -5,3 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: homepage
     app.kubernetes.io/instance: homepage
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/apps/base/homer/namespace.yaml
+++ b/apps/base/homer/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: homer
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/apps/base/immich/namespace.yaml
+++ b/apps/base/immich/namespace.yaml
@@ -5,3 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: immich
     app.kubernetes.io/part-of: homelab-apps
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/apps/base/jellyfin/namespace.yaml
+++ b/apps/base/jellyfin/namespace.yaml
@@ -5,3 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: jellyfin
     app.kubernetes.io/part-of: homelab-apps
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/apps/base/linkding/namespace.yaml
+++ b/apps/base/linkding/namespace.yaml
@@ -5,3 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: linkding
     app.kubernetes.io/part-of: homelab-apps
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/apps/base/linkwarden/namespace.yaml
+++ b/apps/base/linkwarden/namespace.yaml
@@ -5,3 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: linkwarden
     app.kubernetes.io/part-of: homelab-apps
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/apps/base/n8n/namespace.yaml
+++ b/apps/base/n8n/namespace.yaml
@@ -5,3 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: n8n
     app.kubernetes.io/part-of: homelab-ai-ops
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/apps/base/nextcloud/namespace.yaml
+++ b/apps/base/nextcloud/namespace.yaml
@@ -5,3 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: nextcloud
     app.kubernetes.io/part-of: homelab-apps
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/apps/base/nextcloud/nextcloud-exapps-namespace.yaml
+++ b/apps/base/nextcloud/nextcloud-exapps-namespace.yaml
@@ -4,3 +4,6 @@ metadata:
   name: nextcloud-exapps
   labels:
     app.kubernetes.io/part-of: nextcloud
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/apps/base/outline/namespace.yaml
+++ b/apps/base/outline/namespace.yaml
@@ -5,3 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: outline
     app.kubernetes.io/part-of: homelab
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/apps/base/paperless-ngx/namespace.yaml
+++ b/apps/base/paperless-ngx/namespace.yaml
@@ -5,3 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: paperless-ngx
     app.kubernetes.io/part-of: homelab-apps
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/apps/base/pcm/namespace.yaml
+++ b/apps/base/pcm/namespace.yaml
@@ -5,3 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: pcm
     app.kubernetes.io/part-of: homelab-apps
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/apps/base/readeck/namespace.yaml
+++ b/apps/base/readeck/namespace.yaml
@@ -5,3 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: readeck
     app.kubernetes.io/part-of: homelab-apps
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/apps/base/renovate/namespace.yaml
+++ b/apps/base/renovate/namespace.yaml
@@ -5,3 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: renovate
     app.kubernetes.io/part-of: homelab-apps
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/apps/base/searxng/namespace.yaml
+++ b/apps/base/searxng/namespace.yaml
@@ -5,3 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: searxng
     app.kubernetes.io/part-of: homelab-apps
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/apps/base/sparkyfitness/namespace.yaml
+++ b/apps/base/sparkyfitness/namespace.yaml
@@ -5,3 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: sparkyfitness
     app.kubernetes.io/part-of: homelab-apps
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/apps/base/spectrumknx/namespace.yaml
+++ b/apps/base/spectrumknx/namespace.yaml
@@ -5,3 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: spectrumknx
     app.kubernetes.io/part-of: homelab-apps
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/apps/base/speedtest-tracker/namespace.yaml
+++ b/apps/base/speedtest-tracker/namespace.yaml
@@ -5,3 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: speedtest-tracker
     app.kubernetes.io/part-of: homelab-apps
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/apps/base/tandoor/namespace.yaml
+++ b/apps/base/tandoor/namespace.yaml
@@ -5,3 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: tandoor
     app.kubernetes.io/part-of: homelab-apps
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/apps/base/teslamate/namespace.yaml
+++ b/apps/base/teslamate/namespace.yaml
@@ -5,3 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: teslamate
     app.kubernetes.io/part-of: homelab-apps
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/apps/base/workshops/namespace.yaml
+++ b/apps/base/workshops/namespace.yaml
@@ -5,3 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: workshops
     app.kubernetes.io/part-of: homelab
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/infrastructure/base/backup/namespace.yaml
+++ b/infrastructure/base/backup/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: velero
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/infrastructure/base/mcp-server/namespace.yaml
+++ b/infrastructure/base/mcp-server/namespace.yaml
@@ -5,3 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/name: mcp-server
     app.kubernetes.io/part-of: homelab-infrastructure
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/infrastructure/base/sources/namespaces.yaml
+++ b/infrastructure/base/sources/namespaces.yaml
@@ -16,11 +16,19 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: external-dns
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: reflector-system
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted
 ---
 apiVersion: v1
 kind: Namespace


### PR DESCRIPTION
## Was

Schließt die PSA-Lücke: 12 von ~40 Namespaces hatten `enforce`-Labels, der Rest lief ohne Pod-Security-Baseline. Dieser PR ergänzt auf allen ~29 Namespaces ohne enforce:

```yaml
pod-security.kubernetes.io/enforce: baseline
pod-security.kubernetes.io/audit: restricted
pod-security.kubernetes.io/warn: restricted
```

## Warum risikoarm

Alle betroffenen Namespaces wurden vorab als **host-zugriffsfrei** verifiziert (kein `hostNetwork`, `privileged`, `hostPath`) → `enforce: baseline` blockiert keine bestehenden Workloads. `audit/warn: restricted` gibt vorausschauende Sichtbarkeit, ohne zu blockieren. Namespaces mit echtem Host-Bedarf (netbird, watchyourlan, forgejo, ingress-nginx, …) hatten bereits `privileged` und bleiben unangetastet.

PSA `enforce` betrifft nur Pod-Erstellung/-Update — laufende Pods werden nicht evictet.

## Teil von

Platform-Hardening (1/4): PSA → uptime-kuma-Cleanup → VictoriaLogs → NetworkPolicies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)