### PR TITLE
feat(security): default-deny NetworkPolicy framework + pilot

### DIFF
--- a/clusters/main/infrastructure.yaml
+++ b/clusters/main/infrastructure.yaml
@@ -108,3 +108,24 @@ spec:
     secretRef:
       name: sops-age
   force: true
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: infra-network-policies
+  namespace: flux-system
+spec:
+  # Isolated from infra-base so the NetworkPolicy pilot can be rolled back with a
+  # single `flux suspend kustomization infra-network-policies`. Phase 1 only
+  # covers self-contained namespaces; extend via the network-policies overlay.
+  dependsOn:
+    - name: infra-base
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  path: ./infrastructure/base/network/network-policies
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: true

--- a/docs/runbooks/network-policies-rollout.md
+++ b/docs/runbooks/network-policies-rollout.md
@@ -1,0 +1,82 @@
+# Runbook: NetworkPolicy rollout
+
+Default-deny NetworkPolicies are rolled out **per namespace, phased** — never
+big-bang. The cluster runs Cilium, which honours standard
+`networking.k8s.io/v1` NetworkPolicies, so we deliberately use the portable
+resource (not `CiliumNetworkPolicy`).
+
+## Where it lives
+
+```
+infrastructure/base/network/network-policies/
+├── baseline/            # Kustomize Component: the always-safe policy set
+│   ├── 00-default-deny.yaml          # deny all ingress + egress
+│   ├── 10-allow-dns.yaml             # egress → CoreDNS (kube-system)
+│   ├── 20-allow-from-ingress-nginx.yaml
+│   ├── 30-allow-same-namespace.yaml
+│   └── 40-allow-from-monitoring.yaml # ingress ← vmagent (scrape)
+├── egress-external/     # Component: add-on, egress to the internet on 80/443
+│   └── 50-allow-egress-external.yaml
+├── <namespace>/         # per-namespace overlay (sets namespace, picks components)
+└── kustomization.yaml   # bundles the per-namespace overlays
+```
+
+Reconciled by the **`infra-network-policies`** Flux Kustomization
+(`clusters/main/infrastructure.yaml`), separate from `infra-base` so a rollback
+is a single `flux suspend kustomization infra-network-policies`.
+
+## Phase 1 pilot
+
+| Namespace | Components | Why |
+|-----------|------------|-----|
+| `homer`   | baseline | static dashboard, no backend, no egress |
+| `linkding`| baseline + egress-external | SQLite, but OIDC → login.f4mily.net (443) |
+| `readeck` | baseline + egress-external | SQLite, but archives web pages (80/443) |
+
+## Onboarding another namespace
+
+1. **Map the namespace's real traffic first** — what does it need to reach?
+   - DNS, ingress-nginx, intra-namespace, monitoring scrape → already covered by `baseline`.
+   - Outbound HTTP/HTTPS (OIDC, web fetch) → add the `egress-external` component.
+   - Central **CNPG database** in another namespace → add a bespoke
+     `allow-egress-database` policy in the namespace overlay (egress to the DB
+     namespace on 5432). Most cross-namespace DB users live in
+     `apps/overlays/main/databases/`.
+   - Other cross-namespace calls (Redis, Authentik internal, MQTT) → add a
+     matching egress policy.
+2. Create `network-policies/<ns>/kustomization.yaml`:
+   ```yaml
+   apiVersion: kustomize.config.k8s.io/v1beta1
+   kind: Kustomization
+   namespace: <ns>
+   components:
+     - ../baseline
+     # - ../egress-external   # only if it needs outbound 80/443
+   ```
+3. Add `- <ns>` to `network-policies/kustomization.yaml`.
+4. `just validate`, commit, push.
+5. **Verify before moving on** (see below). Onboard one or two namespaces per PR.
+
+## Verification after reconcile
+
+```bash
+kubectl -n <ns> get networkpolicy                 # the set is present
+kubectl -n <ns> get pods                          # app still Running/Ready
+# app still reachable through its ingress (curl the public host)
+# vmagent target still UP:
+#   Grafana → Explore → up{namespace="<ns>"}  == 1
+# DNS works from inside a pod:
+kubectl -n <ns> exec deploy/<app> -- nslookup login.f4mily.net
+```
+
+If a flow is wrongly blocked: `kubectl -n <ns> delete networkpolicy default-deny-all`
+restores connectivity instantly while you fix the allow rule (Flux re-adds it on
+next reconcile — `flux suspend` the Kustomization first if you need it to stay off).
+
+## Rollback (whole pilot)
+
+```bash
+flux suspend kustomization infra-network-policies
+kubectl delete networkpolicy -n homer -n linkding -n readeck --all
+```
+or revert the commit and let Flux prune.

