### PR TITLE
feat(monitoring): add VictoriaLogs log aggregation

### DIFF
--- a/apps/base/monitoring/kustomization.yaml
+++ b/apps/base/monitoring/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - vm-k8s-stack
+  - victoria-logs
   - notifications
   - ntfy-bridge
   # Kite-Prometheus-Bridge: mapped 8429→8481 (vmselect metrics), Label app.kubernetes.io/name: vmselect

--- a/apps/base/monitoring/victoria-logs/helmrelease-victoria-logs-collector.yaml
+++ b/apps/base/monitoring/victoria-logs/helmrelease-victoria-logs-collector.yaml
@@ -1,0 +1,33 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: victoria-logs-collector
+  namespace: monitoring
+spec:
+  interval: 1h
+  timeout: 10m
+  chart:
+    spec:
+      chart: victoria-logs-collector
+      # renovate: registryUrl=https://victoriametrics.github.io/helm-charts
+      version: "0.3.6"
+      sourceRef:
+        kind: HelmRepository
+        name: victoriametrics-repo
+        namespace: flux-system
+  values:
+    # DaemonSet (vlagent): auto-discovers Pod logs via the ServiceAccount and
+    # tails /var/log (hostPath, read-only). Needs the monitoring NS PSA
+    # `privileged` to mount host paths and read root-owned container logs.
+    priorityClassName: homelab-infrastructure
+
+    # Ship enriched logs to the single-node VictoriaLogs server.
+    remoteWrite:
+      - url: http://victoria-logs-single-server.monitoring.svc.cluster.local:9428
+
+    resources:
+      requests:
+        cpu: 25m
+        memory: 64Mi
+      limits:
+        memory: 256Mi

--- a/apps/base/monitoring/victoria-logs/helmrelease-victoria-logs.yaml
+++ b/apps/base/monitoring/victoria-logs/helmrelease-victoria-logs.yaml
@@ -1,0 +1,50 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: victoria-logs-single
+  namespace: monitoring
+spec:
+  interval: 1h
+  timeout: 10m
+  chart:
+    spec:
+      chart: victoria-logs-single
+      # renovate: registryUrl=https://victoriametrics.github.io/helm-charts
+      version: "0.13.8"
+      sourceRef:
+        kind: HelmRepository
+        name: victoriametrics-repo
+        namespace: flux-system
+  values:
+    # ============================================
+    # SERVER - single-node VictoriaLogs (StatefulSet)
+    # ============================================
+    server:
+      enabled: true
+      priorityClassName: homelab-infrastructure
+
+      # Retention: 30 days OR 18 GiB on disk, whichever hits first.
+      # The disk guard keeps VictoriaLogs from filling the 20Gi PVC.
+      retentionPeriod: "30d"
+      retentionDiskSpaceUsage: "18GiB"
+
+      persistentVolume:
+        enabled: true
+        storageClassName: truenas-iscsi
+        size: 20Gi
+
+      service:
+        # Pin the service port so the collector remoteWrite URL is stable.
+        servicePort: 9428
+
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          memory: 1Gi
+
+    # No Velero backup: log data is reproducible and short-lived (30d); snapshotting
+    # it would only add iSCSI churn. DR re-collects from running pods.
+    # Chart Ingress stays disabled (chart default) — we use a dedicated Ingress
+    # resource (ingress-victoria-logs.yaml) to match the repo convention.

