### PR TITLE
fix(nextcloud): pin cron to app node via podAffinity

### DIFF
--- a/apps/base/nextcloud/helmrelease.yaml
+++ b/apps/base/nextcloud/helmrelease.yaml
@@ -510,6 +510,23 @@ spec:
         successfulJobsHistoryLimit: 2
         activeDeadlineSeconds: 1800
         backoffLimit: 2
+        # nextcloud-app-iscsi ist ReadWriteOnce auf truenas-iscsi. Der CronJob mountet
+        # dasselbe Volume wie der App-Pod, kann es aber nur auf DESSEN Node attachen.
+        # Ohne Affinity verteilt der Scheduler die Job-Pods über alle drei Nodes; die
+        # ~2/3, die nicht auf dem App-Node landen, hängen mit "Multi-Attach error" bis
+        # activeDeadlineSeconds (30 min) greift — und blockieren wegen
+        # concurrencyPolicy=Forbid solange alle weiteren Läufe.
+        # requiredDuringScheduling, nicht preferred: ein Job auf dem falschen Node
+        # läuft nicht langsamer, er läuft gar nicht.
+        affinity:
+          podAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              - topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: nextcloud
+                    app.kubernetes.io/instance: nextcloud
+                    app.kubernetes.io/component: app
         resources:
           requests:
             cpu: 50m


### PR DESCRIPTION
Folgefix zu #624. Das Entsuspendieren hat einen strukturellen Bug freigelegt, der vorher unter dem `suspend: true` verborgen lag.

## Symptom

Nach dem Merge von #624 lief der Cron wieder — aber nur teilweise. Job-Pods hängen in `ContainerCreating`:

```
Multi-Attach error for volume "pvc-c687632a-adb4-44d4-8de2-f93a48936ad1"
Volume is already used by pod(s) nextcloud-6c55fcbb9f-sjwg7
```

## Ursache

`nextcloud-app-iscsi` ist **ReadWriteOnce** auf `truenas-iscsi`. Der CronJob mountet dasselbe Volume wie der App-Pod, kann es aber nur auf *dessen* Node attachen. Ohne Affinity verteilt der Scheduler die Job-Pods über alle drei Nodes:

- ~1/3 landet auf dem App-Node → läuft in 5–6 Sekunden durch
- ~2/3 landen woanders → hängen bis `activeDeadlineSeconds` (30 min) greift
- wegen `concurrencyPolicy: Forbid` blockiert ein hängender Job zusätzlich alle weiteren Läufe

Aus dem `*/5`-Rhythmus wird faktisch einer alle 30 Minuten, mit einem fehlgeschlagenen Job dazwischen. `lastcron` stand entsprechend 21 Stunden zurück, obwohl der CronJob aktiv war.

Das relativiert die Diagnose aus #624: die ursprüngliche Suspendierung war vermutlich **nicht** bloß Alert-Unterdrückung während der iSCSI-Störung, sondern eine Reaktion auf genau diese Dauerfehler. Der Zustand war schlecht dokumentiert, aber nicht grundlos.

## Fix

`podAffinity` auf den App-Pod mit `topologyKey: kubernetes.io/hostname`, gesetzt über den Values-Pfad `cronjob.cronjob.affinity` — den das Chart in `templates/cronjob.yaml` unterstützt, kein postRenderer nötig.

`requiredDuringScheduling` statt `preferred` mit Absicht: ein Job auf dem falschen Node läuft nicht langsamer, er läuft überhaupt nicht. Ein `preferred` würde die Fehler nur seltener machen, nicht beseitigen.

## Verifikation

`helm template` gegen Chart 9.2.5 mit den echten HelmRelease-Values: die Affinity landet im CronJob-PodSpec, das App-Deployment bleibt unverändert (`affinity: null`). Nach den beiden stillen Values-Bugs in #632 wurde hier bewusst gerendert statt der Diff gelesen.

`just kustomize-validate`, `just helm-render`, `just ci-lint` alle grün.

## Anmerkung

Sauberer wäre langfristig, dass der Cron-Pod das App-Volume gar nicht braucht — das setzt aber ein Image/Setup voraus, in dem `cron.php` ohne den vollständigen Nextcloud-Baum läuft. Solange das Volume RWO auf iSCSI liegt, ist Co-Scheduling die richtige Lösung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)