### PR TITLE
fix(paperless): raise memory limit to 2Gi to stop OOMKill loop

### DIFF
--- a/apps/base/paperless-ngx/helmrelease.yaml
+++ b/apps/base/paperless-ngx/helmrelease.yaml
@@ -102,10 +102,10 @@ spec:
                 path: /spec/template/spec/containers/0/resources
                 value:
                   requests:
-                    cpu: 50m
-                    memory: 256Mi
-                  limits:
+                    cpu: 200m
                     memory: 1Gi
+                  limits:
+                    memory: 2Gi
           - target:
               group: apps
               version: v1


### PR DESCRIPTION
## Symptom
Betreiber meldet 46 fehlgeschlagene Dateiaufgaben + Scans, die "seit Stunden auf Verarbeitung warten", App "hängt".

## Root Cause (diagnostiziert, read-only)
`paperless-ngx` läuft als **ein** Container (granian-Webserver + Celery-Worker + Beat, `PAPERLESS_TASK_WORKERS=2`) mit `limits.memory: 1Gi`. Schon im Leerlauf ~720–950Mi; jeder OCR-Lauf (Tesseract/OCRmyPDF) kippt ihn über die cgroup-Grenze → **OOMKilled** (Exit 137, zuletzt vor ~85 min, 2 Restarts).

Der Kill mitten im Consume hinterlässt:
- **18× `STARTED`** verwaiste Tasks (Bodensatz zurück bis 2025-07-17) → erscheinen in der UI ewig als "in Bearbeitung" = die "wartenden Scans".
- **120× `FAILURE`** ("File not found" — Duplikat-Task nach Retry).

**Keine Datenverluste:** alle betroffenen Dateien haben ein zugehöriges Dokument in der DB; Consume-Dir + SMB-Share + Redis-Queue sind leer.

## Fix
`limits.memory 1Gi → 2Gi`, `requests` 256Mi→1Gi / 50m→200m CPU. Node hat Headroom.

Bewusst **keine** Liveness/Readiness-Probe: Webserver+Worker teilen den Container — eine HTTP-Probe würde bei langem OCR fehlschlagen und einen Restart-Loop erzeugen.

## Nachgelagert (separat, nicht in diesem PR)
- Verwaiste `STARTED`/`FAILURE`-Task-Einträge in der DB aufräumen (UI-Kosmetik, Dokumente unberührt).
- Falls 2Gi bei großen Scans weiter knapp: `PAPERLESS_TASK_WORKERS` auf 1 senken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)