--- a/infrastructure/base/network/network-policies/baseline/00-default-deny.yaml
+++ b/infrastructure/base/network/network-policies/baseline/00-default-deny.yaml
@@ -1,0 +1,13 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+spec:
+  # Empty podSelector = applies to every Pod in the namespace.
+  podSelector: {}
+  # Deny everything; the allow-* policies below add back the required flows.
+  # (Kubelet health probes are host-local and exempt under Cilium's
+  # --allow-localhost=always default, so readiness/liveness keep working.)
+  policyTypes:
+    - Ingress
+    - Egress

--- a/infrastructure/base/network/network-policies/baseline/10-allow-dns.yaml
+++ b/infrastructure/base/network/network-policies/baseline/10-allow-dns.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    # CoreDNS in kube-system (k8s-app=kube-dns). Without this, default-deny
+    # egress breaks all name resolution.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53

--- a/infrastructure/base/network/network-policies/baseline/20-allow-from-ingress-nginx.yaml
+++ b/infrastructure/base/network/network-policies/baseline/20-allow-from-ingress-nginx.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-ingress-nginx
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    # Public/Internal traffic enters via the NGINX ingress controller.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx

--- a/infrastructure/base/network/network-policies/baseline/30-allow-same-namespace.yaml
+++ b/infrastructure/base/network/network-policies/baseline/30-allow-same-namespace.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-same-namespace
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  # Pods within the same namespace may talk to each other freely
+  # (app <-> its sidecar/redis/worker in the same namespace).
+  ingress:
+    - from:
+        - podSelector: {}
+  egress:
+    - to:
+        - podSelector: {}

--- a/infrastructure/base/network/network-policies/baseline/40-allow-from-monitoring.yaml
+++ b/infrastructure/base/network/network-policies/baseline/40-allow-from-monitoring.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-monitoring
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    # vmagent (monitoring NS) scrapes Pod metrics endpoints. Without this,
+    # default-deny ingress silently drops scrapes and the targets go DOWN.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring

--- a/infrastructure/base/network/network-policies/baseline/kustomization.yaml
+++ b/infrastructure/base/network/network-policies/baseline/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+# Reusable default-deny baseline for a single namespace. Consume it from a
+# per-namespace overlay that sets `namespace:` — the namespace transformer then
+# stamps every policy below into that namespace. See ../../../../docs/runbooks/
+# network-policies-rollout.md for how to onboard a namespace.
+resources:
+  - 00-default-deny.yaml
+  - 10-allow-dns.yaml
+  - 20-allow-from-ingress-nginx.yaml
+  - 30-allow-same-namespace.yaml
+  - 40-allow-from-monitoring.yaml

--- a/infrastructure/base/network/network-policies/egress-external/50-allow-egress-external.yaml
+++ b/infrastructure/base/network/network-policies/egress-external/50-allow-egress-external.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-external
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    # Egress to anywhere on HTTP/HTTPS only. Covers OIDC to login.f4mily.net
+    # (resolves to the ingress LB) and outbound web fetches. Lateral movement
+    # on other ports stays blocked by default-deny.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 80
+        - protocol: TCP
+          port: 443

--- a/infrastructure/base/network/network-policies/egress-external/kustomization.yaml
+++ b/infrastructure/base/network/network-policies/egress-external/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+# Optional add-on for namespaces whose workloads must reach the outside world
+# on HTTP/HTTPS — e.g. OIDC redirects to login.f4mily.net, or apps that fetch
+# arbitrary URLs (bookmark/web archiving). Combine with the baseline component.
+resources:
+  - 50-allow-egress-external.yaml

