### PR TITLE
fix(searxng): allow json search format

### DIFF
--- a/apps/base/searxng/configmap.yaml
+++ b/apps/base/searxng/configmap.yaml
@@ -19,3 +19,6 @@ data:
     search:
       safe_search: 0
       default_lang: "de-DE"
+      formats:
+        - html
+        - json


### PR DESCRIPTION
## Summary
- enable JSON as an allowed SearXNG search format for machine clients
- keep HTML search enabled for the browser UI

## Validation
- nix develop -c just validate