### PR TITLE
feat(netbird): RBAC für Authentik-JWT-Gruppen — admin + View-Stufe

### DIFF
--- a/apps/base/netbird-operator/clusterproxy-rbac.yaml
+++ b/apps/base/netbird-operator/clusterproxy-rbac.yaml
@@ -41,8 +41,10 @@ subjects:
     namespace: netbird
 ---
 # Zugriffsrechte der NetBird-User: Die Gruppennamen aus NetBird landen als
-# K8s-Gruppen in der impersonierten Anfrage. Mitglieder der NetBird-Gruppe
-# "Admin" (aktuell: kreativmonkey) bekommen cluster-admin.
+# K8s-Gruppen in der impersonierten Anfrage (case-sensitiv!). "admin" ist
+# die per JWT-Sync aus Authentik kommende Gruppe (issued: jwt); die alte
+# manuelle NetBird-Gruppe "Admin" fliegt raus, sobald der Umzug auf
+# Authentik-verwaltete Gruppen abgeschlossen ist.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -54,4 +56,7 @@ roleRef:
 subjects:
   - kind: Group
     name: Admin
+    apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: admin
     apiGroup: rbac.authorization.k8s.io

--- a/apps/base/netbird-operator/clusterproxy-rbac.yaml
+++ b/apps/base/netbird-operator/clusterproxy-rbac.yaml
@@ -60,3 +60,24 @@ subjects:
   - kind: Group
     name: admin
     apiGroup: rbac.authorization.k8s.io
+---
+# Eingeschränkte Zugriffsstufe: Mitglieder der Authentik-Gruppe
+# "User-K8S-View" bekommen cluster-weiten Lesezugriff OHNE Secrets
+# (Built-in-ClusterRole "view"). Die Gruppe entsteht in NetBird beim
+# ersten Login eines Mitglieds (JWT-Sync); zusätzlich braucht sie die
+# NetBird-Policy User-K8S-View → K8S-API-Proxy tcp/443.
+# Weitere Stufen nach demselben Muster: z. B. Namespace-beschränktes
+# Bearbeiten via RoleBinding auf die Built-in-ClusterRole "edit" im
+# jeweiligen Namespace für eine Gruppe "User-K8S-Edit-<ns>".
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: netbird-k8s-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+  - kind: Group
+    name: User-K8S-View
+    apiGroup: rbac.authorization.k8s.io

--- a/apps/base/netbird-operator/clusterproxy-rbac.yaml
+++ b/apps/base/netbird-operator/clusterproxy-rbac.yaml
@@ -81,3 +81,44 @@ subjects:
   - kind: Group
     name: User-K8S-View
     apiGroup: rbac.authorization.k8s.io
+---
+# Ops-Stufe ("User-K8S-Ops"): lesen wie view PLUS Pods löschen — reicht,
+# um z. B. CrashLoop-Pods abzuräumen (der Controller erstellt sie neu).
+# Bewusst NICHT enthalten: exec/logs-Secrets/Workload-Änderungen.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: netbird-k8s-ops
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: netbird-k8s-ops-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+  - kind: Group
+    name: User-K8S-Ops
+    apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: netbird-k8s-ops
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: netbird-k8s-ops
+subjects:
+  - kind: Group
+    name: User-K8S-Ops
+    apiGroup: rbac.authorization.k8s.io

--- a/apps/base/netbird-operator/clusterproxy/clusterproxy.yaml
+++ b/apps/base/netbird-operator/clusterproxy/clusterproxy.yaml
@@ -5,9 +5,12 @@
 #   kubectl --context homelab get pods -A
 # Der Operator erzeugt den Setup-Key für die Proxy-Peers selbst (via
 # Management-PAT); spec.groups steuert deren NetBird-Gruppen. Die
-# Default-Policy (All ↔ All) ist seit 2026-07-09 deaktiviert — erreichbar
-# sind die Proxy-Peers über die Policy "Admin → K8S-Cluster" (tcp/443,
-# im NetBird-Dashboard gepflegt, nicht in GitOps).
+# Default-Policy (All ↔ All) ist seit 2026-07-09 deaktiviert — Zugriff
+# regeln NetBird-Policies (im Dashboard gepflegt, nicht in GitOps):
+#   Admin K8S-API-Proxy:      admin → K8S-Cluster tcp/443 (voller Zugriff)
+#   User-K8S-View-Policy:     User-K8S-View → K8S-API-Proxy tcp/443
+# K8S-API-Proxy enthält NUR die Proxy-Pods — eingeschränkte User erreichen
+# damit nicht Port 443 der Talos-Nodes (Ingress).
 apiVersion: netbird.io/v1alpha1
 kind: ClusterProxy
 metadata:
@@ -18,5 +21,8 @@ spec:
   apiServer: https://kubernetes.default.svc.cluster.local/
   serviceAccountName: clusterproxy-homelab
   groups:
-    # K8S-Cluster (per ID, überlebt Umbenennungen der Gruppe)
+    # per ID, überlebt Umbenennungen der Gruppen
+    # K8S-Cluster (Talos-Nodes + Proxy)
     - id: d86n1a4vln0s739sq9tg
+    # K8S-API-Proxy (nur Proxy-Pods, Ziel für eingeschränkte RBAC-Stufen)
+    - id: d98cu2svln0g00e7cv8g

--- a/apps/base/netbird-operator/clusterproxy/clusterproxy.yaml
+++ b/apps/base/netbird-operator/clusterproxy/clusterproxy.yaml
@@ -9,6 +9,7 @@
 # regeln NetBird-Policies (im Dashboard gepflegt, nicht in GitOps):
 #   Admin K8S-API-Proxy:      admin → K8S-Cluster tcp/443 (voller Zugriff)
 #   User-K8S-View-Policy:     User-K8S-View → K8S-API-Proxy tcp/443
+#   User-K8S-Ops-Policy:      User-K8S-Ops → K8S-API-Proxy tcp/443
 # K8S-API-Proxy enthält NUR die Proxy-Pods — eingeschränkte User erreichen
 # damit nicht Port 443 der Talos-Nodes (Ingress).
 apiVersion: netbird.io/v1alpha1


### PR DESCRIPTION
Vorbereitung für den JWT-Group-Sync aus Authentik (NetBird-Gruppen in Authentik managen).

**Erkenntnis aus dem NetBird-Quellcode:** Der JWT-Sync verwaltet ausschließlich Gruppen mit `issued: jwt`. Existiert bereits eine gleichnamige API-Gruppe, wird sie bewusst **nicht** befüllt (Schutz vor Privilegien-Eskalation über den IdP). Die gesyncte Admin-Gruppe ist daher eine **neue** Gruppe — gemappt wird die bestehende Authentik-Gruppe `admin` (kleingeschrieben; K8s-RBAC ist case-sensitiv).

Dieses Binding ergänzt `admin` neben `Admin` (Übergangszeit); `Admin` fliegt raus, sobald der Umzug auf Authentik-verwaltete Gruppen abgeschlossen ist.

Restliche Schritte (außerhalb GitOps): Authentik-Gruppen `User-*` + gefiltertes Scope-Mapping, dann `jwt_groups_enabled` in NetBird, Policies/Nameserver auf die JWT-Gruppen umziehen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)