### PR TITLE
feat(paperless-ngx): upgrade to v3.0.2 (major)

### DIFF
--- a/apps/base/paperless-ngx/helmrelease.yaml
+++ b/apps/base/paperless-ngx/helmrelease.yaml
@@ -22,11 +22,11 @@ spec:
   values:
     image:
       repository: ghcr.io/paperless-ngx/paperless-ngx
-      # Chart-Migration bleibt bewusst auf 2.20.15 (verhaltensneutral). Der Marker
-      # macht das App-Image für Renovate sichtbar (customManager, datasource=docker) —
-      # das v3-Major-Upgrade kommt danach als eigener PR (DB-Backup + Migration-Guide).
+      # Major-Upgrade v2.20.15 -> v3 (v3 ist nur ab exakt 2.20.15 migrierbar; Suche
+      # wechselt Whoosh -> Tantivy, Index wird beim ersten Start neu gebaut). App-Image
+      # wird via customManager (datasource=docker) von Renovate getrackt.
       # renovate: datasource=docker depName=ghcr.io/paperless-ngx/paperless-ngx
-      tag: "2.20.15"
+      tag: "3.0.2"
 
     controller:
       type: deployment
@@ -74,7 +74,9 @@ spec:
       PAPERLESS_CSRF_TRUSTED_ORIGINS: https://paperless.f4mily.net
       PAPERLESS_TASK_WORKERS: "2"
       PAPERLESS_THREADS_PER_WORKER: "1"
-      PAPERLESS_CONSUMER_POLLING: "60"
+      # NFS-Consume: inotify greift dort nicht -> Polling zwingend (v3 hat
+      # PAPERLESS_CONSUMER_POLLING in ..._POLLING_INTERVAL umbenannt; 0 = inotify).
+      PAPERLESS_CONSUMER_POLLING_INTERVAL: "60"
       PAPERLESS_TIKA_ENABLED: "1"
       PAPERLESS_TIKA_GOTENBERG_ENDPOINT: http://gotenberg:3000
       PAPERLESS_TIKA_ENDPOINT: http://tika:9998


### PR DESCRIPTION
Folge-PR zu #541. Hebt Paperless von **2.20.15 → v3.0.2**.

## Upgrade-Pfad verifiziert
- v3 ist [nur ab exakt 2.20.15 migrierbar](https://docs.paperless-ngx.com/migration-v3/) — Basis passt.
- Einzige nötige Config-Änderung: `PAPERLESS_CONSUMER_POLLING` → **`PAPERLESS_CONSUMER_POLLING_INTERVAL`** (v3-Rename; Wert 60 bleibt, **zwingend für NFS-Consume**).
- v3-Pflicht schon erfüllt: `PAPERLESS_SECRET_KEY` (Secret, Session-Erhalt), `PAPERLESS_DBENGINE=postgresql`.
- Keine entfernten Variablen im Einsatz (Encryption, OCR_MODE/SKIP_ARCHIVE, CONSUMER_BARCODE_SCANNER, deprecated DB-Optionen).

## PostgreSQL 18
Der gemeldete „Dokumente unsichtbar"-Bug betraf Backup-**Import** in PG18 + **Whoosh**. Wir migrieren **in-place** auf der laufenden, funktionierenden PG18.4-DB (kein Re-Import), und v3 ersetzt Whoosh durch Tantivy (Index-Neuaufbau) → Fehlerpfad umgangen.

## Sicherheit
- **pg_dump-Backup** (custom + plain, DB 23 MB) vor dem Upgrade gezogen.
- Vorher-Stand: 371 Dokumente / 216 Tags / 112 Correspondents (Post-Check).
- Rollback = DB-Restore + Tag zurück auf 2.20.15 (v3-Migrationen sind vorwärtsgerichtet).

## Deployment
Gleiches Chart/Release → normaler `helm upgrade` via Flux, kein Cutover. v3 fährt DB-Migrationen beim Start, Suchindex wird neu gebaut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)