### PR TITLE
chore(renovate): tiered automerge (digest/pin/patch + minor for leaf apps)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -156,12 +156,31 @@
       "automerge": true
     },
     {
-      "description": "Homepage: Patch-Updates automergen",
+      "description": "Stufe 1: risikoarme Updates (digest/pin/patch) global automergen — nach 7d-Soak + grünem validate-Check. Majors/Minors bleiben manuell (außer Stufe-2-Allowlist unten).",
+      "matchUpdateTypes": [
+        "digest",
+        "pin",
+        "patch"
+      ],
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true
+    },
+    {
+      "description": "Stufe 2: minor-Updates unkritischer, zustandsarmer Leaf-Apps automergen. Bewusst OHNE stateful/kritische Dienste (nextcloud, immich, authentik, forgejo, netbird, DBs).",
       "matchFileNames": [
-        "apps/base/homepage/**"
+        "apps/base/homepage/**",
+        "apps/base/homer/**",
+        "apps/base/linkding/**",
+        "apps/base/readeck/**",
+        "apps/base/gatus/**",
+        "apps/base/speedtest-tracker/**",
+        "apps/base/sterling-pdf/**",
+        "apps/base/jellyfin/**",
+        "apps/base/kite/**"
       ],
       "matchUpdateTypes": [
-        "patch"
+        "minor"
       ],
       "automerge": true,
       "automergeType": "pr",


### PR DESCRIPTION
## Ziel
Manuellen Merge-Aufwand senken, ohne Sicherheit aufzugeben. Gate bleibt der required `validate`-Check + der bestehende 7-Tage-Soak (`minimumReleaseAge`).

## Änderungen an `renovate.json`
- **Stufe 1 — global:** `digest`/`pin`/`patch` automergen. Ersetzt die bisherige enge homepage-patch-Regel (jetzt enthalten).
- **Stufe 2 — Leaf-Apps:** `minor` automergen für zustandsarme, unkritische Apps: `homepage, homer, linkding, readeck, gatus, speedtest-tracker, sterling-pdf, jellyfin, kite`.
- **Manuell (unverändert):** `major` überall; stateful/kritisch (nextcloud, immich, authentik, forgejo, netbird, DBs); gepinnte Deps (CNPG, authentik, talos, postgis, vectorchord).

## Repo-Setting (bereits gesetzt)
`allow_auto_merge=true` + `delete_branch_on_merge=true`, damit `platformAutomerge` GitHubs natives Auto-Merge nutzt (sichtbar in der UI, robuster als Renovate-eigenes Polling).

## Sicherheitsmodell
Automerge greift erst bei grünem `validate` (kustomize build + kubeconform + helm template) nach 7d Soak. Laufzeit-Sicherheit weiterhin über Flux-Reconcile + Monitoring + Rollback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)