--- a/apps/base/monitoring/victoria-logs/ingress-victoria-logs.yaml
+++ b/apps/base/monitoring/victoria-logs/ingress-victoria-logs.yaml
@@ -1,0 +1,34 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: victoria-logs
+  namespace: monitoring
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: VictoriaLogs
+    gethomepage.dev/description: Log aggregation & VLUI
+    gethomepage.dev/group: Cluster Management
+    gethomepage.dev/icon: victoriametrics.png
+    gethomepage.dev/app: victoria-logs-single-server
+    # TLS: wildcard-cluster-f4mily-net-tls via reflector (no cluster-issuer).
+    nginx.org/ssl-redirect: "false"
+    nginx.org/redirect-to-https: "true"
+  labels:
+    app.kubernetes.io/part-of: vm-k8s-stack
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - logs.cluster.f4mily.net
+      secretName: wildcard-cluster-f4mily-net-tls
+  rules:
+    - host: logs.cluster.f4mily.net
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: victoria-logs-single-server
+                port:
+                  number: 9428

--- a/apps/base/monitoring/victoria-logs/kustomization.yaml
+++ b/apps/base/monitoring/victoria-logs/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease-victoria-logs.yaml
+  - helmrelease-victoria-logs-collector.yaml
+  - ingress-victoria-logs.yaml

--- a/apps/base/monitoring/vm-k8s-stack/helmrelease.yaml
+++ b/apps/base/monitoring/vm-k8s-stack/helmrelease.yaml
@@ -300,6 +300,17 @@ spec:
       plugins:
         # renovate: datasource=custom.grafana-plugins depName=victoriametrics-metrics-datasource
         - victoriametrics-metrics-datasource@0.25.0
+        # renovate: datasource=custom.grafana-plugins depName=victoriametrics-logs-datasource
+        - victoriametrics-logs-datasource@0.29.0
+
+      # VictoriaLogs datasource (sidecar.datasources is disabled — provision here).
+      additionalDataSources:
+        - name: VictoriaLogs
+          type: victoriametrics-logs-datasource
+          access: proxy
+          url: http://victoria-logs-single-server.monitoring.svc.cluster.local:9428
+          jsonData:
+            maxLines: 1000
 
       priorityClassName: homelab-infrastructure
 

--- a/apps/overlays/main/kustomization.yaml
+++ b/apps/overlays/main/kustomization.yaml
@@ -396,6 +396,8 @@ replacements:
         fieldPaths: [spec.tls.0.secretName]
       - select: {kind: Ingress, name: victoria-metrics}
         fieldPaths: [spec.tls.0.secretName]
+      - select: {kind: Ingress, name: victoria-logs}
+        fieldPaths: [spec.tls.0.secretName]
       - select: {kind: Ingress, name: n8n}
         fieldPaths: [spec.tls.0.secretName]
       - select: {kind: Ingress, name: watchyourlan}


### PR DESCRIPTION
## Was

Schließt die größte Observability-Lücke: erstklassige Metriken (VictoriaMetrics, Gatus, Alerting) — aber bisher **keine zentrale Log-Aggregation**. Pod-Logs waren nach Restart weg und nicht durchsuchbar.

- **`victoria-logs-single`** (StatefulSet, truenas-iscsi, Retention 30d / 18GiB-Disk-Guard)
- **`victoria-logs-collector`** DaemonSet: sammelt Pod-Logs automatisch via ServiceAccount + hostPath `/var/log` (monitoring-NS ist bereits PSA `privileged`)
- **Grafana VictoriaLogs-Datasource** via `additionalDataSources` (Datasource-Sidecar ist bewusst aus) + Plugin `victoriametrics-logs-datasource@0.29.0`
- Ingress `logs.cluster.f4mily.net`
- CI: neuer monitoring-Pfad wird validiert

Gleicher Hersteller/Helm-Repo wie der bestehende VM-Stack → minimale Reibung. Kein Velero-Backup (Logs reproduzierbar, kurzlebig → keine iSCSI-Churn).

## Verifikation nach Merge

```
kubectl -n monitoring get pods -l app.kubernetes.io/name=victoria-logs-single   # Ready
kubectl -n monitoring get ds  | grep victoria-logs-collector                    # alle Nodes
# Grafana → Explore → Datasource VictoriaLogs → _stream:{namespace="monitoring"}
```

## Teil von

Platform-Hardening (3/4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)