### PR TITLE
fix(sparkyfitness): align frontend with PR server

### DIFF
--- a/apps/base/sparkyfitness/helmrelease.yaml
+++ b/apps/base/sparkyfitness/helmrelease.yaml
@@ -77,9 +77,11 @@ spec:
           memory: 768Mi
     frontend:
       image:
-        repository: docker.io/codewithcj/sparkyfitness
-        tag: v1.6.0
-      # Docker Hub `codewithcj/sparkyfitness` listens on 8080 (not chart default :80 / ghcr frontend image).
+        # Temporary frontend from the same upstream PR commit as the test server.
+        # Keeps the strict frontend API schemas compatible with the newer server response.
+        repository: ghcr.io/kreativmonkey/sparkyfitness-server
+        tag: pr-2019-frontend
+        digest: sha256:45047939f089c5b6dad51904dfd48d45a0b0538035da640e6fba567b3081385d
       port: 8080
       service:
         port: 8080


### PR DESCRIPTION
## Problem
The v1.6.0 frontend rejects the PR server response because its strict exercise snapshot schema does not include `modality`. The API returns HTTP 200, but Zod parsing fails and triggers repeated `Failed to load exercise entries` toasts.

## Fix
Deploy the frontend built from the same upstream PR commit (`16780090`) as the test server, pinned by immutable digest.

## Validation
- Direct exercise endpoint: HTTP 200
- Matching frontend production bundle built successfully
- Anonymous digest pull verified
- `just lint` passes (existing unrelated warnings only)