### PR TITLE
fix(resources): add measured memory requests/limits

### DIFF
--- a/apps/base/immich/helmrelease.yaml
+++ b/apps/base/immich/helmrelease.yaml
@@ -46,6 +46,18 @@ spec:
           enabled: true
           type: emptyDir
           accessMode: ReadWriteOnce
+      controllers:
+        main:
+          containers:
+            main:
+              # p95/p99-derived (14d/7d VictoriaMetrics history), previously unset.
+              # Cache container -> Guaranteed QoS (request == limit).
+              resources:
+                requests:
+                  cpu: 20m
+                  memory: 128Mi
+                limits:
+                  memory: 128Mi
     controllers:
       main:
         containers:
@@ -66,6 +78,18 @@ spec:
               image:
                 repository: ghcr.io/immich-app/immich-server
                 tag: v3.1.0
+              # p95/p99-derived (14d/7d VictoriaMetrics history). Previously
+              # nested as a sibling of `controllers` under `server:` — that
+              # key does not exist in this bjw-s-common-based chart, so Helm
+              # silently dropped it and the container ran with no resources
+              # at all (confirmed via `helm template`). Correct path is here,
+              # under controllers.main.containers.main.
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 1552Mi
+                limits:
+                  memory: 2432Mi
       persistence:
         data:
           accessMode: ReadWriteOnce
@@ -87,12 +111,6 @@ spec:
       ingress:
         main:
           enabled: false
-      resources:
-        requests:
-          cpu: 50m
-          memory: 768Mi
-        limits:
-          memory: 1Gi
     machine-learning:
       enabled: true
       controllers:
@@ -102,14 +120,18 @@ spec:
               image:
                 repository: ghcr.io/immich-app/immich-machine-learning
                 tag: v3.1.0
+              # p95/p99-derived (14d/7d VictoriaMetrics history). Previously
+              # nested as a sibling of `controllers` under `machine-learning:`
+              # — same dead-key mistake as immich-server above (see comment
+              # there); silently dropped by Helm, container ran unbounded.
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 592Mi
+                limits:
+                  memory: 1408Mi
       persistence:
         cache:
           enabled: true
           type: emptyDir
           accessMode: ReadWriteMany
-      resources:
-        requests:
-          cpu: 200m
-          memory: 512Mi
-        limits:
-          memory: 1Gi

--- a/apps/base/monitoring/vm-k8s-stack/helmrelease.yaml
+++ b/apps/base/monitoring/vm-k8s-stack/helmrelease.yaml
@@ -6,6 +6,43 @@ metadata:
 spec:
   interval: 1h
   timeout: 10m
+  postRenderers:
+    - kustomize:
+        patches:
+          # The grafana subchart wires both k8s-sidecar containers
+          # (sc-dashboard, sc-datasources) to a single shared
+          # `sidecar.resources` values key — no per-sidecar override exists
+          # (verified in templates/_pod.tpl of the grafana chart). Since the
+          # two containers need different measured values, values: alone
+          # cannot express this; patch each container directly by name.
+          - target:
+              group: apps
+              version: v1
+              kind: Deployment
+              name: vm-k8s-stack-grafana
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: vm-k8s-stack-grafana
+              spec:
+                template:
+                  spec:
+                    containers:
+                      - name: grafana-sc-dashboard
+                        resources:
+                          requests:
+                            cpu: 10m
+                            memory: 96Mi
+                          limits:
+                            memory: 192Mi
+                      - name: grafana-sc-datasources
+                        resources:
+                          requests:
+                            cpu: 10m
+                            memory: 80Mi
+                          limits:
+                            memory: 128Mi
   chart:
     spec:
       chart: victoria-metrics-k8s-stack
@@ -75,6 +112,14 @@ spec:
       # Avoid install deadlock when operator pod is not up yet (webhook connection refused).
       admissionWebhooks:
         enabled: false
+      # p95/p99-derived (14d/7d VictoriaMetrics history), previously unset
+      # (Burstable, first-to-be-OOM-killed). No CPU limit by convention.
+      resources:
+        requests:
+          cpu: 50m
+          memory: 112Mi
+        limits:
+          memory: 192Mi
       image:
         registry: quay.io
       env:
