### PR TITLE
fix(grafana): korrekte Authentik-OAuth-Endpoints (Slug grafana-talos-cluster)

### DIFF
--- a/apps/base/authentik/blueprints/grafana-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/grafana-oauth.configmap.yaml
@@ -39,10 +39,10 @@ data:
             - !Find [authentik_providers_oauth2.scopemapping, [scope_name, entitlements]]
       - model: authentik_core.application
         identifiers:
-          slug: grafana
+          slug: grafana-talos-cluster
         attrs:
           name: Grafana
-          slug: grafana
+          slug: grafana-talos-cluster
           provider: !KeyOf grafana-provider
           launch_url: https://grafana.cluster.f4mily.net
           meta_launch_url: https://grafana.cluster.f4mily.net

--- a/apps/base/monitoring/vm-k8s-stack/helmrelease.yaml
+++ b/apps/base/monitoring/vm-k8s-stack/helmrelease.yaml
@@ -334,7 +334,7 @@ spec:
       ingress:
         enabled: false
 
-      # Generic OAuth via Authentik (login.f4mily.net, application slug: grafana)
+      # Generic OAuth via Authentik (login.f4mily.net, application slug: grafana-talos-cluster)
       # Requires Secret grafana-authentik-oauth — create with: just grafana-authentik-oauth
       envValueFrom:
         GF_AUTH_GENERIC_OAUTH_CLIENT_ID:
@@ -352,14 +352,16 @@ spec:
           auto_assign_org: true
           auto_assign_org_role: Viewer
         auth:
-          signout_redirect_url: https://login.f4mily.net/application/o/grafana/end-session/
+          signout_redirect_url: https://login.f4mily.net/application/o/grafana-talos-cluster/end-session/
         auth.generic_oauth:
           enabled: true
           name: Authentik
           scopes: openid profile email entitlements
-          auth_url: https://login.f4mily.net/application/o/grafana/authorize/
-          token_url: https://login.f4mily.net/application/o/grafana/token/
-          api_url: https://login.f4mily.net/application/o/grafana/userinfo/
+          # Authentik: authorize/token/userinfo sind global (nicht slug-scoped),
+          # nur end-session trägt den Application-Slug.
+          auth_url: https://login.f4mily.net/application/o/authorize/
+          token_url: https://login.f4mily.net/application/o/token/
+          api_url: https://login.f4mily.net/application/o/userinfo/
           allow_sign_up: true
           use_pkce: true
           role_attribute_path: >-


### PR DESCRIPTION
## Problem

"Sign in with Authentik" in Grafana (grafana.cluster.f4mily.net) lieferte **404 Not Found**.

Die OAuth-URLs im vm-k8s-stack-HelmRelease zeigten auf `/application/o/grafana/authorize/` etc. Das war doppelt falsch:

1. Die Application in Authentik heißt `grafana-talos-cluster`, nicht `grafana`.
2. Bei Authentik sind `authorize`/`token`/`userinfo` **global** (`/application/o/authorize/`, …) — nur `end-session` ist slug-scoped. Bestätigt via OIDC-Discovery: `https://login.f4mily.net/application/o/grafana-talos-cluster/.well-known/openid-configuration`.

## Änderungen

- `auth_url`/`token_url`/`api_url` auf die globalen Authentik-Endpoints umgestellt.
- `signout_redirect_url` auf `/application/o/grafana-talos-cluster/end-session/`.
- Blueprint `grafana-oauth.configmap.yaml`: Application-Slug auf `grafana-talos-cluster` angeglichen (Blueprint ist weiterhin **nicht verdrahtet** — weder in der authentik-Kustomization noch in `blueprints.configMaps`; die App wurde manuell angelegt).

## Verifikation

- `kustomize build apps/overlays/main` OK.
- Authorize-Endpoint mit `client_id=homelab-grafana` + redirect_uri der Grafana-Instanz → 302 in den Login-Flow (Provider existiert, client_id passt).

## Follow-up (nicht in diesem PR)

Blueprint entweder sauber verdrahten (Vorsicht: `client_secret`-Platzhalter würde den manuell gepflegten Provider überschreiben) oder entfernen — aktuell ist er tote Config. Gleiches Muster betrifft `teslamate-grafana-oauth.configmap.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)