### PR TITLE
fix(forgejo): pull image from data.forgejo.org registry

### DIFF
--- a/apps/base/forgejo/deployment.yaml
+++ b/apps/base/forgejo/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: forgejo
-          image: codeberg.org/forgejo/forgejo:16.0.2
+          image: data.forgejo.org/forgejo/forgejo:16.0.2
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000


### PR DESCRIPTION
Behebt den `Package lookup failure` aus dem Dependency Dashboard (#3).

## Ursache

Codebergs Container-Registry beantwortet die Registry-API anonym mit `401` **ohne** `WWW-Authenticate`-Header — Renovate kann darum kein Token holen und bricht mit `no-result` ab:

```
codeberg.org      /v2/ → 401, kein WWW-Authenticate
data.forgejo.org  /v2/ → 200, Tag-Liste anonym lesbar
```

## Fix

Image auf `data.forgejo.org/forgejo/forgejo` umgestellt — dieselben offiziellen Forgejo-Images, aus derselben Registry, aus der der Runner (`data.forgejo.org/forgejo/runner`) ohnehin schon zieht. Damit greift die normale docker-Datasource, ein Sonder-Rule in `renovate.json` (wie bei readeck nötig) entfällt.

Tag `16.0.2` dort verifiziert: `sha256:2fdfe28b5c68f82f49580e227b84e2afb43af0250e0631a54a386ef3b1d9b759`.

readeck bleibt auf Codeberg — dafür gibt es kein offizielles Mirror, der bestehende `gitea-tags`-Workaround bleibt richtig.

`just ci-lint kustomize-validate` lokal grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)