### PR TITLE
fix(pgadmin): Recreate strategy for RWO PVC

### DIFF
--- a/infrastructure/overlays/main/pgadmin/helmrelease.yaml
+++ b/infrastructure/overlays/main/pgadmin/helmrelease.yaml
@@ -24,6 +24,11 @@ spec:
         name: runix-repo
         namespace: flux-system
   values:
+    # RWO-PVC (iSCSI): RollingUpdate kann nie durchkommen — der neue Pod wartet
+    # ewig auf das Volume des alten (Multi-Attach). Blockierte das Chart-Upgrade
+    # auf 1.65.0 vier Mal, bis Helm zurückrollte.
+    strategy:
+      type: Recreate
     existingSecret: pgadmin-credentials
     secretKeys:
       emailKey: email


### PR DESCRIPTION
Chart-Upgrade 1.65.0 scheiterte 4× am Multi-Attach des RWO-iSCSI-Volumes (RollingUpdate startet den neuen Pod, solange der alte das Volume hält). `strategy: Recreate` beendet erst den alten Pod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)