### PR TITLE
fix(nextcloud): unsuspend cron via postRenderer

### DIFF
--- a/apps/base/nextcloud/helmrelease.yaml
+++ b/apps/base/nextcloud/helmrelease.yaml
@@ -41,6 +41,23 @@ spec:
                   name: php-confd
                   mountPath: /usr/local/etc/php/conf.d/redis-session.ini
                   subPath: redis-session.ini
+          - target:
+              group: batch
+              version: v1
+              kind: CronJob
+              name: nextcloud-cron
+            patch: |
+              # Chart 9.2.5's cronjob.yaml never templates spec.suspend, so there is no
+              # values knob for it. On 2026-06-13, during the TrueNAS iSCSI outage, someone
+              # manually suspended this CronJob to stop failed-job alert spam and never
+              # reverted it. Since the field is absent from the rendered manifest, Helm's
+              # 3-way merge never touches it — the manual suspend survives every upgrade
+              # forever, invisible to Flux. Declaring it explicitly here puts it back under
+              # Helm/Flux ownership: a future manual "kubectl patch --suspend" gets reverted
+              # on the next reconcile instead of silently sticking.
+              - op: add
+                path: /spec/suspend
+                value: false
   install:
     disableWait: true
     remediation:


### PR DESCRIPTION
Found during a routine cluster inspection.

## Problem

The live CronJob `nextcloud/nextcloud-cron` has `spec.suspend: true`. It was set manually in-cluster on **2026-06-13** during the TrueNAS iSCSI outage — presumably to stop failed-job alert spam — and never reverted.

Nextcloud confirms the impact: `occ config:app:get core lastcron` returns `1781304906` = **2026-06-13 00:55 CEST**. The `*/5` background job has not run for **53 days**, so file scans, preview generation, notifications, expired-share cleanup and DB housekeeping have all been stalled that whole time.

## Why this went unnoticed, and why values cannot fix it

The repo declares `nextcloud.cronjob.enabled: true` with `type: cronjob` and contains no `suspend` anywhere — so git and cluster disagreed silently:

- Chart `nextcloud` 9.2.5 `templates/cronjob.yaml` **never templates a `suspend` field**, so no values knob exists.
- Because the field is absent from both the old and new rendered manifests, **Helm's 3-way merge never removes it**. The manual `suspend: true` survives every single upgrade.
- Flux compares the release, not live object fields, so it reported the HelmRelease as `Ready` throughout. Verified absent from the stored release manifest `sh.helm.release.v1.nextcloud.v128`.

## Fix

Add a second postRenderer kustomize patch that sets `spec.suspend: false` explicitly on the CronJob — the same postRenderer pattern this HelmRelease already uses for the php-confd mount (#592).

Declaring the field puts it **into** the rendered manifest, which hands ownership to Helm/Flux. The payoff is self-healing: a future manual `kubectl patch --suspend` now gets reverted on the next reconcile instead of sticking forever. RFC-6902 `add` replaces an existing value, so the patch is idempotent.

## Verification

Repo CI does **not** validate postRenderers (`helm-render` renders the raw chart, `kustomize-validate` never touches the HelmRelease CR), so this was verified manually: chart 9.2.5 rendered with the HelmRelease's own values, then both patches applied via `kustomize build`.

- CronJob `nextcloud-cron` comes out with `suspend: false`
- Deployment patch still intact — `hostAliases` (mail.f4mily.net → 91.99.145.19) and the `php-confd` volumeMount at `/usr/local/etc/php/conf.d/redis-session.ini` both survive

`just kustomize-validate`, `just helm-render` and `just ci-lint` all pass (3 yamllint warnings are pre-existing, in unrelated files).

## Note

The stale `nextcloud-cron-29688405` Job (failed, 53d old) is left alone — `failedJobsHistoryLimit: 1` prunes it once cron produces fresh history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)