### PR TITLE
feat(paperless-gpt): AI OCR + metadata via OpenAI

### DIFF
--- a/apps/base/paperless-gpt/deployment.yaml
+++ b/apps/base/paperless-gpt/deployment.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paperless-gpt
+  namespace: paperless-ngx
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: paperless-gpt
+  template:
+    metadata:
+      labels:
+        app: paperless-gpt
+        app.kubernetes.io/name: paperless-gpt
+    spec:
+      enableServiceLinks: false
+      containers:
+        - name: paperless-gpt
+          image: icereed/paperless-gpt:v0.27.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+              name: http
+          env:
+            - name: TZ
+              value: Europe/Berlin
+            # Paperless API (internes ClusterIP; Service hört auf Port 80)
+            - name: PAPERLESS_BASE_URL
+              value: http://paperless-ngx:80
+            - name: PAPERLESS_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: paperless-gpt-secrets
+                  key: PAPERLESS_API_TOKEN
+            # Textbasierte Metadaten (Titel/Tags/Korrespondent/Datum)
+            - name: LLM_PROVIDER
+              value: openai
+            - name: LLM_MODEL
+              value: gpt-4o
+            # LLM-OCR über Vision-Modell (verarbeitet Dokument-Bilder)
+            - name: OCR_PROVIDER
+              value: llm
+            - name: VISION_LLM_PROVIDER
+              value: openai
+            - name: VISION_LLM_MODEL
+              value: gpt-4o
+            - name: OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: paperless-gpt-secrets
+                  key: OPENAI_API_KEY
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: paperless-gpt
+  namespace: paperless-ngx
+spec:
+  ports:
+    - port: 8080
+      targetPort: http
+      name: http
+  selector:
+    app: paperless-gpt

--- a/apps/base/paperless-gpt/kustomization.yaml
+++ b/apps/base/paperless-gpt/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - paperless-gpt-secrets.secret.yaml
+  - deployment.yaml

--- a/apps/base/paperless-gpt/paperless-gpt-secrets.secret.yaml
+++ b/apps/base/paperless-gpt/paperless-gpt-secrets.secret.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: paperless-gpt-secrets
+    namespace: paperless-ngx
+type: Opaque
+stringData:
+    PAPERLESS_API_TOKEN: ENC[AES256_GCM,data:1lnMuha9EOiHkpup3QMuE/DiPsX3EYi1r5wq1XacIQSmCQlT2cOOSA==,iv:cf24aq6XENFw5VMySyUbgR0nlpluBdI666p/GmENCXM=,tag:UX50tWV4arbVCVmvPxmsJg==,type:str]
+    OPENAI_API_KEY: ENC[AES256_GCM,data:I2+KsQN0+nnmBrrs7Z8TxHR/mKKDi6hZJpHmHw7LhpGCnWOrjpjCga0jOvIcaVGL0ENFKVwvQUlLAfNXO1q1ADCaX8Ph/5qsrhIlZWIC2yX0D66lcT/TrT7MFIYxta60CG7WEnPe01I58J3bmITY9qB8s4qVN5Ev3OxjvntmWk+SlvuQZHg4gB9BSx8YMepMvRtlE5B45axoKcjJElyOh6e8sDQ=,iv:tLs7BrmkX0X4Egj0mM3fL/15hqbVymjl9aDy98Z5ZBE=,tag:Bdn6GmLeDrGCZDIbpPS77A==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBySTdybmcrLzBTUmwweE5U
+            TGZSZ1V1N1lNTUhBVGNUUVhnOGJNOUJtbHhvCjhxMjhuVjZDUFMwMkw3RHVjQWNq
+            Z0JZODVHanRLYnlUQnIwVC8xclZPZVUKLS0tIGgwaUVhbFFKWHdOUU96NHZhV1k2
+            aXlEeVVMKzJKMHVVckJKcFN4VmxKd0UKFO6fgPgxxfK4hCjxZ8uT7kbI7RHYp0sz
+            +Hd6ZpnyJPsW1Y7Nworb/TFbscL1w6ACwKBCjej2qD1sGRgadhwyUQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1u5lcvuuwd4lk7f3xewjk70j75yuh68myr89qkd0e8d44zgyjleeqw03vqs
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-07-23T15:53:36Z"
+    mac: ENC[AES256_GCM,data:VeglEz01BYOih/DhklFyCsME3n7Da9g8YClIddtbGzjAJtv9F+fvKWcyiUfxMHybmysdU0a0yzj+iL8ZBNVe1ijStzNYzGfkkn9hQ7JA83eZ2lJWea3iHKsvXJT4YqRvW0w4IG74kj7QGA8vG2cvCgHDwWwrHsBeRhdGTgVS+0w=,iv:P6FROm8n7JMMKrcxeJ38j70jW5Mn6ltBs7zkyBD+Odo=,tag:fOqEVWT/PURMNqA1vE0+Hg==,type:str]
+    version: 3.13.2

--- a/apps/overlays/main/kustomization.yaml
+++ b/apps/overlays/main/kustomization.yaml
@@ -29,6 +29,7 @@ resources:
   - ../../base/kavita
   - ../../base/tandoor
   - ../../base/paperless-ngx
+  - ../../base/paperless-gpt
   - ../../base/immich
 
   # --- Infrastructure & Tools -------------------------------------------


### PR DESCRIPTION
## Ziel
Behebt die schlechte OCR + falsches Datum/Titel bei Scans — über [paperless-gpt](https://github.com/icereed/paperless-gpt) als API-Companion. (Die **native** Paperless-AI kommt erst mit Paperless-ngx **3.0**; wir laufen auf 2.20.15, daher dieser Weg — 3.0-Upgrade separat.)

## Was reinkommt
- `apps/base/paperless-gpt/`: Deployment + Service (ClusterIP `:8080`) in ns `paperless-ngx`, Image `icereed/paperless-gpt:v0.27.0`.
- **LLM-OCR** via `gpt-4o` Vision (`OCR_PROVIDER=llm`) + **Titel/Datum/Tags** via `gpt-4o`.
- Zwei SOPS-Secrets: dedizierter OpenAI-Key + Paperless-API-Token (User `kreativmonkey`).
- Ins `apps/overlays/main` eingehängt.

## Exposition / Sicherheit
**Kein Ingress** — paperless-gpt hat keine eingebaute Auth und verarbeitet sensible Dokumente. Zugriff auf die Review-UI via `kubectl -n paperless-ngx port-forward svc/paperless-gpt 8080:8080` oder NetBird. Authentik-Ingress später möglich.

⚠️ **Datenfluss:** Dokument-Bilder + OCR-Text gehen an die OpenAI-API (LLM-OCR gewünscht). Über die API trainiert OpenAI standardmäßig nicht mit.

## Nutzung (tag-basiert)
paperless-gpt verarbeitet nur getaggte Dokumente:
- Tag **`paperless-gpt-ocr-auto`** → automatische LLM-OCR
- Tag **`paperless-gpt-auto`** → automatische Titel/Tags/Korrespondent
- Tag **`paperless-gpt`** → manueller Review in der UI

Tipp: In Paperless einen Workflow anlegen, der neuen Scans automatisch den passenden Tag gibt.

## Hinweis (separat)
`.sops.yaml` in `main` trägt beim Age-Recipient den Platzhalter `REMOVED_BY_HISTORY_REWRITE` (Kollateralschaden der History-Bereinigung) → lokales SOPS-Verschlüsseln ist damit kaputt. Dieses Secret wurde über die echte `.sops.yaml` des Haupt-Checkouts verschlüsselt. Sollte separat gefixt werden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)