@@ -102,6 +147,16 @@ spec:
             memory: 64Mi
           limits:
             memory: 512Mi
+        # config-reloader sidecar, injected by the VM operator from this CR
+        # field (not a plain Deployment `resources:` — there is no chart
+        # values path for it). p95/p99-derived (14d/7d VictoriaMetrics
+        # history); already had a 25Mi request (operator default), no limit.
+        configReloaderResources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            memory: 128Mi
 
     # ============================================
     # VMALERT - Alerting
@@ -115,6 +170,13 @@ spec:
             memory: 64Mi
           limits:
             memory: 256Mi
+        # config-reloader sidecar (see vmagent.spec.configReloaderResources comment above).
+        configReloaderResources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            memory: 128Mi
 
     # ============================================
     # ALERTMANAGER - ntfy via homelab-monitoring topic
@@ -129,6 +191,13 @@ spec:
           - alertmanager-ntfy-credentials
           - alertmanager-n8n-webhook
         resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            memory: 128Mi
+        # config-reloader sidecar (see vmagent.spec.configReloaderResources comment above).
+        configReloaderResources:
           requests:
             cpu: 10m
             memory: 32Mi
@@ -217,12 +286,26 @@ spec:
     # ============================================
     prometheus-node-exporter:
       enabled: true
+      # p95/p99-derived (14d/7d VictoriaMetrics history), previously unset
+      # (Burstable, first-to-be-OOM-killed). No CPU limit by convention.
+      resources:
+        requests:
+          cpu: 10m
+          memory: 32Mi
+        limits:
+          memory: 128Mi
 
     # ============================================
     # KUBE STATE METRICS
     # ============================================
     kube-state-metrics:
       enabled: true
+      resources:
+        requests:
+          cpu: 10m
+          memory: 64Mi
+        limits:
+          memory: 128Mi
 
     # ============================================
     # DEFAULT DASHBOARDS & RULES

--- a/infrastructure/base/backup/helmrelease.yaml
+++ b/infrastructure/base/backup/helmrelease.yaml
@@ -55,15 +55,23 @@ spec:
         limits:
           cpu: 200m
           memory: 128Mi
+    # `velero:` is not a top-level key in this chart (verified via `helm
+    # template` against a clean checkout: the pre-existing `resources:`
+    # below rendered as nothing on the velero container, matching Phase-1's
+    # metrics finding of no current request/limit). priorityClassName is a
+    # separate, real pre-existing bug left untouched here (out of scope for
+    # this memory-requests change) — the correct resources path is the
+    # top-level `resources:` key below.
     velero:
       priorityClassName: "homelab-infrastructure"
-      resources:
-        requests:
-          cpu: 50m
-          memory: 64Mi
-        limits:
-          cpu: 200m
-          memory: 128Mi
+    # p95/p99-derived (14d/7d VictoriaMetrics history), previously unset
+    # (Burstable, first-to-be-OOM-killed). No CPU limit by convention.
+    resources:
+      requests:
+        cpu: 20m
+        memory: 80Mi
+      limits:
+        memory: 256Mi
     metrics:
       enabled: true
       service:

--- a/infrastructure/base/network/cert-manager/helmrelease.yaml
+++ b/infrastructure/base/network/cert-manager/helmrelease.yaml
@@ -33,6 +33,22 @@ spec:
       limits:
         cpu: 100m
         memory: 128Mi
+    # p95/p99-derived (14d/7d VictoriaMetrics history), previously unset (Burstable
+    # first-to-be-OOM-killed). No CPU limit — cluster convention is requests-only for CPU.
+    cainjector:
+      resources:
+        requests:
+          cpu: 10m
+          memory: 80Mi
+        limits:
+          memory: 128Mi
+    webhook:
+      resources:
+        requests:
+          cpu: 10m
+          memory: 48Mi
+        limits:
+          memory: 128Mi
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
@@ -51,3 +67,11 @@ spec:
         namespace: flux-system
   dependsOn:
     - name: cert-manager
