### PR TITLE
fix(sterling-pdf): raise ingress body size limit for PDF merge

### DIFF
--- a/apps/base/sterling-pdf/helmrelease.yaml
+++ b/apps/base/sterling-pdf/helmrelease.yaml
@@ -109,6 +109,10 @@ spec:
         # TLS: wildcard-f4mily-net-tls replicated from cert-manager (reflector)
         nginx.org/ssl-redirect: "false"
         nginx.org/redirect-to-https: "true"
+        # default client_max_body_size (1m) blocks merging larger PDF sets with 413
+        nginx.org/client-max-body-size: "100m"
+        nginx.org/proxy-read-timeout: "300"
+        nginx.org/proxy-send-timeout: "300"
       hosts:
         - name: pdf.f4mily.net
           path: /


### PR DESCRIPTION
## Summary
- Merging multiple PDFs in Stirling PDF failed with HTTP 413 - the nginx.org ingress controller's default `client_max_body_size` (1m) blocked uploads above 1MB before reaching the pod.
- Adds `nginx.org/client-max-body-size: "100m"` plus generous read/send proxy timeouts to the ingress annotations.

## Test plan
- [ ] Flux reconciles `sterling-pdf` HelmRelease after merge
- [ ] Merge several PDFs (>1MB total) via https://pdf.f4mily.net and confirm no more 413

🤖 Generated with [Claude Code](https://claude.com/claude-code)