### PR TITLE
fix(kite,nextcloud): resolve stalled HelmReleases + harden CI validation

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -18,5 +18,7 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@v31.11.0
 
-      - name: Run validation (includes Renovate audit)
-        run: nix develop -c just validate
+      - name: Run validation (includes Renovate audit + kind server-side dry-run)
+        env:
+          ENABLE_KIND_CI: "1"
+        run: nix develop -c just validate-full

--- a/apps/base/kite/helmrelease.yaml
+++ b/apps/base/kite/helmrelease.yaml
@@ -34,10 +34,13 @@ spec:
         namespace: flux-system
   values:
     replicaCount: 1
-    # Recreate strategy required for RWO volumes
+    # Recreate strategy required for RWO volumes.
+    # Do NOT add `rollingUpdate: null` here - the chart's `with .Values.deploymentStrategy`
+    # renders the whole map via toYaml regardless of nil leaves, so an explicit
+    # `rollingUpdate: null` still shows up in the Deployment spec and Kubernetes
+    # rejects it as Forbidden when type is Recreate. Omit the key entirely instead.
     deploymentStrategy:
       type: Recreate
-      rollingUpdate: null
     # Image tag defaults to chart appVersion (v0.12.2) — do not override via Renovate helm-values
     service:
       port: 8080

--- a/apps/base/nextcloud/helmrelease.yaml
+++ b/apps/base/nextcloud/helmrelease.yaml
@@ -160,30 +160,13 @@ spec:
         runAsNonRoot: true
       podSecurityContext:
         fsGroup: 1000
-      # php-confd emptyDir for Redis session config (non-root cannot write to conf.d).
-      extraVolumes:
-        - name: php-confd
-          emptyDir: {}
-      extraVolumeMounts:
-        # Non-root cannot create redis-session.ini in image-owned conf.d (nextcloud/helm#187).
-        - name: php-confd
-          mountPath: /usr/local/etc/php/conf.d/redis-session.ini
-          subPath: redis-session.ini
+      # Chart >=9.x already ships its own php-confd emptyDir + init-redis-session-ini
+      # container when redis.enabled=true (nextcloud/helm#187 fix landed upstream).
+      # Do not re-add extraVolumes/extraVolumeMounts/extraInitContainers for this —
+      # it duplicates the chart's own "php-confd" volume name and the Deployment
+      # is rejected with ".spec.template.spec.volumes: duplicate entries for key
+      # [name=\"php-confd\"]".
       extraInitContainers:
-        - name: create-redis-session-ini
-          image: docker.io/library/busybox:1.38
-          securityContext:
-            runAsUser: 1000
-            runAsGroup: 1000
-            runAsNonRoot: true
-          command:
-            - sh
-            - -c
-            - touch /mnt/redis-session.ini
-          volumeMounts:
-            - name: php-confd
-              mountPath: /mnt
-
         - name: occ-db-sync
           image: docker.io/library/nextcloud:34.0.1-apache
           securityContext:

