### PR TITLE
docs(talos): record CNI deadlock from v1.13.8 upgrade

### DIFF
--- a/docs/learnings/talos-automatic-upgrade-suc-auth.md
+++ b/docs/learnings/talos-automatic-upgrade-suc-auth.md
@@ -194,11 +194,118 @@ every drain of its node. Scaled to `instances: 2` with `required` pod-anti-affin
 need extensions the shared `homelab-postgres` (vanilla `postgresql:18.4`) does not ship
 (`postgis` / vector `vchord`).
 
+## Update 2026-08-07 — the CNI deadlock (v1.13.7 → v1.13.8)
+
+The single most damaging stall so far, and the most portable lesson in this document:
+**a fail-closed admission webhook can prevent the cluster from rebuilding its own
+networking on a rebooted node.** Nothing about it is homelab-specific — any cluster
+running a mutating webhook on `pods` is exposed.
+
+**8. A `failurePolicy: Fail` webhook on `CREATE pods` without a `kube-system`
+exemption bricks CNI on every node reboot.**
+
+The netbird operator ships this:
+
+```yaml
+name:              mpod-v1.netbird.io
+failurePolicy:     Fail        # fail closed
+namespaceSelector: {}          # every namespace, including kube-system
+rules:             [{apiGroups: [""], resources: [pods], operations: [CREATE], scope: "*"}]
+objectSelector:    # only exempts the operator's OWN pods
+  matchExpressions: [{key: app.kubernetes.io/name, operator: NotIn, values: [netbird-operator]}]
+```
+
+Sequence: SUC upgrades cp2 → node reboots → its `kube-flannel` and `kube-proxy`
+DaemonSet pods are deleted → the DaemonSet controller tries to recreate them → the
+API server calls the webhook → the webhook's only backend pod is itself down (it was
+scheduled on that same node) → **admission fails closed** → flannel is never
+recreated → the node has no CNI → the operator pod can never start there → the
+webhook stays down. A closed loop that does not resolve on its own:
+
+```
+FailedCreate  daemonset/kube-flannel  Internal error occurred: failed calling webhook
+"mpod-v1.netbird.io": dial tcp 10.105.0.227:443: connect: connection refused
+```
+
+The blast radius is cluster-wide, not node-local: `kube-flannel`, `kube-proxy`,
+`coredns`, the CNPG operator and pgadmin all failed to create pods in every
+namespace. From there it cascaded into the drain: CNPG replicas pinned to cp2 could
+not start → every CNPG PDB sat at `disruptionsAllowed: 0` → the drain of cp1 retried
+`Cannot evict pod ... would violate the pod's disruption budget` for its full 10 min
+and the init container exited 1.
+
+**Manual unblock** (breaks the loop; everything else then self-heals in order —
+flannel → operators → CNPG replicas → PDB → drain):
+
+```bash
+kubectl patch mutatingwebhookconfiguration netbird-netbird-operator-mpod-webhook \
+  --type=json -p '[{"op":"replace","path":"/webhooks/0/failurePolicy","value":"Ignore"}]'
+```
+
+**Durable rule — audit this on every cluster before enabling autonomous upgrades:**
+no webhook may be `failurePolicy: Fail` on core `pods` without a `namespaceSelector`
+that excludes `kube-system` and the infrastructure namespaces. Sidecar injection is
+never important enough to hard-block pod admission cluster-wide.
+
+```bash
+kubectl get mutatingwebhookconfiguration,validatingwebhookconfiguration -o json | jq -r '
+  .items[].webhooks[] | select(.failurePolicy=="Fail")
+  | select([.rules[]?.resources[]?] | index("pods"))
+  | "\(.name) namespaceSelector=\(.namespaceSelector)"'
+```
+
+**9. A single-replica webhook backend is a single point of failure for everything it
+gates.** `netbird-operator` and `cnpg-cloudnative-pg` both run 1 replica with no
+anti-affinity. The netbird pod happened to land on the very node whose CNI had
+broken, so no endpoint survived anywhere. Any webhook backend that gates pod
+admission needs ≥2 replicas with `podAntiAffinity` on `kubernetes.io/hostname` — or
+`failurePolicy: Ignore`.
+
+**10. After fixing the cause, the DaemonSet controller still waits out its backoff.**
+Once the webhook was patched, ordinary pods were admitted again immediately, but
+`kube-flannel` stayed at 2/3 for a further **16 minutes**. The DaemonSet controller's
+`failedPodsBackoff` grows to a 15-minute cap after repeated `FailedCreate`, and it
+does not reset when the underlying cause disappears. Do not conclude the fix failed
+and start deleting things — verify that ordinary pods are being created again, then
+wait.
+
+**11. Node-pinned storage turns a CPU shortage into an unschedulable pod.**
+After the reboots `immich-postgres-8` sat `Pending`:
+
+```
+0/3 nodes are available: 1 Insufficient cpu,
+                         2 node(s) didn't match PersistentVolume's node affinity
+```
+
+Its `local-path` PV has hard `nodeAffinity` to exactly one node, and that node was at
+97 % of CPU **requests**. With node-local storage a replica has exactly one candidate
+node — so any resource pressure there is not a scheduling delay, it is a permanent
+stall. Two consequences for upgrade planning: keep meaningful CPU headroom on every
+node that hosts node-pinned volumes, and remember that `local-path` instances can
+never migrate — they can only be deleted and re-bootstrapped elsewhere.
+
+**12. Operational: a guest reboot does not apply a hypervisor CPU/RAM change.**
+Proxmox marks `cores`/`sockets` edits on a running VM as *pending* and applies them
+only on a full stop/start. `talosctl reboot` keeps the same qemu process, so the node
+comes back with the old capacity. Use `talosctl shutdown` + start the VM, one node at
+a time, cordoning first and verifying `capacity.cpu` after each.
+
+### Checklist before trusting an autonomous upgrade on a new cluster
+
+1. No `failurePolicy: Fail` webhook matches `pods` without excluding `kube-system` (#8).
+2. Every webhook backend that gates pod admission has ≥2 replicas + anti-affinity (#9).
+3. Every stateful cluster has ≥2 instances and a switchover target (#7).
+4. No node hosting node-pinned volumes runs near its CPU/memory request ceiling (#11).
+5. All node requests still fit on N-1 nodes.
+6. SUC controller anti-affinity does not match the upgrade Job labels (#5).
+7. Controller `images.newTag` is a published tag and equals the manifest `?ref=` (#6).
+
 ## Related
 
 - PRs: #268 (talosconfig mTLS auth), #269 (`-n $(NODE_IP)`),
   #270 (`-e $(NODE_IP)` over TCP), #271 (drop `exclusive: true`),
-  #355 (dawarich-postgres `instances: 2`), #358 (SUC image pin `v0.20.0` → `v0.19.2`)
+  #355 (dawarich-postgres `instances: 2`), #358 (SUC image pin `v0.20.0` → `v0.19.2`),
+  #634 (nextcloud cron podAffinity — RWO co-scheduling, same drain-blocker class)
 - Terraform module `kreativmonkey/terraform-module` **v0.2.0** (per-node `storage_id`,
   `etcd_advertised_subnets`)
 - `infrastructure/overlays/main/system-upgrade-controller/talos-plan.yaml`

--- a/docs/learnings/talos-autonomous-upgrade-handbook.md
+++ b/docs/learnings/talos-autonomous-upgrade-handbook.md
@@ -1,13 +1,14 @@
 # Talos Autonomous Upgrade Handbook
 
 **Date**: 2026-07-25
+**Updated**: 2026-08-07
 **Severity**: high
 **Affected**: cluster-wide
 **Status**: active guardrail
 
 ## What Went Wrong
 
-Four Talos/SUC upgrade rounds needed manual intervention:
+Five Talos/SUC upgrade rounds needed manual intervention:
 
 - SUC auth/endpoint mistakes left nodes cordoned and jobs failed.
 - SUC controller/job anti-affinity and an unpublished controller image tag stalled
@@ -16,6 +17,9 @@ Four Talos/SUC upgrade rounds needed manual intervention:
   failover storms.
 - Node reboots exposed mutable application image drift (`:latest`) and RWO attach
   races, producing NGINX 502s because backend Services had no ready endpoints.
+- A fail-closed admission webhook blocked recreation of the rebooted node's CNI
+  DaemonSet pods, so the cluster could not rebuild its own networking — cluster-wide
+  pod creation stopped until the webhook was relaxed by hand.
 
 ## Why It Failed
 
@@ -40,6 +44,15 @@ The repeated failure classes were:
 7. Slow recovery fan-out: after all nodes reboot, iSCSI attach, image pulls, DB
    readiness, and OIDC discovery cascade; NGINX 502 usually means no ready backend,
    not broken NGINX.
+8. Fail-closed admission control: a webhook with `failurePolicy: Fail` on `CREATE
+   pods` and no `kube-system` exemption gates the CNI DaemonSet pods of the node it
+   just rebooted. If its backend pod lived on that node it can never come back —
+   flannel needs the webhook, the webhook needs flannel. Blast radius is cluster-wide,
+   not node-local, and it cascades: replicas that cannot start hold every PDB at
+   `disruptionsAllowed: 0`, which then blocks the *next* node's drain.
+9. Node-pinned storage plus resource pressure: a `local-path` PV pins its pod to
+   exactly one node. If that node lacks CPU or memory *requests* headroom, the pod is
+   not delayed — it is permanently unschedulable, because it has no second candidate.
 
 ## The Correct Approach
 
@@ -95,6 +108,15 @@ Hard requirements for this repo:
   but those apps need `Recreate` strategy or chart-equivalent single-writer behavior.
 - No production app image uses `:latest`; avoid `imagePullPolicy: Always` unless
   there is a documented reason.
+- No admission webhook is `failurePolicy: Fail` on core `pods` without a
+  `namespaceSelector` excluding `kube-system`. Sidecar injection and label
+  enrichment run `Ignore`; only real security gates may fail closed, and those need
+  the namespace exemption *and* an HA backend.
+- Every webhook backend that gates pod admission runs ≥2 replicas with
+  `podAntiAffinity` on `kubernetes.io/hostname`. A singleton can land on the very
+  node whose CNI is broken.
+- Nodes hosting `local-path` volumes keep real request headroom. A node at >90 % of
+  CPU or memory requests cannot restart its own pinned pods after a reboot.
 
 ## Upgrade Checklist
 
@@ -105,7 +127,21 @@ kubectl --context admin@homelab-kube get nodes
 kubectl --context admin@homelab-kube -n system-upgrade get deploy,pods,plan,jobs
 kubectl --context admin@homelab-kube -n cnpg-system get clusters,pods
 rg -n "image:\s*.*:latest|imagePullPolicy:\s*Always" apps infrastructure -g '*.yaml'
+
+# no fail-closed webhook may gate pod creation in kube-system (failure class 8)
+kubectl --context admin@homelab-kube get mutatingwebhookconfiguration,validatingwebhookconfiguration -o json | jq -r '
+  .items[].webhooks[] | select(.failurePolicy=="Fail")
+  | select([.rules[]?.resources[]?] | index("pods"))
+  | "RISK \(.name) namespaceSelector=\(.namespaceSelector)"'
+
+# every node must have request headroom for its own pinned pods (failure class 9)
+kubectl --context admin@homelab-kube describe nodes | rg -A5 'Allocated resources' | rg '^\s+(cpu|memory)'
 ```
+
+Do not merge while any of these is true: a webhook shows up as `RISK` without a
+`kube-system` exemption, a node is above ~90 % of CPU or memory requests, or any
+stateful cluster is below its full instance count. All three turn a routine drain
+into a stall.
 
 After SUC starts:
 
@@ -136,12 +172,45 @@ kubectl --context admin@homelab-kube describe pod -n <namespace> <pod>
   as emergency unblock, then fix Git.
 - For post-reboot 502s, wait through normal iSCSI attach/image-pull startup, but
   investigate CrashLoopBackOff immediately.
+- If `FailedCreate ... failed calling webhook` appears on a DaemonSet or ReplicaSet,
+  stop diagnosing the workload — the cluster cannot create pods at all. Relax the
+  webhook, then let the chain heal itself in order (CNI → operators → stateful
+  replicas → PDB → drain):
+
+  ```bash
+  kubectl patch mutatingwebhookconfiguration <name> \
+    --type=json -p '[{"op":"replace","path":"/webhooks/0/failurePolicy","value":"Ignore"}]'
+  ```
+
+  Revert to `Fail` only after the durable fix (namespace exemption + HA backend) is
+  in Git; a live patch is drift and will be reconciled away.
+- After relaxing the webhook, expect the DaemonSet controller to wait out its
+  `failedPodsBackoff` — up to 15 minutes, and it does **not** reset when the cause
+  disappears. Confirm ordinary pods are being created again, then wait instead of
+  deleting objects.
+- Counting readiness with `grep -v Running` is wrong: a pod stuck at `0/1 Running`
+  matches and is silently counted as healthy. Compare the READY column instead:
+
+  ```bash
+  kubectl get pods -A --no-headers \
+    | awk '{split($3,a,"/"); if (a[1]!=a[2] && $4!="Completed") print $1"/"$2"  "$3"  "$4}'
+  ```
 
 ## Prevention
 
 - Treat Talos upgrades as node-drain tests for every stateful workload.
 - Keep mutable-image checks part of every Talos bump review.
 - Prefer pinned app tags with Renovate PRs over silent pull-on-reboot updates.
+- Treat every newly installed operator as a possible admission-control change: check
+  what webhooks its chart ships before it reaches `main`, not after a reboot exposes
+  them. Chart defaults are not validated for this cluster.
+- Anything the cluster needs in order to repair itself — CNI, kube-proxy, CoreDNS,
+  CSI — must not depend on a workload that can be down. That is the general form of
+  failure class 8, and it is worth checking against any new cluster-wide gate.
+- Hypervisor CPU/RAM changes need a full VM stop/start. Proxmox marks `cores`/
+  `sockets` edits on a running VM as *pending*; `talosctl reboot` keeps the same
+  qemu process and the node returns with the old capacity. Use `talosctl shutdown`,
+  start the VM, verify `capacity.cpu`, one node at a time.
 - Keep one canonical upgrade handrail here; incident-specific learnings remain
   historical evidence.
 


### PR DESCRIPTION
Zwei Dokumente aus dem gestoppten Talos-Rollout v1.13.7 → v1.13.8. Beide beschreiben denselben Vorfall, aber bewusst getrennt nach ihrer Rolle: das eine hält die Kausalkette fest, das andere die Regel, die künftig davor schützt.

Die zentrale Lektion ist portabel: **ein fail-closed Admission-Webhook kann verhindern, dass ein Cluster nach einem Node-Reboot sein eigenes Netzwerk wieder aufbaut.** Daran ist nichts homelab-spezifisch — jeder Cluster mit einem mutating webhook auf `pods` ist exponiert.

---

## 1. `talos-automatic-upgrade-suc-auth.md` — der Vorfallsbericht

Setzt die Reihe der datierten Update-Abschnitte fort, Fehlermodi **8–12**:

**8 — Der CNI-Deadlock.** `mpod-v1.netbird.io` läuft mit `failurePolicy: Fail`, leerem `namespaceSelector` und `CREATE pods` clusterweit. Nach dem Reboot von cp2 wurden dessen `kube-flannel`/`kube-proxy`-Pods gelöscht; ihre Neuerstellung ging durch den Webhook, dessen einziges Backend-Pod auf genau diesem Node lag und ohne CNI nicht starten konnte. Geschlossener Kreis. Blast Radius clusterweit — auch `coredns`, CNPG-Operator und pgadmin konnten keine Pods mehr erzeugen. Von dort kaskadierte es: CNPG-Replicas auf cp2 kamen nicht hoch → alle PDBs auf `disruptionsAllowed: 0` → der Drain von cp1 lief 10 min in die Wand und brach mit Exit 1 ab.

**9 — Single-Replica-Webhook-Backends.** netbird- und CNPG-Operator laufen je mit 1 Replica ohne Anti-Affinity. Das netbird-Pod lag ausgerechnet auf dem Node mit kaputtem CNI.

**10 — Backoff nach dem Fix.** Nach dem Patch wurden normale Pods sofort wieder zugelassen, `kube-flannel` blieb aber weitere **16 Minuten** bei 2/3. Der `failedPodsBackoff` des DaemonSet-Controllers wächst auf 15 min und setzt sich nicht zurück, wenn die Ursache verschwindet.

**11 — Node-gepinnter Storage + CPU-Druck.** `immich-postgres-8` blieb `Pending`: `local-path`-PV hart auf einen Node gepinnt, der bei 97 % CPU-Requests lag. Bei node-lokalem Storage gibt es genau einen Kandidaten-Node — Ressourcendruck dort ist kein Verzug, sondern Dauerstillstand.

**12 — Operativ.** Ein Gast-Reboot übernimmt keine Proxmox-CPU-Änderung; das braucht stop/start.

Plus eine Checkliste für **neue** Cluster mit jq-Einzeiler für den Webhook-Audit.

---

## 2. `talos-autonomous-upgrade-handbook.md` — die Leitplanke

Das Handbuch ist präskriptiv („keep one canonical upgrade handrail here"), hier steht also die Regel statt der Erzählung:

- **Fehlerklassen 8 und 9** ergänzt (fail-closed Admission-Control, node-gepinnter Storage ohne Headroom)
- **Hard Requirements**: kein fail-closed Webhook auf `pods` ohne `kube-system`-Ausnahme; HA-Backend für jeden Webhook, der Pod-Admission gatet; Request-Headroom auf Nodes mit node-gepinnten Volumes
- **Upgrade-Checkliste**: zwei Preflight-Kommandos (jq-Audit der Webhooks, Request-Auslastung je Node) plus explizite Merge-Blocker — nicht mergen, solange ein Webhook als `RISK` auftaucht, ein Node über ~90 % Requests liegt oder ein Stateful-Cluster unvollständig ist
- **Recovery Rules**: Webhook-Deadlock erkennen und auflösen, danach den Backoff abwarten statt einzugreifen
- **Prevention**: Charts neuer Operatoren vor dem Merge auf mitgelieferte Webhooks prüfen; alles, was der Cluster zur Selbstreparatur braucht (CNI, kube-proxy, CoreDNS, CSI), darf nicht von einem ausfallbaren Workload abhängen

### Ein Messfehler, den ich mitdokumentiert habe

Ich habe während des Vorfalls mit `grep -v "Running|Completed"` gezählt und daraufhin „0 nicht-bereit" gemeldet, während Nextcloud tatsächlich auf `0/1 Running` hing — der Status-String enthält `Running`, der Pod fiel aus der Zählung. Die korrekte Prüfung vergleicht die READY-Spalte. Steht jetzt als Recovery-Regel im Handbuch, weil der Fehler leicht zu wiederholen ist.

---

Nur Dokumentation, keine Manifest-Änderung. Die eigentliche Härtung (Webhook-`namespaceSelector`, Operator-HA, CNPG-Maintenance-Window, CI-Check, Preflight) folgt separat — der netbird-Webhook steht derzeit nur per manuellem `kubectl patch` auf `Ignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)