### PR TITLE
fix(immich): size ML memory limit from cgroup highwater, not working set

### DIFF
--- a/apps/base/immich/helmrelease.yaml
+++ b/apps/base/immich/helmrelease.yaml
@@ -127,20 +127,35 @@ spec:
               # — same dead-key mistake as immich-server above (see comment
               # there); silently dropped by Helm, container ran unbounded.
               #
-              # Limit war zunächst 1408Mi = exakt der beobachtete 28d-Peak. Das
-              # war zu knapp: der Container erreicht beim Batch-Processing
-              # regelmäßig 1136–1407Mi (über viele Pod-Generationen gemessen),
-              # der Peak ist also kein Ausreißer, sondern der Normalfall. Ein
-              # Limit AUF dem Peak statt DARÜBER führte prompt zum OOMKill.
-              # Für einen zuvor unlimitierten Container ist das Maximum aus der
-              # Historie nur das, was er zufällig gebraucht hat — keine
-              # Bedarfsobergrenze. Daher Peak + 35 %.
+              # Limit-Historie: 1408Mi (= beobachteter 28d-Peak) → OOMKill,
+              # dann 1920Mi (Peak + 35 %) → am 2026-08-07 erneut OOMKill.
+              #
+              # Beide Werte stammten aus container_memory_working_set_bytes.
+              # Das war die falsche Metrik: cAdvisor scrapet alle 30s, der
+              # Bedarf hier ist aber ein Burst von wenigen Sekunden. Im
+              # 30s-Raster blieb die Serie über den OOM hinweg flach bei
+              # 265Mi — der Spike ist zwischen zwei Scrapes komplett
+              # unsichtbar. Maßgeblich ist stattdessen der cgroup-Highwater
+              # container_memory_max_usage_bytes: die früheren, noch
+              # unlimitierten Pod-Generationen lagen dort bei 2357–2829Mi.
+              #
+              # Auslöser des Bursts ist der Cold-Start der Modelle: der
+              # Container lädt in ~15s vier ONNX-Sessions gleichzeitig
+              # (buffalo_l detection + recognition, CLIP ViT-B-32, seit v3
+              # zusätzlich OCR PP-OCRv5) bei 4 Request-Threads. Die alten
+              # Messwerte kannten das OCR-Modell noch gar nicht.
+              #
+              # Daher Limit über den unlimitierten Highwater (2829Mi) statt
+              # über einen Working-Set-Peak. Requests bleiben bei 592Mi:
+              # talos-cp1 liegt bei 95 % Memory-Requests, eine Anhebung
+              # würde die Schedulebarkeit gefährden — Limits sind ohnehin
+              # übercommitted.
               resources:
                 requests:
                   cpu: 10m
                   memory: 592Mi
                 limits:
-                  memory: 1920Mi
+                  memory: 3072Mi
       persistence:
         cache:
           enabled: true


### PR DESCRIPTION
immich-machine-learning wurde am 2026-08-07 erneut OOMKilled, diesmal am Limit von 1920Mi (Peak + 35 %).

## Warum die bisherige Sizing-Methode falsch war

Beide bisherigen Limits (1408Mi, 1920Mi) stammten aus `container_memory_working_set_bytes`. Diese Metrik taugt für diesen Container nicht: cAdvisor scrapet alle 30s, der Bedarf ist aber ein Burst von wenigen Sekunden. Über den OOM-Zeitpunkt (12:43:35) hinweg blieb die Serie flach bei 265Mi — der Spike liegt vollständig zwischen zwei Scrapes und ist in der Historie schlicht unsichtbar.

Der cgroup-Highwater `container_memory_max_usage_bytes` erzählt eine andere Geschichte. Für die früheren, noch unlimitierten Pod-Generationen:

| Pod-Generation | working_set (30d max) | max_usage (30d max) |
|---|---|---|
| `754f9c-v6sn2` | 1351Mi | **2829Mi** |
| `754f9c-ckt6w` | 1407Mi | **2795Mi** |
| `8964c8-m9qd7` | 1267Mi | **2767Mi** |
| `f84b87-69rhf` | 1311Mi | **2522Mi** |
| `476cff-dtdww` | 1136Mi | **2357Mi** |

## Auslöser

Die Logs des gekillten Containers zeigen einen Modell-Cold-Start: in ~15s werden vier ONNX-Sessions parallel geladen — `buffalo_l` detection + recognition, CLIP `ViT-B-32__openai`, und seit v3 zusätzlich OCR `PP-OCRv5_mobile` — bei 4 Request-Threads. Das OCR-Modell existierte zum Zeitpunkt der alten Messung noch gar nicht, die Baseline war also ohnehin veraltet.

## Änderung

Limit auf **3072Mi**, oberhalb des unlimitierten Highwaters von 2829Mi. Requests bleiben bei 592Mi: talos-cp1 liegt bei 95 % Memory-Requests, eine Anhebung würde die Schedulebarkeit gefährden. Limits sind dort ohnehin auf 277 % übercommitted.

## Offener Folgepunkt (nicht in diesem PR)

Der Model-Cache liegt auf `emptyDir`. Jeder Pod-Neustart lädt alle Modelle neu herunter und provoziert damit genau den Burst, der hier zum OOM geführt hat — ein OOM erzeugt also die Bedingungen für den nächsten. Ein persistenter Cache (PVC, ~2-3Gi) würde das entkoppeln.

## Validierung

`just ci-lint helm-render` grün; gerendert liegt das Limit nachweislich auf dem `immich-machine-learning` Container (kein stiller Key-Drop wie früher).

🤖 Generated with [Claude Code](https://claude.com/claude-code)