### PR TITLE
feat(flux): pivot bootstrap to private

### DIFF
--- a/clusters/AGENTS.md
+++ b/clusters/AGENTS.md
@@ -15,6 +15,10 @@ Flux Kustomization entry points. `main/` wires the cluster: `infrastructure.yaml
 - `private-gitops.yaml` is a temporary migration seed: it wires the private repo
   as an additional source with `prune: false`; remove it after private root
   bootstrap owns the live cluster.
+- During the private-root migration, `flux-system/gotk-sync.yaml` pivots the
+  bootstrap `GitRepository/flux-system` to `homelab-gitops-private`; the
+  private repo then owns live entrypoints and includes this public repo as
+  source material.
 
 # Work Guidance
 

--- a/clusters/main/flux-system/gotk-sync.yaml
+++ b/clusters/main/flux-system/gotk-sync.yaml
@@ -11,7 +11,7 @@ spec:
     branch: main
   secretRef:
     name: flux-system
-  url: https://github.com/kreativmonkey/homelab-gitops.git
+  url: https://github.com/kreativmonkey/homelab-gitops-private.git
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization


### PR DESCRIPTION
## Summary
- point bootstrap GitRepository/flux-system at homelab-gitops-private
- document that private root now owns live entrypoints and includes this public repo

## Pre-merge state
- homelab-gitops-private-composed is Ready at 9f3afc8
- private-infrastructure and private-apps are Ready
- all current public flux-system kustomizations are Ready

## Rollback
Revert this PR or set clusters/main/flux-system/gotk-sync.yaml back to https://github.com/kreativmonkey/homelab-gitops.git, then reconcile source/kustomization flux-system.

## Verification
- nix develop -c just validate
- nix develop -c kubeconform -strict -ignore-missing-schemas -summary clusters/main/flux-system/gotk-sync.yaml