+  values:
+    # p95/p99-derived (14d/7d VictoriaMetrics history), previously unset.
+    resources:
+      requests:
+        cpu: 10m
+        memory: 80Mi
+      limits:
+        memory: 128Mi

--- a/infrastructure/base/network/external-dns/helmrelease.yaml
+++ b/infrastructure/base/network/external-dns/helmrelease.yaml
@@ -43,6 +43,14 @@ spec:
           timeoutSeconds: 5
         service:
           port: 8888
+        # p95/p99-derived (14d/7d VictoriaMetrics history), previously unset
+        # (Burstable, first-to-be-OOM-killed). No CPU limit by convention.
+        resources:
+          requests:
+            cpu: 10m
+            memory: 48Mi
+          limits:
+            memory: 128Mi
     extraArgs:
       - --webhook-provider-url=http://localhost:8888
     domainFilters:

--- a/infrastructure/base/storage/democratic-csi/helmrelease.yaml
+++ b/infrastructure/base/storage/democratic-csi/helmrelease.yaml
@@ -41,8 +41,51 @@ spec:
       driver:
         image:
           tag: next
+        # p95/p99-derived (14d/7d VictoriaMetrics history), previously unset
+        # (Burstable, first-to-be-OOM-killed). No CPU limit by convention.
+        resources:
+          requests:
+            cpu: 10m
+            memory: 112Mi
+          limits:
+            memory: 192Mi
+      externalAttacher:
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            memory: 128Mi
+      externalProvisioner:
+        resources:
+          requests:
+            cpu: 10m
+            memory: 48Mi
+          limits:
+            memory: 128Mi
+      externalResizer:
+        resources:
+          requests:
+            cpu: 10m
+            memory: 48Mi
+          limits:
+            memory: 128Mi
+      externalSnapshotter:
+        resources:
+          requests:
+            cpu: 10m
+            memory: 48Mi
+          limits:
+            memory: 128Mi
     node:
       hostPID: true
+      cleanup:
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            memory: 128Mi
       driver:
         image:
           tag: next
@@ -53,6 +96,29 @@ spec:
             value: /usr/local/sbin/iscsiadm
         iscsiDirHostPath: /var/iscsi
         iscsiDirHostPathType: ""
+        resources:
+          requests:
+            cpu: 40m
+            memory: 192Mi
+          limits:
+            memory: 320Mi
+      driverRegistrar:
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            memory: 128Mi
+    # Shared csi-grpc-proxy sidecar injected into both the controller and node
+    # pods (single top-level key, no per-pod override in the chart). Both
+    # pods measured to the same target, so one value covers both.
+    csiProxy:
+      resources:
+        requests:
+          cpu: 10m
+          memory: 32Mi
+        limits:
+          memory: 128Mi
     storageClasses:
       - name: truenas-iscsi
         defaultClass: true

--- a/infrastructure/base/system-upgrade-controller/kustomization.yaml
+++ b/infrastructure/base/system-upgrade-controller/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 patches:
   - path: patch-deployment-strategy.yaml
   - path: patch-controller-anti-affinity.yaml
+  - path: patch-resources.yaml
 images:
   - name: rancher/system-upgrade-controller
     # Must be a published stable tag. v0.20.0 was never released (only v0.20.0-rc.1),

--- a/infrastructure/base/system-upgrade-controller/patch-resources.yaml
+++ b/infrastructure/base/system-upgrade-controller/patch-resources.yaml
@@ -1,0 +1,20 @@
+# p95/p99-derived (14d/7d VictoriaMetrics history), previously unset
+# (Burstable, first-to-be-OOM-killed). No CPU limit by convention.
+# Plain kustomize base (fetched from upstream GitHub), no Helm values path —
+# resources are set via this strategic-merge patch on the container by name.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: system-upgrade-controller
+  namespace: system-upgrade
+spec:
+  template:
+    spec:
+      containers:
+        - name: system-upgrade-controller
+          resources:
+            requests:
+              cpu: 10m
+              memory: 48Mi
+            limits:
+              memory: 128Mi


