### PR TITLE
revert(flux): keep public bootstrap root

### DIFF
--- a/clusters/AGENTS.md
+++ b/clusters/AGENTS.md
@@ -15,10 +15,6 @@ Flux Kustomization entry points. `main/` wires the cluster: `infrastructure.yaml
 - `private-gitops.yaml` is a temporary migration seed: it wires the private repo
   as an additional source with `prune: false`; remove it after private root
   bootstrap owns the live cluster.
-- During the private-root migration, `flux-system/gotk-sync.yaml` pivots the
-  bootstrap `GitRepository/flux-system` to `homelab-gitops-private`; the
-  private repo then owns live entrypoints and includes this public repo as
-  source material.
 
 # Work Guidance
 

--- a/clusters/main/flux-system/gotk-sync.yaml
+++ b/clusters/main/flux-system/gotk-sync.yaml
@@ -11,7 +11,7 @@ spec:
     branch: main
   secretRef:
     name: flux-system
-  url: https://github.com/kreativmonkey/homelab-gitops-private.git
+  url: https://github.com/kreativmonkey/homelab-gitops.git
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization


### PR DESCRIPTION
## Summary
- revert bootstrap GitRepository/flux-system URL to homelab-gitops public repo
- remove stale private-root pivot note from clusters AGENTS

## Why
Private-root pivot is more operational work than wanted right now. Keep the current public bootstrap and continue using private repo only as an additional source/overlay.

## Verification
- nix develop -c just validate