### PR TITLE
fix(paperless): allow internal service host (paperless-gpt API 400)

### DIFF
--- a/apps/base/paperless-ngx/helmrelease.yaml
+++ b/apps/base/paperless-ngx/helmrelease.yaml
@@ -155,8 +155,11 @@ spec:
           value: Europe/Berlin
         - name: PAPERLESS_OCR_LANGUAGE
           value: eng
+        # paperless-ngx = interner Service-Name; nötig, damit In-Cluster-Clients
+        # (paperless-gpt) die API über http://paperless-ngx erreichen, ohne dass
+        # Django den Host als DisallowedHost mit 400 ablehnt.
         - name: PAPERLESS_ALLOWED_HOSTS
-          value: paperless.f4mily.net
+          value: paperless.f4mily.net,paperless-ngx
         - name: PAPERLESS_CSRF_TRUSTED_ORIGINS
           value: https://paperless.f4mily.net
         - name: PAPERLESS_TASK_WORKERS


### PR DESCRIPTION
paperless-gpt (#527/#529) erreicht die Paperless-API über `http://paperless-ngx`, aber Django lehnte den Host als DisallowedHost mit **HTTP 400** ab (`PAPERLESS_ALLOWED_HOSTS` nur `paperless.f4mily.net`). Interner Service-Name `paperless-ngx` ergänzt → In-Cluster-API-Zugriff funktioniert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)