### PR TITLE
tune(paperless-gpt): German, model split, OCR write-back

### DIFF
--- a/apps/base/paperless-gpt/deployment.yaml
+++ b/apps/base/paperless-gpt/deployment.yaml
@@ -39,7 +39,9 @@ spec:
             - name: LLM_PROVIDER
               value: openai
             - name: LLM_MODEL
-              value: gpt-4o
+              value: gpt-4o-mini
+            - name: LLM_LANGUAGE
+              value: German
             # LLM-OCR über Vision-Modell (verarbeitet Dokument-Bilder)
             - name: OCR_PROVIDER
               value: llm
@@ -52,6 +54,22 @@ spec:
                 secretKeyRef:
                   name: paperless-gpt-secrets
                   key: OPENAI_API_KEY
+            # Deterministische OCR, keine neuen Tags anlegen (nur bestehende nutzen)
+            - name: VISION_LLM_TEMPERATURE
+              value: "0"
+            - name: CREATE_NEW_TAGS
+              value: "false"
+            - name: PAPERLESS_PUBLIC_URL
+              value: https://paperless.f4mily.net
+            # Verbessertes durchsuchbares PDF zurückschreiben und Original ersetzen.
+            # Original wandert in den Paperless-Papierkorb (30 Tage wiederherstellbar);
+            # Metadaten werden auf das neue PDF übernommen.
+            - name: PDF_UPLOAD
+              value: "true"
+            - name: PDF_REPLACE
+              value: "true"
+            - name: PDF_COPY_METADATA
+              value: "true"
           readinessProbe:
             tcpSocket:
               port: http


### PR DESCRIPTION
Sinnvolle Einstellungen für paperless-gpt (nach Review der Optionen).

## Änderungen
- **`LLM_MODEL` gpt-4o → gpt-4o-mini** — Kostenhebel: Text-Metadaten brauchen kein gpt-4o. Vision-OCR (`VISION_LLM_MODEL`) bleibt `gpt-4o`.
- **`LLM_LANGUAGE=German`** — deutsche Dokumente.
- **`VISION_LLM_TEMPERATURE=0`** — deterministische, texttreue OCR.
- **`CREATE_NEW_TAGS=false`** — kein Tag-Wildwuchs (nur bestehende der 212 Tags).
- **`PAPERLESS_PUBLIC_URL=https://paperless.f4mily.net`** — korrekte Links.
- **`PDF_UPLOAD=true` + `PDF_REPLACE=true`** (deine Wahl) — verbessertes, durchsuchbares PDF ersetzt das Original. `PDF_COPY_METADATA=true` erhält Metadaten.

## ⚠️ Wichtig zu PDF_REPLACE
Ersetzt das Originaldokument. Sicherheitsnetz: das Original wandert in den **Paperless-Papierkorb** (Aufbewahrung Default **30 Tage** → wiederherstellbar). **Trotzdem: erst an EINEM Dokument testen**, bevor du breit taggst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)