### PR TITLE
fix(monitoring): stale Grafana-Datasources räumen — behebt CrashLoop nach #433

### DIFF
--- a/apps/base/monitoring/vm-k8s-stack/grafana-ds-cleanup.yaml
+++ b/apps/base/monitoring/vm-k8s-stack/grafana-ds-cleanup.yaml
@@ -1,0 +1,27 @@
+# Räumt die vor der vmcluster-Migration provisionierten Datasource-Einträge
+# (Zufalls-uids) aus Grafanas DB, BEVOR datasource.yaml die Chart-uids
+# (VictoriaMetrics/VictoriaMetricsDS/Alertmanager) upsertet — Grafana 12
+# bricht sonst beim Start fatal ab (uid-Konflikt bei gleichem Namen:
+# "Datasource provisioning error: data source not found"). Der 00-Präfix
+# stellt sicher, dass der Sidecar-Ordner die Datei lexikalisch vor
+# datasource.yaml einsortiert; Grafana verarbeitet Provisioning-Dateien in
+# dieser Reihenfolge. Idempotent — kann nach erfolgreicher Übernahme
+# drinbleiben oder entfernt werden.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-ds-cleanup-stale
+  namespace: monitoring
+  labels:
+    grafana_datasource: "1"
+    app.kubernetes.io/component: grafana
+data:
+  00-cleanup-stale-datasources.yaml: |
+    apiVersion: 1
+    deleteDatasources:
+      - name: VictoriaMetrics
+        orgId: 1
+      - name: VictoriaMetrics (DS)
+        orgId: 1
+      - name: Alertmanager
+        orgId: 1

--- a/apps/base/monitoring/vm-k8s-stack/kustomization.yaml
+++ b/apps/base/monitoring/vm-k8s-stack/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - admin-credentials.secret.yaml
+  - grafana-ds-cleanup.yaml
   - helmrelease.yaml
   - ingress-grafana.yaml
   - ingress-victoria-metrics.yaml


### PR DESCRIPTION
**Grafana ist aktuell down (CrashLoopBackOff)** — bitte zügig mergen.

Nach dem Merge von #433 scheitert Grafanas Start am Datasource-Provisioning: die neuen Chart-uids (`VictoriaMetrics`, `VictoriaMetricsDS`, `Alertmanager`) kollidieren mit den gleichnamigen readonly-Alt-Einträgen (Zufalls-uids) in der DB — Grafana 12 behandelt das als fatalen Startfehler:

```
Failed to provision data sources: Datasource provisioning error: data source not found
invalid service state: Failed … starting module provisioning
```

Das ist auch die wahre Geschichte hinter dem alten Kommentar „Sidecar prevented Grafana from starting" — nicht Duplikation, sondern dieser uid-Konflikt.

## Fix
Zusätzliche `grafana_datasource`-ConfigMap `00-cleanup-stale-datasources.yaml` mit `deleteDatasources` für die drei Alt-Einträge. Der 00-Präfix sorgt dafür, dass Grafana die Löschung vor dem Upsert aus `datasource.yaml` verarbeitet. Idempotent; kann später entfernt werden.

Verifikation lokal: `kustomize build apps/base/monitoring` ok. Nach Merge: Flux-Reconcile, Grafana-Start, Datasource-Health + Panel-Query prüfe ich live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)