### PR TITLE
fix(nextcloud): pin mail.f4mily.net to IPv4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ You are **Senior Kubernetes System Architect** and **GitOps Automation Engineer*
 
 # Ingress & HelmRelease Conventions
 - Every public app uses a **HelmRelease**.
+- Cluster has no IPv6 egress to the mail VPS: Nextcloud pins `mail.f4mily.net` → `91.99.145.19` via HelmRelease `postRenderers`/`hostAliases` (AAAA would time out IMAP).
 - Ingress must include:
   - `nginx.org/ssl-redirect: "false"`
   - `nginx.org/redirect-to-https: "true"`

--- a/apps/base/nextcloud/helmrelease.yaml
+++ b/apps/base/nextcloud/helmrelease.yaml
@@ -8,6 +8,23 @@ metadata:
 spec:
   interval: 1h
   timeout: 20m
+  # Cluster hat kein IPv6-Egress zur VPS; AAAA für mail.f4mily.net → IMAP-Timeouts.
+  # hostAliases pinnt A-Record, Happy-Eyeballs fällt nicht auf unreachable v6.
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              group: apps
+              version: v1
+              kind: Deployment
+              name: nextcloud
+            patch: |
+              - op: add
+                path: /spec/template/spec/hostAliases
+                value:
+                  - ip: "91.99.145.19"
+                    hostnames:
+                      - mail.f4mily.net
   install:
     disableWait: true
     remediation:


### PR DESCRIPTION
## Summary
- Cluster has no IPv6 egress to the mail VPS; `mail.f4mily.net` AAAA made IMAP Happy-Eyeballs hang.
- Pin hostname to `91.99.145.19` via HelmRelease `postRenderers`/`hostAliases`.

## Test plan
- [ ] Nextcloud pod: `getent hosts mail.f4mily.net` shows only `91.99.145.19`
- [ ] `occ mail:account:sync` completes in ~seconds, not minutes
- [ ] Mail app folder load no longer hangs

Made with [Cursor](https://cursor.com)