### PR TITLE
fix(monitoring): Grafana-Datasources reparieren — Sidecar-Provisioning an, vmselect statt totem vmsingle

### DIFF
--- a/apps/base/monitoring/vm-k8s-stack/helmrelease.yaml
+++ b/apps/base/monitoring/vm-k8s-stack/helmrelease.yaml
@@ -303,15 +303,6 @@ spec:
         # renovate: datasource=custom.grafana-plugins depName=victoriametrics-logs-datasource
         - victoriametrics-logs-datasource@0.29.0
 
-      # VictoriaLogs datasource (sidecar.datasources is disabled — provision here).
-      additionalDataSources:
-        - name: VictoriaLogs
-          type: victoriametrics-logs-datasource
-          access: proxy
-          url: http://victoria-logs-single-server.monitoring.svc.cluster.local:9428
-          jsonData:
-            maxLines: 1000
-
       priorityClassName: homelab-infrastructure
 
       resources:
@@ -373,12 +364,15 @@ spec:
       podAnnotations:
         backup.velero.io/backup-volumes: grafana-storage
 
-      # Sidecar watches dashboard ConfigMaps only; defaultDatasources below
-      # provisions VM datasource — enabling the datasource sidecar duplicates
-      # provisioning and prevented Grafana from starting (exit 1 ~2s).
+      # Der Datasource-Sidecar ist der EINZIGE Provisioning-Weg dieses Charts
+      # (templates/grafana/datasource.yaml rendert nur mit aktiviertem
+      # Sidecar). Ohne ihn verwalten die Values gar keine Datasources und in
+      # Grafanas DB veralten die zuletzt provisionierten Einträge — so
+      # geschehen bei der vmcluster-Migration: Dashboards zeigten "no such
+      # host" auf den toten vmsingle-Service.
       sidecar:
         datasources:
-          enabled: false
+          enabled: true
         dashboards:
           enabled: true
           label: grafana_dashboard
@@ -387,11 +381,21 @@ spec:
     # ============================================
     # DATASOURCE - chart manages this natively
     # ============================================
+    # Chart-Defaults provisionieren uid=VictoriaMetrics (prometheus, Default)
+    # und uid=VictoriaMetricsDS (natives VM-Plugin) mit der zum Topologie-
+    # Modus (vmsingle/vmcluster) passenden URL; Alertmanager kommt ebenfalls
+    # automatisch. Die Dashboards des Charts referenzieren uid=VictoriaMetrics.
     defaultDatasources:
-      enabled: true
-      victoriametrics:
-        # Use native VM datasource plugin as default
-        datasourceType: victoriametrics-metrics-datasource
+      # VictoriaLogs ist ein eigenes HelmRelease — seine URL kennt der Chart
+      # nicht, daher explizit als Extra-Datasource.
+      extra:
+        - name: VictoriaLogs
+          type: victoriametrics-logs-datasource
+          access: proxy
+          uid: VictoriaLogs
+          url: http://victoria-logs-single-server.monitoring.svc.cluster.local:9428
+          jsonData:
+            maxLines: 1000
 
     # ============================================
     # KUBELET SCRAPING


### PR DESCRIPTION
## Symptom
Grafana-Login ok, aber alle Panels rot („no such host"): jede Query gegen die Default-Datasource endet mit 400.

## Diagnose (verifiziert am Live-System)
- Datasource-Health: `dial tcp: lookup vmsingle-vm-k8s-stack-….monitoring.svc… no such host` — die DB-Einträge zeigen noch auf den **vmsingle**-Service aus der Zeit vor der vmcluster-Migration.
- `vmselect` antwortet unter `:8481/select/0/prometheus` einwandfrei (count(up) = 61).
- Ursache: Chart 0.85.x provisioniert Datasources **nur** über den `grafana_datasource`-Sidecar (`templates/grafana/datasource.yaml`) — der war in den Values deaktiviert. Damit verwaltete nichts mehr die Datasources; die readonly-DB-Einträge veralteten still.
- Drei Values waren zudem tote Config: `grafana.additionalDataSources` (existiert im Chart nicht — deshalb fehlte VictoriaLogs komplett), `defaultDatasources.enabled`, `defaultDatasources.victoriametrics.datasourceType`.
- Die Chart-Dashboards referenzieren `uid=VictoriaMetrics` — diese uid existierte in der DB nicht.

## Fix
- `grafana.sidecar.datasources.enabled: true` (Kommentar korrigiert — der Sidecar ist der einzige Provisioning-Weg).
- Tote Values entfernt; VictoriaLogs nach `defaultDatasources.extra` (eigenes HelmRelease, URL kennt der Chart nicht) mit `uid=VictoriaLogs`.
- Chart-Defaults provisionieren dann `uid=VictoriaMetrics` (prometheus, Default), `uid=VictoriaMetricsDS` (natives Plugin) und Alertmanager mit der topologie-korrekten vmcluster-URL. Bestehende DB-Einträge werden per Namen übernommen (identische Namen), Dashboards finden ihre uid wieder.

## Verifikation
- `helm template` (0.85.9, extrahierte Values): grafana-ds-ConfigMap enthält alle 4 Datasources mit vmselect-URL, `grafana-sc-datasources`-Sidecar im Deployment. `kustomize build apps/base/monitoring` ok.
- Nach dem Merge prüfe ich am Live-System: Datasource-Health grün + VictoriaLogs vorhanden + Panel-Queries 200.

Hinweis: Selbstgebaute Dashboards, die die alten Zufalls-uids (P4169…, PA144…) hart referenzieren, müssten einmalig auf die neue uid zeigen — die Chart-Dashboards sind nicht betroffen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)