### PR TITLE
feat(mcp): allow Hermes to trigger CNPG backups

### DIFF
--- a/infrastructure/base/mcp-server/hermes-cnpg-backup-rbac.yaml
+++ b/infrastructure/base/mcp-server/hermes-cnpg-backup-rbac.yaml
@@ -1,0 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: mcp-hermes-cnpg-backup
+  namespace: cnpg-system
+  labels:
+    app.kubernetes.io/name: mcp-server
+rules:
+  - apiGroups: ["postgresql.cnpg.io"]
+    resources: ["clusters", "scheduledbackups", "backups"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["postgresql.cnpg.io"]
+    resources: ["backups"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: mcp-hermes-cnpg-backup
+  namespace: cnpg-system
+  labels:
+    app.kubernetes.io/name: mcp-server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: mcp-hermes-cnpg-backup
+subjects:
+  - kind: User
+    name: mcp-hermes
+    apiGroup: rbac.authorization.k8s.io

--- a/infrastructure/base/mcp-server/kustomization.yaml
+++ b/infrastructure/base/mcp-server/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - rbac.yaml
+  - hermes-cnpg-backup-rbac.yaml
   - deployment.yaml
   - service.yaml
   - ingress.yaml


### PR DESCRIPTION
## Summary

- grant the authenticated `mcp-hermes` Kubernetes user read access to CNPG backup status in `cnpg-system`
- allow creating one-shot CNPG `Backup` resources
- keep the public in-cluster MCP deployment in `--read-only` mode
- do not grant secret, exec, patch, delete, or general workload write access

## Validation

- `just lint`
- `just build-infra`

## Test use case

Create and verify a fresh `homelab-postgres` S3 backup immediately before temporarily deploying SparkyFitness PR #2019 images.