### PR DESCRIPTION
Phase 1 von 2. Größen stammen aus der VictoriaMetrics-Historie, nicht aus Schätzungen.

## Problem

27 Container liefen ohne Memory-Request. Ohne Request landen sie in QoS-Klasse BestEffort bzw. Burstable und werden bei Speicherdruck **als Erste** evictet oder OOM-gekillt — unabhängig davon, wie wichtig sie sind. Zusätzlich rechnete der Scheduler mit zu viel freiem Speicher: deklarierte Requests 17,6 GiB, tatsächlicher p95-Verbrauch 24,5 GiB.

## Methodik

- `request` = p95 über 14 Tage, auf 16 Mi aufgerundet
- `limit` = p99 über 7 Tage × 1,5, mindestens 1,5 × Request; deckt den 28-Tage-Peak ab, **außer** dieser ist ein einmaliger Transient (>3× Steady State)
- Stateful (DB/Cache) → `request == limit`, also **Guaranteed QoS**: Datenbanken werden zuletzt evictet
- **Keine CPU-Limits.** 136 von 150 Containern haben bewusst keine — CPU-Limits verursachen CFS-Throttling. Das bleibt so.

Warum p99/7d statt max/28d als Limit-Basis: `netbird/clusterproxy` spitzte am 26.07. einmalig auf 3,6 GiB (Initial-Sync nach Neuerstellung), liegt seit 9 Tagen stabil bei ~210 Mi. Auf den Peak zu dimensionieren hätte 4,5 GiB Limit für einen Proxy bedeutet.

Null OOM-Kills in 28 Tagen, es musste also nirgends Headroom draufgelegt werden.

## Zwei stille Vorbugs mitgefunden

Beide vom selben Typ — `resources:` an einem Values-Pfad, den das Chart nicht kennt. Helm verwirft unbekannte Values **kommentarlos**: sauberer Diff, grüne CI, null Wirkung.

- **immich-server / immich-machine-learning**: `resources:` lag als Geschwister von `controllers:` unter `server:`. Das Repo deklarierte `requests.memory: 768Mi` — der Live-Container hat nachweislich *gar keine* Resources. Beide Container liefen unbegrenzt.
- **velero**: `resources:` unter einem `velero:`-Wrapper-Key, den das Chart nicht hat. Live ebenfalls `{}`.

Genau deshalb wurde hier jeder einzelne Container per `helm template` / `kustomize build` gegengeprüft, statt sich auf einen plausiblen Diff zu verlassen.

## Ergebnis

| | vorher | nachher |
|---|---|---|
| Requests (repo-managed) | 17,6 GiB | 24,1 GiB |
| Limits | 62,7 GiB | 39,1 GiB |
| Container ohne Request | 24 | 0 |
| Container ohne Limit | 28 | 0 |

Cluster-Requests inkl. Talos-Static-Pods ~26,7 von 45,0 GiB = **59 % committed**. N+1 geprüft: fällt ein Node aus, passen alle Requests auf die verbleibenden 30,0 GiB.

## Nicht setzbar

`netbird/clusterproxy-homelab` — die `ClusterProxy`-CRD hat kein `resources`-Feld, das Operator-Chart keinen Knopf dafür; der Operator generiert das Deployment mit hartkodierten Werten. Kein Override-Punkt im Repo.

## Verifikation

Jeder Container wurde gerendert und gegen den Zielwert geprüft (nicht nur der Diff gelesen). `just kustomize-validate`, `just helm-render`, `just ci-lint` grün; 3 yamllint-Warnungen sind vorbestehend und in fremden Dateien.

Ein `postRenderer` war nötig: grafanas `sc-dashboard`/`sc-datasources` teilen sich im Chart einen `sidecar.resources`-Key, brauchen aber unterschiedliche Werte.

Phase 2 (Right-Sizing der 76 bereits gesetzten Container, Limits 62,3 → 30,7 GiB) folgt separat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)