### PR TITLE
fix(renovate): don't automerge minor updates of 0.x deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -207,6 +207,14 @@
       "automerge": true,
       "automergeType": "pr",
       "platformAutomerge": true
+    },
+    {
+      "description": "Guard: 0.x-Versionen — bei 0.y.z ist laut Semver das minor-Feld (y) die Breaking-Stelle. Minor-Automerge (Stufe 2) hier zurücknehmen, damit ein potenziell breaking 0.x-Minor nicht automatisch durchrutscht. Patch (0.y.Z) bleibt automerge.",
+      "matchUpdateTypes": [
+        "minor"
+      ],
+      "matchCurrentVersion": "/^0\\./",
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
Folgeschliff zu #522.

Bei `0.y.z` ist laut Semver das **minor-Feld (`y`) die Breaking-Stelle** — ein `0.x`-Minor kann also brechen, würde aber durch die Stufe-2-Leaf-Regel (gatus, kite & Co. liegen auf `0.x`) automatisch gemergt.

**Guard:** letzte packageRule setzt `automerge: false` für `matchUpdateTypes: [minor]` + `matchCurrentVersion: /^0\./`. Überschreibt Stufe 2 für `0.x`-Deps. `patch` (`0.y.Z`) bleibt weiterhin Automerge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)