### PR TITLE
fix(immich): move subPath into globalMounts (bjw-s common v4 syntax)

### DIFF
--- a/apps/base/immich/helmrelease.yaml
+++ b/apps/base/immich/helmrelease.yaml
@@ -69,15 +69,21 @@ spec:
       persistence:
         data:
           accessMode: ReadWriteOnce
-          subPath: Bilder
+          # bjw-s common v4 (Chart 0.10+): subPath gehört IN den globalMounts-Eintrag.
+          # Ein subPath auf Persistence-Ebene wird stillschweigend ignoriert — /data
+          # zeigt dann auf die Share-Root statt auf die Immich-Library (Folder-Check
+          # stoppt den Start; genau das blockierte das Upgrade von Chart 0.9.3).
+          globalMounts:
+            - path: /data
+              subPath: Bilder
         fotos:
           enabled: true
           type: persistentVolumeClaim
           existingClaim: immich-fotos
           accessMode: ReadWriteOnce
-          subPath: Fotos
           globalMounts:
             - path: /fotos
+              subPath: Fotos
       ingress:
         main:
           enabled: false


### PR DESCRIPTION
Entsperrt das seit Mai hängende Chart-Upgrade 0.9.3→0.12.0: `subPath` auf Persistence-Ebene wird von bjw-s common v4 ignoriert → `/data` zeigte auf die NAS-Share-Root statt `Bilder/`, der Immich-Folder-Check verweigerte (korrekt) den Start. subPath jetzt im `globalMounts`-Eintrag, für `/data` und `/fotos`. Mit `helm template` 0.12.0 verifiziert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)