### PR TITLE
fix(mcp): bind CNPG backup role to service account

### DIFF
--- a/infrastructure/base/mcp-server/hermes-cnpg-backup-rbac.yaml
+++ b/infrastructure/base/mcp-server/hermes-cnpg-backup-rbac.yaml
@@ -25,6 +25,6 @@ roleRef:
   kind: Role
   name: mcp-hermes-cnpg-backup
 subjects:
-  - kind: User
+  - kind: ServiceAccount
     name: mcp-hermes
-    apiGroup: rbac.authorization.k8s.io
+    namespace: ai-agents


### PR DESCRIPTION
## Summary

Bind the scoped CNPG backup role to the actual Kubernetes identity used by the authenticated MCP connection: `system:serviceaccount:ai-agents:mcp-hermes`.

The previous subject used Kubernetes `User mcp-hermes` and therefore granted no effective permission.

## Scope

Unchanged minimal permissions in `cnpg-system`:
- read CNPG clusters, scheduled backups, and backups
- create CNPG backups
- no secrets, exec, patch, delete, or workload write access

## Validation

- `just lint`
- `just build-infra`
- live API error confirmed effective identity before this fix