### PR TITLE
fix(talos): avoid SUC controller self-block

### DIFF
--- a/docs/learnings/talos-automatic-upgrade-suc-auth.md
+++ b/docs/learnings/talos-automatic-upgrade-suc-auth.md
@@ -137,19 +137,19 @@ FailedScheduling: 1 node(s) didn't satisfy existing pods anti-affinity rules,
 ```
 
 That node never cordons/drains and the Plan sits `applying: [<that-node>]`. **Fix:**
-relocate the controller onto an *already-upgraded* node and leave it there for the rest
-of the rollout — it then blocks nothing:
+make the controller anti-affinity match only controller pods, and make the Talos Plan
+use its own app name:
 
-```bash
-# cordon the other free nodes so the controller can only land on the done node, then:
-kubectl -n system-upgrade delete pod -l app.kubernetes.io/name=system-upgrade-controller
-# uncordon afterwards
-```
+- Patch the SUC Deployment anti-affinity to select
+  `app.kubernetes.io/component=controller` instead of
+  `app.kubernetes.io/name=system-upgrade-controller`.
+- Label the Talos Plan `app.kubernetes.io/name=talos-upgrade`; SUC copies Plan labels
+  to upgrade Jobs, so those Jobs must never look like controller pods.
 
-Caveat: that label selector **also matches the live upgrade job pod**. A
-`--field-selector status.phase!=Running` to "only kill the broken controller" can
-delete a mid-reboot upgrade pod too — harmless (the Job re-reconciles), but don't be
-surprised.
+With that split, the upgrade job can schedule on the node that currently runs the
+controller. SUC's drain already ignores its own controller pod, so Kubernetes evicts
+and recreates the controller through the Deployment while the node reboots; no manual
+controller relocation is needed.
 
 **6. The controller image was pinned to a tag that was never released.**
 `infrastructure/base/system-upgrade-controller/kustomization.yaml` had

--- a/infrastructure/base/system-upgrade-controller/kustomization.yaml
+++ b/infrastructure/base/system-upgrade-controller/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - https://github.com/rancher/system-upgrade-controller?ref=v0.19.2
 patches:
   - path: patch-deployment-strategy.yaml
+  - path: patch-controller-anti-affinity.yaml
 images:
   - name: rancher/system-upgrade-controller
     # Must be a published stable tag. v0.20.0 was never released (only v0.20.0-rc.1),

--- a/infrastructure/base/system-upgrade-controller/patch-controller-anti-affinity.yaml
+++ b/infrastructure/base/system-upgrade-controller/patch-controller-anti-affinity.yaml
@@ -1,0 +1,22 @@
+# Upstream matches app.kubernetes.io/name=system-upgrade-controller. Talos Plan
+# labels are copied to per-node upgrade Jobs, so those Jobs can inherit the same
+# label and fail to schedule on the node running the controller. Match only the
+# controller component instead.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: system-upgrade-controller
+  namespace: system-upgrade
+spec:
+  template:
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                      - controller
+              topologyKey: kubernetes.io/hostname

--- a/infrastructure/overlays/main/system-upgrade-controller/talos-plan.yaml
+++ b/infrastructure/overlays/main/system-upgrade-controller/talos-plan.yaml
@@ -11,7 +11,9 @@ metadata:
   name: talos
   namespace: system-upgrade
   labels:
-    app.kubernetes.io/name: system-upgrade-controller
+    # SUC copies Plan labels to upgrade Jobs. Do not reuse the controller name:
+    # the controller Deployment has required podAntiAffinity for that workload.
+    app.kubernetes.io/name: talos-upgrade
     app.kubernetes.io/component: talos-upgrade
 spec:
   # One node at a time — safe for 3-node stacked control-plane.


### PR DESCRIPTION
## Summary
- retarget SUC controller pod anti-affinity to controller pods only
- rename Talos Plan app label so upgrade Jobs no longer look like controller pods
- update Talos upgrade learning with the declarative prevention

## Verification
- nix develop -c kustomize build infrastructure/base/system-upgrade-controller
- nix develop -c kustomize build infrastructure/overlays/main/system-upgrade-controller
- nix develop -c just lint
- nix develop -c just validate

Note: just validate skips kind dry-run by default via SKIP_KIND=1.