--- a/infrastructure/base/network/network-policies/homer/kustomization.yaml
+++ b/infrastructure/base/network/network-policies/homer/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# homer = static dashboard, no backend, no outbound calls. Baseline only.
+namespace: homer
+components:
+  - ../baseline

--- a/infrastructure/base/network/network-policies/kustomization.yaml
+++ b/infrastructure/base/network/network-policies/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Phase 1 pilot: default-deny NetworkPolicies on self-contained namespaces.
+# Wired as its own Flux Kustomization (infra-network-policies) so a rollback is
+# a single `flux suspend` / file removal. Onboard further namespaces by adding a
+# <namespace>/ overlay here — see docs/runbooks/network-policies-rollout.md.
+resources:
+  - homer
+  - linkding
+  - readeck

--- a/infrastructure/base/network/network-policies/linkding/kustomization.yaml
+++ b/infrastructure/base/network/network-policies/linkding/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# linkding = SQLite (no cross-ns DB) but uses OIDC against login.f4mily.net,
+# so it needs outbound HTTPS in addition to the baseline.
+namespace: linkding
+components:
+  - ../baseline
+  - ../egress-external

--- a/infrastructure/base/network/network-policies/readeck/kustomization.yaml
+++ b/infrastructure/base/network/network-policies/readeck/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# readeck = SQLite (no cross-ns DB) but archives bookmarked web pages,
+# so it needs outbound HTTP/HTTPS in addition to the baseline.
+namespace: readeck
+components:
+  - ../baseline
+  - ../egress-external

--- a/scripts/ci/validate.sh
+++ b/scripts/ci/validate.sh
@@ -32,6 +32,7 @@ trap 'rm -rf "$BUILD_DIR"' EXIT
 KUSTOMIZE_PATHS=(
   infrastructure/base
   infrastructure/base/backup-schedules
+  infrastructure/base/network/network-policies
   infrastructure/overlays/main
   apps/overlays/main
 )


### PR DESCRIPTION
## Was

Der Cluster lief **netzwerk-flach** — die einzige NetworkPolicy stammte von Flux selbst — trotz public-facing Apps auf Cilium-CNI. Dieser PR führt ein wiederverwendbares, portables **default-deny-Framework** ein (Standard `networking.k8s.io/v1`, von Cilium honoriert — bewusst keine CiliumNetworkPolicy) und rollt es **phased** auf selbst-enthaltene Namespaces aus.

- **`baseline`** Kustomize-Component: default-deny + allow DNS / from ingress-nginx / same-namespace / from monitoring (vmagent-Scrape — kritisch, sonst gehen Targets DOWN)
- **`egress-external`** Component: ausgehend 80/443 für OIDC-/Web-Archiving-Apps
- **Pilot:** `homer` (baseline), `linkding` + `readeck` (baseline + egress-external)
- eigene Flux-Kustomization **`infra-network-policies`** → Rollback = 1× `flux suspend`
- Runbook: `docs/runbooks/network-policies-rollout.md`

## Risiko & Rollback

Phased by design — nur 3 verifizierte Namespaces. Pilot deckt die nötigen Flows ab (homer egress-frei; linkding OIDC→login.f4mily.net:443; readeck Web-Archiving 80/443). Kubelet-Health-Probes bleiben (Cilium `--allow-localhost=always`).

Rollback: `flux suspend kustomization infra-network-policies` oder Revert.

## Verifikation nach Merge

```
kubectl -n homer get networkpolicy            # 5 Policies
kubectl -n homer get pods                     # Running, Ingress erreichbar
# Grafana → up{namespace="homer"} == 1 (Scrape lebt)
kubectl -n linkding exec deploy/linkding -- nslookup login.f4mily.net   # DNS ok
```

Weitere Namespaces danach gemäß Runbook (1–2 pro PR).

## Teil von

Platform-Hardening (4/4) — Abschluss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)