### PR TITLE
feat(netbird): Kubernetes-API-Server-Proxy via NetBird-Operator

### DIFF
--- a/apps/base/netbird-operator/clusterproxy-rbac.yaml
+++ b/apps/base/netbird-operator/clusterproxy-rbac.yaml
@@ -1,0 +1,57 @@
+# RBAC für den API-Server-Proxy: Der Proxy hängt die NetBird-Identität
+# (User + Gruppen) per Impersonation an jede Anfrage. Diese Rechte kann
+# der Operator nicht selbst anlegen (Privilege-Escalation), daher hier.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: clusterproxy-homelab
+  namespace: netbird
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: netbird-clusterproxy-homelab
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - users
+      - groups
+    verbs:
+      - impersonate
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - userextras/*
+      - uids
+    verbs:
+      - impersonate
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: netbird-clusterproxy-homelab
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: netbird-clusterproxy-homelab
+subjects:
+  - kind: ServiceAccount
+    name: clusterproxy-homelab
+    namespace: netbird
+---
+# Zugriffsrechte der NetBird-User: Die Gruppennamen aus NetBird landen als
+# K8s-Gruppen in der impersonierten Anfrage. Mitglieder der NetBird-Gruppe
+# "Admin" (aktuell: kreativmonkey) bekommen cluster-admin.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: netbird-admin-cluster-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: Group
+    name: Admin
+    apiGroup: rbac.authorization.k8s.io

--- a/apps/base/netbird-operator/clusterproxy.yaml
+++ b/apps/base/netbird-operator/clusterproxy.yaml
@@ -1,0 +1,16 @@
+# Exponiert den Kubernetes-API-Server als "homelab" im NetBird-Netz.
+# Client-Seite (netbird-Client aktuell halten):
+#   netbird kubernetes list
+#   netbird kubernetes write-kubeconfig homelab
+#   kubectl --context homelab get pods -A
+# Keine eigene NetBird-Policy nötig: die Default-Policy (All ↔ All) macht
+# den Proxy-Peer erreichbar; spec.groups daher bewusst weggelassen.
+apiVersion: netbird.io/v1alpha1
+kind: ClusterProxy
+metadata:
+  name: homelab
+  namespace: netbird
+spec:
+  clusterName: homelab
+  apiServer: https://kubernetes.default.svc.cluster.local/
+  serviceAccountName: clusterproxy-homelab

--- a/apps/base/netbird-operator/helmrelease.yaml
+++ b/apps/base/netbird-operator/helmrelease.yaml
@@ -1,0 +1,60 @@
+# NetBird Kubernetes-Operator — hier primär für den API-Server-Proxy
+# (docs.netbird.io/use-cases/kubernetes/api-server-proxy): kubectl-Zugriff
+# über das NetBird-Netz mit Impersonation der NetBird-User/-Gruppen, ohne
+# den API-Server zu exponieren und ohne Credentials auf den Clients.
+#
+# Der Operator spricht die Management-API der self-hosted Instanz
+# (netbird.f4mily.net, läuft auf hetzner-vps1) mit einem PAT aus dem
+# SOPS-Secret netbird-mgmt-api-key (siehe .template).
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: netbird-operator-repo
+  namespace: flux-system
+spec:
+  interval: 24h
+  type: oci
+  url: oci://ghcr.io/netbirdio/helm-charts
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: netbird-operator
+  namespace: netbird
+spec:
+  interval: 1h
+  timeout: 15m
+  targetNamespace: netbird
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: netbird-operator
+      version: "0.7.0"
+      sourceRef:
+        kind: HelmRepository
+        name: netbird-operator-repo
+        namespace: flux-system
+  values:
+    managementURL: https://netbird.f4mily.net
+    cluster:
+      # Taucht als Cluster-/Ressourcenname in NetBird auf.
+      name: homelab
+    webhook:
+      # cert-manager läuft im Cluster und stellt die Webhook-Zertifikate.
+      enableCertManager: true
+    operator:
+      resources:
+        requests:
+          cpu: 10m
+          memory: 64Mi
+        limits:
+          memory: 256Mi
+    # netbirdAPI.keyFromSecret bleibt Chart-Default:
+    # Secret netbird-mgmt-api-key, Key NB_API_KEY (SOPS, siehe Template).

--- a/apps/base/netbird-operator/kustomization.yaml
+++ b/apps/base/netbird-operator/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - netbird-mgmt-api-key.secret.yaml
+  - helmrelease.yaml
+  - clusterproxy-rbac.yaml
+  - clusterproxy.yaml

--- a/apps/base/netbird-operator/netbird-mgmt-api-key.secret.yaml
+++ b/apps/base/netbird-operator/netbird-mgmt-api-key.secret.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+data:
+    NB_API_KEY: ENC[AES256_GCM,data:vpMcLKPhM9bnVnnL+DTg+8I56knmZwN8ncgy/YHlJ+M=,iv:mKtBDBh9CvHfnXEU+uWNZaMQKxE3svnRsDT9rTYIJgg=,tag:g5+vafCDHGQVV887kQtMeQ==,type:str]
+kind: Secret
+metadata:
+    name: netbird-mgmt-api-key
+    namespace: netbird
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJbHZyaFlvZkF5bTAvcGFN
+            VEtnNlU3MHB4dVJVQ0s2NGVheVcwaDJuTjJvCjJLQkt1bDltRFNQVWxqcEFDOTdH
+            WHQ1bTZQMWhDM2ZucG92N3YzZVVJZlEKLS0tIEd0NEhud240WGNzUUR2aWVMeEtL
+            NlJtRW5TdkhkeCttRFFNU2J1bFRXRVkK9CcIDaN7+QrxlO6tg9xJ6tio1CCe7FuK
+            sImwAZFEDfS574nnaTLDj8Mo5lUuUacuVNL+jzXp0QdFxHh+0AcRrg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1u5lcvuuwd4lk7f3xewjk70j75yuh68myr89qkd0e8d44zgyjleeqw03vqs
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-07-09T07:43:00Z"
+    mac: ENC[AES256_GCM,data:VwOsyDxEfhxQ9CWAxjce9YxWznlyEsKCHmvo/g+b5/S/W25nGwHf9Q5fhLGXjPfDplalDwV/J/I8dek3TAINVoSAkXLGfXR322pYY5EuX9awVxn4ecXKvC9UPLrbgxaIHuT7N+LrdxzIwz0KEfoSGRxcO0+lw/UoHOU4we3m57A=,iv:mLAQmJZl96vR+2ztXAyAliBgXK9h7VjWS1O94b65jXE=,tag:5YgIaxQtYQeqKW40qwbNjg==,type:str]
+    version: 3.13.1

--- a/apps/base/netbird-operator/netbird-mgmt-api-key.secret.yaml
+++ b/apps/base/netbird-operator/netbird-mgmt-api-key.secret.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-    NB_API_KEY: ENC[AES256_GCM,data:vpMcLKPhM9bnVnnL+DTg+8I56knmZwN8ncgy/YHlJ+M=,iv:mKtBDBh9CvHfnXEU+uWNZaMQKxE3svnRsDT9rTYIJgg=,tag:g5+vafCDHGQVV887kQtMeQ==,type:str]
+    NB_API_KEY: ENC[AES256_GCM,data:J1shHT2GectCsdtLzpy4hRhS5ifNfbkPfw8eDSYn1J/rWWadzG9dWPtj/XC/vUuwHeunCIPx38k=,iv:+8XJECv4pKCNJiXxmXuxPHy8wWTdMNHc9nz0FZUv1/8=,tag:aGlLb7iF6QR8g7mpQDum3Q==,type:str]
 kind: Secret
 metadata:
     name: netbird-mgmt-api-key
@@ -9,14 +9,14 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJbHZyaFlvZkF5bTAvcGFN
-            VEtnNlU3MHB4dVJVQ0s2NGVheVcwaDJuTjJvCjJLQkt1bDltRFNQVWxqcEFDOTdH
-            WHQ1bTZQMWhDM2ZucG92N3YzZVVJZlEKLS0tIEd0NEhud240WGNzUUR2aWVMeEtL
-            NlJtRW5TdkhkeCttRFFNU2J1bFRXRVkK9CcIDaN7+QrxlO6tg9xJ6tio1CCe7FuK
-            sImwAZFEDfS574nnaTLDj8Mo5lUuUacuVNL+jzXp0QdFxHh+0AcRrg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQeUtIdjBxc1E3YThsSGp2
+            Q2taQWZ3cmduYkZEbFhYVzFjemJzVDAvSGpBCmViVFFlTi9RS05MVkNsYjFZNEVp
+            UEorb0QzWmhzL0pFYS9CS25vQmZaY1EKLS0tIE5RSENBcTQydVQxSkF5MkNHcENp
+            T2xKRVQ5MTZvSkRzazZ2TUlqN1AzNk0KRYNlL2//j5rDRkjg9CduAaM/vnyi5QID
+            GASuXdaWfGWdgeFQIOVe86a4guPqb0mj5EY245lOw53+q1BjZG+7SQ==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1u5lcvuuwd4lk7f3xewjk70j75yuh68myr89qkd0e8d44zgyjleeqw03vqs
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-07-09T07:43:00Z"
-    mac: ENC[AES256_GCM,data:VwOsyDxEfhxQ9CWAxjce9YxWznlyEsKCHmvo/g+b5/S/W25nGwHf9Q5fhLGXjPfDplalDwV/J/I8dek3TAINVoSAkXLGfXR322pYY5EuX9awVxn4ecXKvC9UPLrbgxaIHuT7N+LrdxzIwz0KEfoSGRxcO0+lw/UoHOU4we3m57A=,iv:mLAQmJZl96vR+2ztXAyAliBgXK9h7VjWS1O94b65jXE=,tag:5YgIaxQtYQeqKW40qwbNjg==,type:str]
+    lastmodified: "2026-07-09T07:53:45Z"
+    mac: ENC[AES256_GCM,data:rDMUjpKGN6n7KEMVGK5zRwoZeRKEbqUYn98Di9kQu1dxM+cnGJr8viqy1oiz02P2qsibWGddqE2jF2ad+7E3t5ZCYX7hCMcoIkeUmvNttLsucD0ORkScUWbeBghwGxo5ssi61sxl1TM4LtKocrSFrgY/4iZVjCl0IrPROZ7uio4=,iv:dhidhKbIGxeEIr7eIw8oH9YDokbVJPtyIsjfFmuQy7A=,tag:1N9OmILb0EJ2H+biKpwUmQ==,type:str]
     version: 3.13.1

--- a/apps/base/netbird-operator/netbird-mgmt-api-key.secret.yaml.template
+++ b/apps/base/netbird-operator/netbird-mgmt-api-key.secret.yaml.template
@@ -1,0 +1,12 @@
+# Personal Access Token für die NetBird-Management-API (self-hosted,
+# https://netbird.f4mily.net). Empfehlung: eigenen Service-User
+# "kubernetes-operator" (Rolle: admin) anlegen und dessen PAT verwenden —
+# Dashboard → Team → Service Users → Create Service User → Access Token.
+#
+# Secret erzeugen (im Repo committen, SOPS verschlüsselt automatisch):
+#
+#   cd apps/base/netbird-operator
+#   just sops-create netbird-mgmt-api-key netbird NB_API_KEY="nbp_..."
+#
+# Bis das echte Token drin ist, liegt hier ein Platzhalter — der Operator
+# startet damit, kann aber keine NetBird-Ressourcen anlegen (401 im Log).

--- a/apps/overlays/main/kustomization.yaml
+++ b/apps/overlays/main/kustomization.yaml
@@ -33,6 +33,7 @@ resources:
 
   # --- Infrastructure & Tools -------------------------------------------
   - ../../base/netbird
+  - ../../base/netbird-operator
   # - ../../base/backrest            # wip: ingress only, no workload
   - ../../base/searxng
   # - ../../base/unifi-controller    # disabled: dropped from catalog (DR test)


### PR DESCRIPTION
Deployt den [NetBird Kubernetes-Operator](https://docs.netbird.io/use-cases/kubernetes/api-server-proxy) (Chart `netbird-operator` 0.7.0 via OCI) und einen `ClusterProxy homelab`: kubectl-Zugriff über das NetBird-Netz, Authentifizierung über die NetBird-Identität (Impersonation) — der API-Server bleibt unexponiert, auf den Clients liegen keine Cluster-Credentials.

## Bausteine
- `apps/base/netbird-operator/`: HelmRelease (managementURL = self-hosted `netbird.f4mily.net`, cert-manager-Webhook-Zertifikate — cert-manager läuft bereits), ClusterProxy + Impersonations-RBAC (kann der Operator nicht selbst anlegen), Zugriffs-Binding **NetBird-Gruppe `Admin` → cluster-admin** (aktuell: kreativmonkey via auto-group).
- Keine neue NetBird-Policy nötig: die Default-Policy (All↔All) macht den Proxy-Peer erreichbar; `spec.groups` bewusst weggelassen.
- PAT-Secret `netbird-mgmt-api-key` (SOPS) enthält einen **Platzhalter**.

## Vor/nach dem Merge nötig (einmalig)
1. In https://netbird.f4mily.net → Team → **Service User** `kubernetes-operator` (Rolle admin) anlegen, Access Token erzeugen.
2. `cd apps/base/netbird-operator && just sops-create netbird-mgmt-api-key netbird NB_API_KEY="nbp_…"` und committen (gerne direkt auf diesen Branch).

## Client-Nutzung (netbird-CLI aktuell halten)
```
netbird kubernetes list
netbird kubernetes write-kubeconfig homelab
kubectl --context homelab get pods -A
```

## Verifikation
- `kustomize build apps/overlays/main` + `just validate` grün.
- Hinweis: Beim ersten Reconcile kann die ClusterProxy-CR kurz fehlschlagen, bis das HelmRelease die CRDs installiert hat — Flux retried das selbst.
- Nach Merge + echtem PAT prüfe ich live: Operator ready, Proxy-Pod als Peer im Netz, `netbird kubernetes list`.

⚠️ Ein Punkt zum Gegenprüfen beim Review: Das Feature ist relativ neu — die self-hosted Management-Instanz (netbird-server:latest auf hetzner-vps1, Stand 2026-07-05) sollte aktuell genug sein; falls `netbird kubernetes list` nichts findet, ist ein Update des netbird-server-Containers der erste Kandidat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)