--- a/scripts/ci/validate.sh
+++ b/scripts/ci/validate.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# CI validation: yamllint, kustomize build, kubeconform, kind dry-run
+# CI validation: yamllint, kustomize build, kubeconform, kind server-side dry-run
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -16,6 +16,43 @@ KUBECONFORM_ARGS=(
 
 log() { printf '\n==> %s\n' "$*"; }
 
+# A server-side dry-run catches admission-time rules (e.g. "rollingUpdate
+# forbidden with type Recreate", "duplicate volume name") that schema-only
+# kubeconform validation cannot see. It needs a real API server, so it's
+# gated on kind/docker being usable, and on ENABLE_KIND_CI in CI (some
+# runners can't run privileged containers).
+KIND_AVAILABLE=0
+if [[ -z "${SKIP_KIND:-}" ]] && command -v kind >/dev/null && docker info >/dev/null 2>&1; then
+  if [[ "${CI:-}" != "true" || "${ENABLE_KIND_CI:-}" == "1" ]]; then
+    KIND_AVAILABLE=1
+  fi
+fi
+
+CLUSTER_NAME="gitops-homelab-ci"
+BUILD_DIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "$BUILD_DIR"
+  if [[ "$KIND_AVAILABLE" == "1" ]]; then
+    kind delete cluster --name "$CLUSTER_NAME" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+# Server-side dry-run against objects whose CRDs aren't installed in the
+# bare-bones kind cluster (only Flux's are) fails with "no matches for kind"
+# rather than a real semantic error — treat that as a skip, not a failure.
+dry_run_server() {
+  local file="$1" out
+  if ! out="$(kubectl apply --dry-run=server --force-conflicts -f "$file" 2>&1)"; then
+    if grep -qE 'no matches for kind|the server doesn.t have a resource type' <<<"$out"; then
+      echo "WARN: dry-run skipped for $(basename "$file") (CRD not installed in CI kind cluster): $(head -1 <<<"$out")"
+      return 0
+    fi
+    echo "$out" >&2
+    return 1
+  fi
+}
+
 log "Stage 0: Renovate Dependency Audit"
 ./scripts/ci/renovate-audit.sh
 
@@ -25,10 +62,20 @@ yamllint -c .yamllint.yml \
   .forgejo/workflows \
   .github/workflows
 
-log "Stage 2: Kustomize build + kubeconform"
-BUILD_DIR="$(mktemp -d)"
-trap 'rm -rf "$BUILD_DIR"' EXIT
+if [[ "$KIND_AVAILABLE" == "1" ]]; then
+  log "Stage 2: kind cluster bootstrap (for server-side admission checks)"
+  KIND_IMAGE="kindest/node:v${K8S_VERSION}"
+  kind delete cluster --name "$CLUSTER_NAME" 2>/dev/null || true
+  kind create cluster --name "$CLUSTER_NAME" --image "$KIND_IMAGE" --wait 120s
 
+  kubectl apply --server-side --force-conflicts -f \
+    https://github.com/fluxcd/flux2/releases/latest/download/install.yaml
+  kubectl wait -n flux-system --for=condition=available deployment --all --timeout=180s
+else
+  echo "WARN: kind stage skipped (SKIP_KIND set, kind/docker unavailable, or ENABLE_KIND_CI not set in CI) — server-side admission checks will not run this pass."
+fi
+
+log "Stage 3: Kustomize build + kubeconform + server-side dry-run"
 KUSTOMIZE_PATHS=(
   infrastructure/base
   infrastructure/base/backup-schedules
@@ -42,24 +89,48 @@ for path in "${KUSTOMIZE_PATHS[@]}"; do
   out="${BUILD_DIR}/$(echo "$path" | tr / -).yaml"
   kustomize build "$path" >"$out"
   kubeconform "${KUBECONFORM_ARGS[@]}" -summary -output text "$out"
+
+  if [[ "$KIND_AVAILABLE" == "1" ]]; then
+    # Non-fatal for now: this covers the whole repo's Kustomize output, which
+    # hasn't had a verified clean server-side dry-run run yet. Promote to a
+    # hard failure once a real CI run confirms no pre-existing false positives.
+    dry_run_server "$out" || echo "WARN: server-side dry-run failed for $path (see above)"
+  fi
 done
 
-log "HelmRelease chart render (helm template)"
+log "Stage 4: HelmRelease chart render (helm template) + kubeconform + server-side dry-run"
 while IFS= read -r -d '' file; do
-  chart="$(yq -r '.spec.chart.spec.chart // ""' "$file")"
-  version="$(yq -r '.spec.chart.spec.version // ""' "$file")"
-  repo_kind="$(yq -r '.spec.chart.spec.sourceRef.kind // ""' "$file")"
-  repo_name="$(yq -r '.spec.chart.spec.sourceRef.name // ""' "$file")"
-  release_ns="$(yq -r '.metadata.namespace // "default"' "$file")"
-  release_name="$(yq -r '.metadata.name' "$file")"
+  # A file may hold both a HelmRelease and its own HelmRepository (kite,
+  # sterling-pdf, netbird-operator) — `select(.kind == "HelmRelease")` picks
+  # only that document. Without it, yq's default multi-doc output interleaves
+  # both documents' values, which breaks every equality check below and makes
+  # the release silently `continue` out of the loop with no diagnostic at
+  # all (this is exactly how kite went unrendered/unvalidated).
+  chart="$(yq -r 'select(.kind == "HelmRelease") | .spec.chart.spec.chart // ""' "$file")"
+  version="$(yq -r 'select(.kind == "HelmRelease") | .spec.chart.spec.version // ""' "$file")"
+  repo_kind="$(yq -r 'select(.kind == "HelmRelease") | .spec.chart.spec.sourceRef.kind // ""' "$file")"
+  repo_name="$(yq -r 'select(.kind == "HelmRelease") | .spec.chart.spec.sourceRef.name // ""' "$file")"
+  release_ns="$(yq -r 'select(.kind == "HelmRelease") | .metadata.namespace // "default"' "$file")"
+  release_name="$(yq -r 'select(.kind == "HelmRelease") | .metadata.name' "$file")"
 
   [[ -n "$chart" && "$chart" != "null" ]] || continue
-  [[ "$repo_kind" == "HelmRepository" ]] || continue
+  if [[ "$repo_kind" != "HelmRepository" ]]; then
+    echo "WARN: skip helm template for $release_name (chart sourced from $repo_kind, not HelmRepository)"
+    continue
+  fi
 
+  # HelmRepository may be defined in the same file, or centrally.
   repo_url="$(yq -r "
     select(.kind == \"HelmRepository\" and .metadata.name == \"$repo_name\") |
     .spec.url
-  " infrastructure/base/sources/helm-repositories.yaml 2>/dev/null | head -1)"
+  " "$file" 2>/dev/null | head -1)"
+
+  if [[ -z "$repo_url" || "$repo_url" == "null" ]]; then
+    repo_url="$(yq -r "
+      select(.kind == \"HelmRepository\" and .metadata.name == \"$repo_name\") |
+      .spec.url
+    " infrastructure/base/sources/helm-repositories.yaml 2>/dev/null | head -1)"
+  fi
 
   if [[ -z "$repo_url" || "$repo_url" == "null" ]]; then
     echo "WARN: skip helm template for $release_name (repo $repo_name not resolved)"
@@ -74,48 +145,31 @@ while IFS= read -r -d '' file; do
   log "helm template: $release_name ($chart@$version)"
   helm repo add "ci-${repo_name}" "$repo_url" --force-update >/dev/null 2>&1 || true
   helm repo update "ci-${repo_name}" >/dev/null 2>&1 || helm repo update >/dev/null
-  
+
   # Extract values to a temporary file for better template rendering
   VALUES_FILE=$(mktemp)
-  yq -r '.spec.values // {}' "$file" > "$VALUES_FILE"
+  yq -r 'select(.kind == "HelmRelease") | .spec.values // {}' "$file" > "$VALUES_FILE"
 
+  RENDERED="${BUILD_DIR}/helm-${release_name}.yaml"
   if ! helm template "$release_name" "ci-${repo_name}/${chart}" \
     --version "$version" \
     --namespace "$release_ns" \
     -f "$VALUES_FILE" \
-    | kubeconform "${KUBECONFORM_ARGS[@]}" -summary -output text -; then
-    echo "WARN: helm template/kubeconform failed for $release_name"
+    >"$RENDERED"; then
+    echo "WARN: helm template failed for $release_name"
+    rm -f "$VALUES_FILE"
+    continue
   fi
   rm -f "$VALUES_FILE"
+
+  kubeconform "${KUBECONFORM_ARGS[@]}" -summary -output text "$RENDERED" \
+    || echo "WARN: kubeconform failed for $release_name"
+
+  if [[ "$KIND_AVAILABLE" == "1" ]]; then
+    kubectl create namespace "$release_ns" --dry-run=client -o yaml \
+      | kubectl apply -f - >/dev/null
+    dry_run_server "$RENDERED"
+  fi
 done < <(find infrastructure apps -name helmrelease.yaml -print0 2>/dev/null)
 
-log "Stage 3: kind cluster server-side dry-run"
-if [[ -n "${SKIP_KIND:-}" ]] || ! command -v kind >/dev/null; then
-  echo "WARN: kind stage skipped (SKIP_KIND set or kind unavailable)"
-  exit 0
-fi
-if [[ "${CI:-}" == "true" && "${ENABLE_KIND_CI:-}" != "1" ]]; then
-  echo "WARN: kind stage skipped in CI (set ENABLE_KIND_CI=1 and configure runner: container.privileged, container.docker_host=automount)"
-  exit 0
-fi
-if ! docker info >/dev/null 2>&1; then
-  echo "WARN: kind stage skipped (docker daemon not reachable)"
-  exit 0
-fi
-
-CLUSTER_NAME="gitops-homelab-ci"
-KIND_IMAGE="kindest/node:v${K8S_VERSION}"
-kind delete cluster --name "$CLUSTER_NAME" 2>/dev/null || true
-kind create cluster --name "$CLUSTER_NAME" --image "$KIND_IMAGE" --wait 120s
-
-kubectl apply --server-side --force-conflicts -f \
-  https://github.com/fluxcd/flux2/releases/latest/download/install.yaml
-kubectl wait -n flux-system --for=condition=available deployment --all --timeout=180s
-
-for path in "${KUSTOMIZE_PATHS[@]}"; do
-  log "kubectl apply --dry-run=server: $path"
-  kustomize build "$path" | kubectl apply --dry-run=server -f -
-done
-
-kind delete cluster --name "$CLUSTER_NAME"
 log "All validation stages passed."

--- a/scripts/ci/validate.sh
+++ b/scripts/ci/validate.sh
@@ -43,7 +43,7 @@ trap cleanup EXIT
 # rather than a real semantic error — treat that as a skip, not a failure.
 dry_run_server() {
   local file="$1" out
-  if ! out="$(kubectl apply --dry-run=server --force-conflicts -f "$file" 2>&1)"; then
+  if ! out="$(kubectl apply --dry-run=server -f "$file" 2>&1)"; then
     if grep -qE 'no matches for kind|the server doesn.t have a resource type' <<<"$out"; then
       echo "WARN: dry-run skipped for $(basename "$file") (CRD not installed in CI kind cluster): $(head -1 <<<"$out")"
       return 0

--- a/scripts/ci/validate.sh
+++ b/scripts/ci/validate.sh
@@ -41,9 +41,15 @@ trap cleanup EXIT
 # Server-side dry-run against objects whose CRDs aren't installed in the
 # bare-bones kind cluster (only Flux's are) fails with "no matches for kind"
 # rather than a real semantic error — treat that as a skip, not a failure.
+#
+# Uses --server-side (matching how Flux's own controllers apply resources)
+# rather than client-side apply: client-side apply stores the full previous
+# config in a last-applied-configuration annotation, which large CRDs (e.g.
+# CNPG's Cluster CRD) blow past the 262144-byte annotation size limit with —
+# a real Kubernetes limitation, not a bug in our manifests.
 dry_run_server() {
   local file="$1" out
-  if ! out="$(kubectl apply --dry-run=server -f "$file" 2>&1)"; then
+  if ! out="$(kubectl apply --server-side --force-conflicts --dry-run=server -f "$file" 2>&1)"; then
     if grep -qE 'no matches for kind|the server doesn.t have a resource type' <<<"$out"; then
       echo "WARN: dry-run skipped for $(basename "$file") (CRD not installed in CI kind cluster): $(head -1 <<<"$out")"
       return 0
@@ -91,10 +97,16 @@ for path in "${KUSTOMIZE_PATHS[@]}"; do
   kubeconform "${KUBECONFORM_ARGS[@]}" -summary -output text "$out"
 
   if [[ "$KIND_AVAILABLE" == "1" ]]; then
+    # SOPS-encrypted Secrets are ciphertext in git — they can never pass
+    # admission (illegal base64, unknown "sops" field) and CI never decrypts
+    # them, so they're a permanent, meaningless source of noise here. Drop
+    # them before the dry-run; kubeconform above already ignores Secret kind.
+    NOSECRETS="${out%.yaml}-nosecrets.yaml"
+    yq 'select(.kind != "Secret")' "$out" > "$NOSECRETS" 2>/dev/null || cp "$out" "$NOSECRETS"
     # Non-fatal for now: this covers the whole repo's Kustomize output, which
     # hasn't had a verified clean server-side dry-run run yet. Promote to a
     # hard failure once a real CI run confirms no pre-existing false positives.
-    dry_run_server "$out" || echo "WARN: server-side dry-run failed for $path (see above)"
+    dry_run_server "$NOSECRETS" || echo "WARN: server-side dry-run failed for $path (see above)"
   fi
 done
 
@@ -106,70 +118,83 @@ while IFS= read -r -d '' file; do
   # both documents' values, which breaks every equality check below and makes
   # the release silently `continue` out of the loop with no diagnostic at
   # all (this is exactly how kite went unrendered/unvalidated).
-  chart="$(yq -r 'select(.kind == "HelmRelease") | .spec.chart.spec.chart // ""' "$file")"
-  version="$(yq -r 'select(.kind == "HelmRelease") | .spec.chart.spec.version // ""' "$file")"
-  repo_kind="$(yq -r 'select(.kind == "HelmRelease") | .spec.chart.spec.sourceRef.kind // ""' "$file")"
-  repo_name="$(yq -r 'select(.kind == "HelmRelease") | .spec.chart.spec.sourceRef.name // ""' "$file")"
-  release_ns="$(yq -r 'select(.kind == "HelmRelease") | .metadata.namespace // "default"' "$file")"
-  release_name="$(yq -r 'select(.kind == "HelmRelease") | .metadata.name' "$file")"
+  #
+  # A file can also hold *more than one* HelmRelease document (cert-manager +
+  # cert-manager-webhook-hetzner) — select(.kind == "HelmRelease") alone still
+  # yields one multi-doc blob per field in that case, corrupting every value
+  # with an embedded "---". List the release names first, then re-select by
+  # name so each release is extracted as its own single document.
+  release_names="$(yq -r 'select(.kind == "HelmRelease") | .metadata.name' "$file")"
+  [[ -n "$release_names" ]] || continue
 
-  [[ -n "$chart" && "$chart" != "null" ]] || continue
-  if [[ "$repo_kind" != "HelmRepository" ]]; then
-    echo "WARN: skip helm template for $release_name (chart sourced from $repo_kind, not HelmRepository)"
-    continue
-  fi
+  while IFS= read -r release_name; do
+    [[ -n "$release_name" ]] || continue
+    sel="select(.kind == \"HelmRelease\" and .metadata.name == \"$release_name\")"
 
-  # HelmRepository may be defined in the same file, or centrally.
-  repo_url="$(yq -r "
-    select(.kind == \"HelmRepository\" and .metadata.name == \"$repo_name\") |
-    .spec.url
-  " "$file" 2>/dev/null | head -1)"
+    chart="$(yq -r "$sel | .spec.chart.spec.chart // \"\"" "$file")"
+    version="$(yq -r "$sel | .spec.chart.spec.version // \"\"" "$file")"
+    repo_kind="$(yq -r "$sel | .spec.chart.spec.sourceRef.kind // \"\"" "$file")"
+    repo_name="$(yq -r "$sel | .spec.chart.spec.sourceRef.name // \"\"" "$file")"
+    release_ns="$(yq -r "$sel | .metadata.namespace // \"default\"" "$file")"
 
-  if [[ -z "$repo_url" || "$repo_url" == "null" ]]; then
+    [[ -n "$chart" && "$chart" != "null" ]] || continue
+    if [[ "$repo_kind" != "HelmRepository" ]]; then
+      echo "WARN: skip helm template for $release_name (chart sourced from $repo_kind, not HelmRepository)"
+      continue
+    fi
+
+    # HelmRepository may be defined in the same file, or centrally.
     repo_url="$(yq -r "
       select(.kind == \"HelmRepository\" and .metadata.name == \"$repo_name\") |
       .spec.url
-    " infrastructure/base/sources/helm-repositories.yaml 2>/dev/null | head -1)"
-  fi
+    " "$file" 2>/dev/null | head -1)"
 
-  if [[ -z "$repo_url" || "$repo_url" == "null" ]]; then
-    echo "WARN: skip helm template for $release_name (repo $repo_name not resolved)"
-    continue
-  fi
+    if [[ -z "$repo_url" || "$repo_url" == "null" ]]; then
+      repo_url="$(yq -r "
+        select(.kind == \"HelmRepository\" and .metadata.name == \"$repo_name\") |
+        .spec.url
+      " infrastructure/base/sources/helm-repositories.yaml 2>/dev/null | head -1)"
+    fi
 
-  if [[ "$repo_url" == oci://* ]]; then
-    echo "WARN: skip OCI chart $release_name ($repo_url)"
-    continue
-  fi
+    if [[ -z "$repo_url" || "$repo_url" == "null" ]]; then
+      echo "WARN: skip helm template for $release_name (repo $repo_name not resolved)"
+      continue
+    fi
 
-  log "helm template: $release_name ($chart@$version)"
-  helm repo add "ci-${repo_name}" "$repo_url" --force-update >/dev/null 2>&1 || true
-  helm repo update "ci-${repo_name}" >/dev/null 2>&1 || helm repo update >/dev/null
+    if [[ "$repo_url" == oci://* ]]; then
+      echo "WARN: skip OCI chart $release_name ($repo_url)"
+      continue
+    fi
 
-  # Extract values to a temporary file for better template rendering
-  VALUES_FILE=$(mktemp)
-  yq -r 'select(.kind == "HelmRelease") | .spec.values // {}' "$file" > "$VALUES_FILE"
+    log "helm template: $release_name ($chart@$version)"
+    helm repo add "ci-${repo_name}" "$repo_url" --force-update >/dev/null 2>&1 || true
+    helm repo update "ci-${repo_name}" >/dev/null 2>&1 || helm repo update >/dev/null
 
-  RENDERED="${BUILD_DIR}/helm-${release_name}.yaml"
-  if ! helm template "$release_name" "ci-${repo_name}/${chart}" \
-    --version "$version" \
-    --namespace "$release_ns" \
-    -f "$VALUES_FILE" \
-    >"$RENDERED"; then
-    echo "WARN: helm template failed for $release_name"
+    # Extract values to a temporary file for better template rendering
+    VALUES_FILE=$(mktemp)
+    yq -r "$sel | .spec.values // {}" "$file" > "$VALUES_FILE"
+
+    RENDERED="${BUILD_DIR}/helm-${release_name}.yaml"
+    if ! helm template "$release_name" "ci-${repo_name}/${chart}" \
+      --version "$version" \
+      --namespace "$release_ns" \
+      -f "$VALUES_FILE" \
+      >"$RENDERED"; then
+      echo "WARN: helm template failed for $release_name"
+      rm -f "$VALUES_FILE"
+      continue
+    fi
     rm -f "$VALUES_FILE"
-    continue
-  fi
-  rm -f "$VALUES_FILE"
 
-  kubeconform "${KUBECONFORM_ARGS[@]}" -summary -output text "$RENDERED" \
-    || echo "WARN: kubeconform failed for $release_name"
+    kubeconform "${KUBECONFORM_ARGS[@]}" -summary -output text "$RENDERED" \
+      || echo "WARN: kubeconform failed for $release_name"
 
-  if [[ "$KIND_AVAILABLE" == "1" ]]; then
-    kubectl create namespace "$release_ns" --dry-run=client -o yaml \
-      | kubectl apply -f - >/dev/null
-    dry_run_server "$RENDERED"
-  fi
+    if [[ "$KIND_AVAILABLE" == "1" ]]; then
+      kubectl create namespace "$release_ns" --dry-run=client -o yaml \
+        | kubectl apply -f - >/dev/null
+      dry_run_server "$RENDERED"
+    fi
+  done <<< "$release_names"
 done < <(find infrastructure apps -name helmrelease.yaml -print0 2>/dev/null)
 
 log "All validation stages passed."


### PR DESCRIPTION
## Summary
- **kite**: `deploymentStrategy.rollingUpdate: null` still rendered a `rollingUpdate` key in the Deployment (the chart's `with .Values.deploymentStrategy` toYaml's the whole map regardless of nil leaves), which Kubernetes rejects as `Forbidden` alongside `type: Recreate`. Fix: omit the key entirely.
- **nextcloud**: chart 9.2.x now ships its own `php-confd` emptyDir + `init-redis-session-ini` init container when `redis.enabled: true` (upstream nextcloud/helm#187 fix), duplicating our manual `extraVolumes`/`extraVolumeMounts`/`extraInitContainers` workaround for the same problem → `duplicate entries for key [name="php-confd"]`. Fix: drop the now-redundant manual workaround.
- Both HelmReleases have been `Stalled`/`RetriesExceeded` since 2026-07-25, auto-rolled-back to their previous working release. Verified locally via `helm template` against the pinned chart versions — no more `rollingUpdate` key, no more duplicate volume.

## CI hardening (why this wasn't caught)
- Neither bug is visible to schema-only `kubeconform` validation — both are Kubernetes admission-time checks that only a real API server enforces. The `kind` server-side dry-run stage already existed in `validate.sh` but was unconditionally skipped in CI. Wired it up on GitHub Actions (`just validate-full` + `ENABLE_KIND_CI=1`); Forgejo runner stays on the schema-only path (may lack privileged containers).
- Extended the dry-run to the per-HelmRelease rendered chart output as a **hard failure** — the exact bug class this closes. The broader Kustomize-build dry-run stays WARN-only until a real CI run confirms no pre-existing false positives elsewhere in the repo.
- Found and fixed a separate, worse bug while testing: `yq`'s default multi-document output silently broke every check in the render loop for HelmRelease files that also embed their own HelmRepository (**kite, sterling-pdf**) — those charts were never rendered or schema-checked by CI at all, with no warning printed. Scoped every extraction to `select(.kind == "HelmRelease")`; repo_url resolution now also checks the file itself before falling back to the central `helm-repositories.yaml`. GitRepository-sourced (goloom, sparkyfitness) and OCI charts now emit an explicit WARN instead of silently vanishing from the loop.

## Test plan
- [x] `helm template` locally against pinned chart versions for kite (0.14.1) and nextcloud (9.2.4) — confirmed no `rollingUpdate` key, single `php-confd` volume, all four custom init containers + chart's own `init-redis-session-ini` present.
- [x] `SKIP_KIND=1 ./scripts/ci/validate.sh` (the Forgejo-CI path) run locally end-to-end — all 17 HelmRepository-sourced releases now render and validate, including kite and sterling-pdf which previously never appeared in the log at all.
- [ ] GitHub Actions run on this PR — first real exercise of the kind server-side dry-run stage; watch for it actually passing (or surfacing something new).
- [ ] After merge: `flux reconcile helmrelease kite -n kite` and `flux reconcile helmrelease nextcloud -n nextcloud` to confirm both come back to `Ready=True` on the new chart versions.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>