### PR TITLE
experiment(ci): test Talos-in-Docker server-dry-run on GitHub Actions

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -50,3 +50,21 @@ jobs:
         env:
           ENABLE_KIND_CI: "1"
         run: nix develop -c just server-dry-run
+
+  # Experimental — not a required check. Exercises the same server-dry-run
+  # stage against Talos-in-Docker instead of kind, to see whether talosctl's
+  # docker provisioner works cleanly on a GitHub-hosted runner. Remove this
+  # job (or promote it to replace/parallel the kind job as a required check)
+  # once that's confirmed.
+  server-dry-run-talos:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31.11.0
+      - name: Server-side dry-run (talos)
+        env:
+          ENABLE_KIND_CI: "1"
+          CLUSTER_PROVISIONER: "talos"
+        run: nix develop -c just server-dry-run

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -58,6 +58,7 @@ jobs:
   # once that's confirmed.
   server-dry-run-talos:
     runs-on: ubuntu-latest
+    timeout-minutes: 8
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1

--- a/scripts/ci/server-dry-run.sh
+++ b/scripts/ci/server-dry-run.sh
@@ -39,15 +39,10 @@ fi
 CLUSTER_NAME="gitops-homelab-ci"
 BUILD_DIR="$(mktemp -d)"
 
-# talosctl's docker provisioner needs root (it sets up CNI networking on the
-# host) — "please run as root user" otherwise. `sudo -E env "PATH=$PATH"`
-# keeps the nix-shell PATH intact under sudo; kind needs no such elevation.
-talosctl_sudo() { sudo -E env "PATH=$PATH" talosctl "$@"; }
-
 cleanup() {
   rm -rf "$BUILD_DIR"
   if [[ "$CLUSTER_PROVISIONER" == "talos" ]]; then
-    talosctl_sudo cluster destroy --provisioner=docker --name "$CLUSTER_NAME" 2>/dev/null || true
+    talosctl cluster destroy --name "$CLUSTER_NAME" 2>/dev/null || true
   else
     kind delete cluster --name "$CLUSTER_NAME" 2>/dev/null || true
   fi
@@ -56,15 +51,24 @@ trap cleanup EXIT
 
 log "${CLUSTER_PROVISIONER} cluster bootstrap"
 if [[ "$CLUSTER_PROVISIONER" == "talos" ]]; then
-  talosctl_sudo cluster destroy --provisioner=docker --name "$CLUSTER_NAME" 2>/dev/null || true
-  talosctl_sudo cluster create --provisioner=docker --name "$CLUSTER_NAME" \
-    --kubernetes-version "$K8S_VERSION" --wait
+  # talosctl >=1.13 split `cluster create` into subcommands (dev/docker/qemu)
+  # instead of a --provisioner flag; `docker` is the one that runs Talos
+  # nodes as plain containers (no host CNI/QEMU, unlike `dev`/`qemu`) and
+  # needs no root. It also has no --wait flag, so poll for API reachability
+  # ourselves before handing off to the Flux install + dry-run steps below.
+  talosctl cluster destroy --name "$CLUSTER_NAME" 2>/dev/null || true
+  talosctl cluster create docker --name "$CLUSTER_NAME" \
+    --kubernetes-version "$K8S_VERSION"
   TALOS_KUBECONFIG="${BUILD_DIR}/talos-kubeconfig"
-  talosctl_sudo kubeconfig "$TALOS_KUBECONFIG" --provisioner=docker --name "$CLUSTER_NAME" --force
-  # kubeconfig was written by root (via sudo) — hand it back so plain kubectl
-  # calls below (not running under sudo) can read it.
-  sudo chown "$(id -u):$(id -g)" "$TALOS_KUBECONFIG"
+  talosctl kubeconfig "$TALOS_KUBECONFIG" --force
   export KUBECONFIG="$TALOS_KUBECONFIG"
+
+  log "waiting for talos cluster API to become reachable"
+  for _ in $(seq 1 60); do
+    kubectl cluster-info >/dev/null 2>&1 && break
+    sleep 2
+  done
+  kubectl cluster-info
 else
   KIND_IMAGE="kindest/node:v${K8S_VERSION}"
   kind delete cluster --name "$CLUSTER_NAME" 2>/dev/null || true

--- a/scripts/ci/server-dry-run.sh
+++ b/scripts/ci/server-dry-run.sh
@@ -57,7 +57,9 @@ if [[ "$CLUSTER_PROVISIONER" == "talos" ]]; then
   # needs no root. It also has no --wait flag, so poll for API reachability
   # ourselves before handing off to the Flux install + dry-run steps below.
   talosctl cluster destroy --name "$CLUSTER_NAME" 2>/dev/null || true
-  talosctl cluster create docker --name "$CLUSTER_NAME" \
+  # cluster create docker has no --wait and no --debug flag, so a hard
+  # timeout is the only guard against it hanging silently.
+  timeout 300 talosctl cluster create docker --name "$CLUSTER_NAME" \
     --kubernetes-version "$K8S_VERSION"
   TALOS_KUBECONFIG="${BUILD_DIR}/talos-kubeconfig"
   talosctl kubeconfig "$TALOS_KUBECONFIG" --force

--- a/scripts/ci/server-dry-run.sh
+++ b/scripts/ci/server-dry-run.sh
@@ -38,10 +38,16 @@ fi
 
 CLUSTER_NAME="gitops-homelab-ci"
 BUILD_DIR="$(mktemp -d)"
+
+# talosctl's docker provisioner needs root (it sets up CNI networking on the
+# host) — "please run as root user" otherwise. `sudo -E env "PATH=$PATH"`
+# keeps the nix-shell PATH intact under sudo; kind needs no such elevation.
+talosctl_sudo() { sudo -E env "PATH=$PATH" talosctl "$@"; }
+
 cleanup() {
   rm -rf "$BUILD_DIR"
   if [[ "$CLUSTER_PROVISIONER" == "talos" ]]; then
-    talosctl cluster destroy --provisioner=docker --name "$CLUSTER_NAME" 2>/dev/null || true
+    talosctl_sudo cluster destroy --provisioner=docker --name "$CLUSTER_NAME" 2>/dev/null || true
   else
     kind delete cluster --name "$CLUSTER_NAME" 2>/dev/null || true
   fi
@@ -50,10 +56,15 @@ trap cleanup EXIT
 
 log "${CLUSTER_PROVISIONER} cluster bootstrap"
 if [[ "$CLUSTER_PROVISIONER" == "talos" ]]; then
-  talosctl cluster destroy --provisioner=docker --name "$CLUSTER_NAME" 2>/dev/null || true
-  talosctl cluster create --provisioner=docker --name "$CLUSTER_NAME" \
+  talosctl_sudo cluster destroy --provisioner=docker --name "$CLUSTER_NAME" 2>/dev/null || true
+  talosctl_sudo cluster create --provisioner=docker --name "$CLUSTER_NAME" \
     --kubernetes-version "$K8S_VERSION" --wait
-  talosctl kubeconfig --provisioner=docker --name "$CLUSTER_NAME" --force
+  TALOS_KUBECONFIG="${BUILD_DIR}/talos-kubeconfig"
+  talosctl_sudo kubeconfig "$TALOS_KUBECONFIG" --provisioner=docker --name "$CLUSTER_NAME" --force
+  # kubeconfig was written by root (via sudo) — hand it back so plain kubectl
+  # calls below (not running under sudo) can read it.
+  sudo chown "$(id -u):$(id -g)" "$TALOS_KUBECONFIG"
+  export KUBECONFIG="$TALOS_KUBECONFIG"
 else
   KIND_IMAGE="kindest/node:v${K8S_VERSION}"
   kind delete cluster --name "$CLUSTER_NAME" 2>/dev/null || true


### PR DESCRIPTION
Not meant to merge as-is — this is a live test.

Adds a non-required \`server-dry-run-talos\` job that runs the same server-dry-run stage against Talos-in-Docker (\`CLUSTER_PROVISIONER=talos\`) instead of kind, purely to see whether \`talosctl cluster create --provisioner=docker\` works cleanly on a GitHub-hosted \`ubuntu-latest\` runner. Untestable locally (no Docker in the dev sandbox).

If it passes: talos gives CI the exact same Talos/Kubernetes version as production instead of kind's generic node images — worth promoting to replace or run alongside the kind job as a required check.
If it fails: keep kind as-is, talos stays available as an opt-in local-only option.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>