### PR TITLE
fix(forgejo): CORS für OAuth2-PKCE-Clients (Sveltia CMS)

### DIFF
--- a/apps/base/forgejo/deployment.yaml
+++ b/apps/base/forgejo/deployment.yaml
@@ -37,6 +37,14 @@ spec:
               value: "1000"
             - name: USER_GID
               value: "1000"
+            # CORS für browserbasierte OAuth2-PKCE-Clients (Sveltia CMS):
+            # der Token-Exchange läuft im Browser gegen /login/oauth/access_token
+            # und braucht CORS-Header. Bei Bedarf auf die finale Site-Domain
+            # einschränken (kommagetrennte Liste statt *).
+            - name: GITEA__cors__ENABLED
+              value: "true"
+            - name: GITEA__cors__ALLOW_DOMAIN
+              value: "*"
             - name: GITEA__cache__ADAPTER
               value: redis
             - name: GITEA__cache__HOST

--- a/apps/base/forgejo/deployment.yaml
+++ b/apps/base/forgejo/deployment.yaml
@@ -39,12 +39,12 @@ spec:
               value: "1000"
             # CORS für browserbasierte OAuth2-PKCE-Clients (Sveltia CMS):
             # der Token-Exchange läuft im Browser gegen /login/oauth/access_token
-            # und braucht CORS-Header. Bei Bedarf auf die finale Site-Domain
-            # einschränken (kommagetrennte Liste statt *).
+            # und braucht CORS-Header. Bewusst nur die nötigen Origins —
+            # beim Produktivgang die finale Site-Domain ergänzen.
             - name: GITEA__cors__ENABLED
               value: "true"
             - name: GITEA__cors__ALLOW_DOMAIN
-              value: "*"
+              value: "http://localhost:1313"
             - name: GITEA__cache__ADAPTER
               value: redis
             - name: GITEA__cache__HOST


### PR DESCRIPTION
## Problem

Sveltia CMS (Stack-PoC für den MT-R-Relaunch, MT-R/poc-hugo-sveltia) authentifiziert per OAuth2-PKCE direkt aus dem Browser gegen Forgejo. Der Code→Token-Exchange (`POST /login/oauth/access_token`) scheitert mit „Failed to request an access token", weil Forgejo keine CORS-Header liefert (Preflight: 405, kein `Access-Control-Allow-Origin`).

## Fix

`GITEA__cors__ENABLED=true` + `GITEA__cors__ALLOW_DOMAIN=*` am Forgejo-Deployment. Kommentar im Manifest weist darauf hin, dass die Domain-Liste später auf die finale Site-Domain eingeschränkt werden kann.

`just validate` läuft durch (kind-Stage übersprungen wie üblich).

🤖 Generated with [Claude Code](https://claude.com/claude-code)