### PR TITLE
fix(paperless): disable content date detection (use scan date)

### DIFF
--- a/apps/base/paperless-ngx/helmrelease.yaml
+++ b/apps/base/paperless-ngx/helmrelease.yaml
@@ -187,6 +187,11 @@ spec:
           value: "true"
         - name: PAPERLESS_SOCIALACCOUNT_ALLOW_SIGNUPS
           value: "true"
+        # Datums-Erkennung aus dem Dokumentinhalt abschalten: neue Dokumente
+        # erhalten das Consumption-/Scan-Datum als created-Datum statt eines aus
+        # dem OCR-Text geratenen (das lag reihenweise daneben, u.a. 1988er-Daten).
+        - name: PAPERLESS_NUMBER_OF_SUGGESTED_DATES
+          value: "0"
       ingress:
         enabled: false
       volumes:


### PR DESCRIPTION
## Problem
Paperless rät das Dokumentdatum aus dem OCR-Text (`PAPERLESS_NUMBER_OF_SUGGESTED_DATES` default 3). Bei Scanner-PDFs ohne Datum im Dateinamen trifft das oft daneben: heute eingescannte Docs bekamen Juni/März-Daten, 8 Altdokumente standen auf **1988**.

## Fix
`PAPERLESS_NUMBER_OF_SUGGESTED_DATES=0` → Datums-Erkennung aus. Neue Dokumente erhalten das Consumption-/Scan-Datum als `created`; bei Bedarf im UI manuell korrigierbar.

Angehängt ans **Ende** der env-Liste, damit der `valuesFrom`-targetPath `paperless.env[4].value` (DB-Passwort) unverändert bleibt.

## Bereits erledigt (außerhalb dieses PR)
Die 8 falsch auf 1988 datierten Bestandsdokumente wurden live auf ihr Scan-Datum korrigiert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)