### PR TITLE
fix(resources): give memory limits headroom over peak

### DIFF
--- a/apps/base/immich/helmrelease.yaml
+++ b/apps/base/immich/helmrelease.yaml
@@ -84,12 +84,14 @@ spec:
               # silently dropped it and the container ran with no resources
               # at all (confirmed via `helm template`). Correct path is here,
               # under controllers.main.containers.main.
+              # Limit auf Peak (1998Mi) + 35 % statt knapp darüber — siehe die
+              # ausführliche Begründung bei machine-learning weiter unten.
               resources:
                 requests:
                   cpu: 10m
                   memory: 1552Mi
                 limits:
-                  memory: 2432Mi
+                  memory: 2752Mi
       persistence:
         data:
           accessMode: ReadWriteOnce
@@ -124,12 +126,21 @@ spec:
               # nested as a sibling of `controllers` under `machine-learning:`
               # — same dead-key mistake as immich-server above (see comment
               # there); silently dropped by Helm, container ran unbounded.
+              #
+              # Limit war zunächst 1408Mi = exakt der beobachtete 28d-Peak. Das
+              # war zu knapp: der Container erreicht beim Batch-Processing
+              # regelmäßig 1136–1407Mi (über viele Pod-Generationen gemessen),
+              # der Peak ist also kein Ausreißer, sondern der Normalfall. Ein
+              # Limit AUF dem Peak statt DARÜBER führte prompt zum OOMKill.
+              # Für einen zuvor unlimitierten Container ist das Maximum aus der
+              # Historie nur das, was er zufällig gebraucht hat — keine
+              # Bedarfsobergrenze. Daher Peak + 35 %.
               resources:
                 requests:
                   cpu: 10m
                   memory: 592Mi
                 limits:
-                  memory: 1408Mi
+                  memory: 1920Mi
       persistence:
         cache:
           enabled: true

--- a/apps/base/monitoring/vm-k8s-stack/helmrelease.yaml
+++ b/apps/base/monitoring/vm-k8s-stack/helmrelease.yaml
@@ -300,12 +300,15 @@ spec:
     # ============================================
     kube-state-metrics:
       enabled: true
+      # Limit = 28d-Peak (107Mi) + 35 %. Vorher 128Mi, also nur 19 % über dem
+      # Peak — zu knapp, sobald mehr Objekte im Cluster entstehen (kube-state-
+      # metrics skaliert mit der Objektzahl).
       resources:
         requests:
           cpu: 10m
           memory: 64Mi
         limits:
-          memory: 128Mi
+          memory: 192Mi
 
     # ============================================
     # DEFAULT DASHBOARDS & RULES

--- a/infrastructure/base/backup/helmrelease.yaml
+++ b/infrastructure/base/backup/helmrelease.yaml
@@ -66,12 +66,14 @@ spec:
       priorityClassName: "homelab-infrastructure"
     # p95/p99-derived (14d/7d VictoriaMetrics history), previously unset
     # (Burstable, first-to-be-OOM-killed). No CPU limit by convention.
+    # Limit = 28d-Peak (214Mi) + 35 %; Backup-Läufe sind schubweise, und ein
+    # OOM mitten im Lauf kostet das Backup.
     resources:
       requests:
         cpu: 20m
         memory: 80Mi
       limits:
-        memory: 256Mi
+        memory: 320Mi
     metrics:
       enabled: true
       service:


### PR DESCRIPTION
Hotfix zu #632. `immich-machine-learning` wurde OOMKilled — das war ein Fehler in meiner Sizing-Policy, kein Ausreißer der Last.

## Was schiefging

Das Limit stand auf **1408Mi = exakt dem beobachteten 28-Tage-Maximum**. Die Messung über viele Pod-Generationen zeigt aber Peaks von 1136, 1260, 1265, 1267, 1311, 1320, 1351, 1351 und 1407Mi. Der Peak ist also der **wiederkehrende Normalfall** beim Batch-Processing, kein Einzelereignis. Ein Limit *auf* dem Peak statt *darüber* führt beim nächsten regulären Lauf zwangsläufig zum OOMKill — was nach rund 14 Stunden passiert ist.

Der methodische Fehler dahinter, und der eigentliche Lerneffekt:

> Für einen Container, der vorher **unlimitiert** lief, ist das historische Maximum nur das, was er *zufällig* gebraucht hat — keine Bedarfsobergrenze. Als Limit taugt es deshalb nur mit Aufschlag.

Bei den Containern, die vorher schon ein Limit hatten, ist das Maximum aussagekräftiger, weil es dort ohnehin gedeckelt war. Genau die zuvor unlimitierten Container sind aber die, die Phase 1 angefasst hat.

## Korrektur

Peak-Abdeckung bekommt Faktor 1,35 statt 1,0. Danach hat **kein Container** mehr ein Limit auf oder unter seinem Peak (vorher 2, davon 1 real betroffen).

| Container | alt | neu | 28d-Peak |
|---|---|---|---|
| immich-machine-learning | 1408Mi | **1920Mi** | 1408 (+36 %) |
| immich-server | 2432Mi | **2752Mi** | 1998 |
| kube-state-metrics | 128Mi | **192Mi** | 107 |
| velero | 256Mi | **320Mi** | 214 |

`netbird/clusterproxy` bleibt unverändert — dort greifen die Values ohnehin nicht, der Operator hardcodet die Resources (siehe #632).

## Auswirkung

Requests bleiben **unverändert** bei 25,0 GiB — nur Limits steigen, und Limits belegen keinen Speicher. Cluster-Commitment 61 %, N+1-Failover weiterhin erfüllt.

## Verifikation

`helm template` gegen die gepinnten Chart-Versionen mit den echten HelmRelease-Values: alle vier Werte landen im gerenderten Output. Für `kube-state-metrics` zusätzlich gegen den Live-Zustand geprüft, dass der Subchart-Values-Pfad überhaupt greift (live steht der Phase-1-Wert 128Mi — der Pfad ist also wirksam, kein Silent Drop).

`just kustomize-validate`, `just helm-render`, `just ci-lint` grün.

## Konsequenz für Phase 2

Die korrigierte Policy gilt ab jetzt auch für das noch ausstehende Right-Sizing der 76 bereits gesetzten Container. Dort war die Gefahr geringer, weil deren Peaks unter einem bestehenden Limit gemessen wurden — die Regel wird trotzdem einheitlich angewandt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)