### PR TITLE
feat(flux): seed private gitops source

### DIFF
--- a/clusters/AGENTS.md
+++ b/clusters/AGENTS.md
@@ -12,6 +12,9 @@ Flux Kustomization entry points. `main/` wires the cluster: `infrastructure.yaml
 - Entry-point Kustomizations point at `infrastructure/` and `apps/` overlays.
 - Respect dependency chain: infrastructure reconciles before dependent apps (`dependsOn`).
 - New top-level overlay → add a Kustomization here.
+- `private-gitops.yaml` is a temporary migration seed: it wires the private repo
+  as an additional source with `prune: false`; remove it after private root
+  bootstrap owns the live cluster.
 
 # Work Guidance
 

--- a/clusters/main/private-gitops.yaml
+++ b/clusters/main/private-gitops.yaml
@@ -1,0 +1,74 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: homelab-gitops-public
+  namespace: flux-system
+spec:
+  interval: 1m
+  ref:
+    branch: main
+  url: https://github.com/kreativmonkey/homelab-gitops.git
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: homelab-gitops-private-composed
+  namespace: flux-system
+spec:
+  interval: 1m
+  ref:
+    branch: main
+  secretRef:
+    name: flux-system
+  url: https://github.com/kreativmonkey/homelab-gitops-private.git
+  include:
+    - repository:
+        name: homelab-gitops-public
+      fromPath: apps/base
+      toPath: vendor/public/apps/base
+    - repository:
+        name: homelab-gitops-public
+      fromPath: infrastructure/base
+      toPath: vendor/public/infrastructure/base
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: private-infrastructure
+  namespace: flux-system
+spec:
+  interval: 10m
+  retryInterval: 1m
+  path: ./infrastructure/overlays/main
+  prune: false
+  sourceRef:
+    kind: GitRepository
+    name: homelab-gitops-private-composed
+  wait: true
+  timeout: 5m
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: private-apps
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: private-infrastructure
+  interval: 10m
+  retryInterval: 1m
+  path: ./apps/overlays/main
+  prune: false
+  sourceRef:
+    kind: GitRepository
+    name: homelab-gitops-private-composed
+  wait: true
+  timeout: 5m
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age


### PR DESCRIPTION
## Summary
- add temporary public root seed for homelab-gitops-private
- create composed private source including public bases
- enable private infrastructure/apps smoke layers with prune disabled

## Notes
- this does not pivot Flux bootstrap to the private repo
- private layers use prune: false for the migration smoke test
- remove this seed after private root bootstrap owns the cluster

## Verification
- nix develop -c just validate
- nix develop -c kubeconform -strict -ignore-missing-schemas -summary clusters/main/private-gitops.yaml