### PR TITLE
feat(monitoring): add Proxmox exporter for the 4-node PVE cluster

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -3,6 +3,6 @@ creation_rules:
   - path_regex: .*\.secret\.ya?ml$
     # Der LOKALE Age Public Key (Beginnt meist mit age1...)
     # Der zugehörige Private Key wurde über Terraform ins Cluster deployt
-    age: "REMOVED_BY_HISTORY_REWRITE"
+    age: "age1u5lcvuuwd4lk7f3xewjk70j75yuh68myr89qkd0e8d44zgyjleeqw03vqs"
     # Nur Werte in data und stringData verschlüsseln, nicht die YAML-Struktur
     encrypted_regex: '^(data|stringData)$'

--- a/apps/base/monitoring/extra-scrapes/kustomization.yaml
+++ b/apps/base/monitoring/extra-scrapes/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - blackbox-vmprobe.yaml
   - blackbox-vmprobe-tandoor.yaml
   - truenas-exporter-vmservicescrape.yaml
+  - proxmox-exporter-vmprobe.yaml

--- a/apps/base/monitoring/extra-scrapes/proxmox-exporter-vmprobe.yaml
+++ b/apps/base/monitoring/extra-scrapes/proxmox-exporter-vmprobe.yaml
@@ -1,0 +1,28 @@
+# prometheus-pve-exporter is a blackbox-style multi-target exporter: the PVE
+# node to query comes from the ?target= query param, not from its own config.
+# One cluster-wide credential ("default" module) covers all 4 nodes.
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMProbe
+metadata:
+  name: proxmox-exporter
+  namespace: monitoring
+  labels:
+    release: victoriametrics
+spec:
+  jobName: proxmox
+  vmProberSpec:
+    url: http://proxmox-exporter.monitoring.svc.cluster.local:9221
+  path: /pve
+  module: default
+  params:
+    cluster: ["1"]
+    node: ["1"]
+  targets:
+    static:
+      targets:
+        - 192.168.10.240 # red
+        - 192.168.10.241 # white
+        - 192.168.10.5 # pve
+        - 192.168.10.10 # ugos
+  interval: 60s
+  scrapeTimeout: 30s

--- a/apps/base/proxmox-exporter/deployment.yaml
+++ b/apps/base/proxmox-exporter/deployment.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: proxmox-exporter
+  namespace: monitoring
+  labels:
+    app: proxmox-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: proxmox-exporter
+  template:
+    metadata:
+      labels:
+        app: proxmox-exporter
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        runAsGroup: 101
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: exporter
+          image: prompve/prometheus-pve-exporter:3.9.0
+          ports:
+            - containerPort: 9221
+              name: metrics
+          env:
+            - name: PVE_VERIFY_SSL
+              value: "false"
+            - name: PVE_USER
+              valueFrom:
+                secretKeyRef:
+                  name: proxmox-exporter-credentials
+                  key: PVE_USER
+            - name: PVE_TOKEN_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: proxmox-exporter-credentials
+                  key: PVE_TOKEN_NAME
+            - name: PVE_TOKEN_VALUE
+              valueFrom:
+                secretKeyRef:
+                  name: proxmox-exporter-credentials
+                  key: PVE_TOKEN_VALUE
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          livenessProbe:
+            httpGet:
+              path: /
+              port: metrics
+            initialDelaySeconds: 10
+            periodSeconds: 60
+            timeoutSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: metrics
+            initialDelaySeconds: 5
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi

--- a/apps/base/proxmox-exporter/kustomization.yaml
+++ b/apps/base/proxmox-exporter/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/apps/base/proxmox-exporter/service.yaml
+++ b/apps/base/proxmox-exporter/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: proxmox-exporter
+  namespace: monitoring
+  labels:
+    app: proxmox-exporter
+spec:
+  selector:
+    app: proxmox-exporter
+  ports:
+    - name: metrics
+      port: 9221
+      targetPort: metrics
+      protocol: TCP
+  type: ClusterIP

--- a/apps/overlays/main/kustomization.yaml
+++ b/apps/overlays/main/kustomization.yaml
@@ -57,6 +57,8 @@ resources:
   - ../../base/gatus
   - ../../base/truenas-exporter
   - truenas-exporter.secret.yaml
+  - ../../base/proxmox-exporter
+  - proxmox-exporter.secret.yaml
 
   # --- Smart Home -------------------------------------------------------
   - ../../base/spectrumknx

--- a/apps/overlays/main/proxmox-exporter.secret.yaml
+++ b/apps/overlays/main/proxmox-exporter.secret.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+data:
+    PVE_TOKEN_NAME: ENC[AES256_GCM,data:w/slAqjEWSiewAYK9lX7aw==,iv:r98+UEZpRESMMLH6yiP5W2kFlCj0HdVIJAxvsQ4/Rv4=,tag:E7mv4O9Z6xSx3t92KyRVVQ==,type:str]
+    PVE_TOKEN_VALUE: ENC[AES256_GCM,data:RcgRPWtGrL/255tpC5rVR1Vg/ctad4AFmQuIsOINMny9LvPddNhkgBCCTQg=,iv:t+T9PtuFrMbbn4Xa99++aN8rDmVQCBhFx3HrXR0jbA8=,tag:nztmiqxZYWOYC5hBLKlOnA==,type:str]
+    PVE_USER: ENC[AES256_GCM,data:Jq7sp59F3tNI6TuRJhmp06KY9cY=,iv:VmYIOeSzZG3r2zTkd90YUjSb7Gvf3BW28+w7gbz217k=,tag:C2tKg51orAn0gI28n120Aw==,type:str]
+kind: Secret
+metadata:
+    name: proxmox-exporter-credentials
+    namespace: monitoring
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUSmlBQUZENUFxcjE5dDlh
+            Uldjak5MOWlkdmdtY0s0OXg3WmtKZjlNdFNRClZabWtnWW5SRGZvVENEODZFL0hK
+            bzk3Vk91Nmw5dU9hUk1oRWdDTFh3WlEKLS0tIFRrSk9UWjZFbTIzOWxVWFRtdzV1
+            TGNIZjZ6Z0VRNTE4ajlNdWFyaXhYbUEKr8ro9HRhxgMBGK6ki0VjPEMXuHLDMh0R
+            ENFTJKTBmNYl8kAfFmLZGuwo14xiWbHbxRKw2nhB0/sUxriVl380qQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1u5lcvuuwd4lk7f3xewjk70j75yuh68myr89qkd0e8d44zgyjleeqw03vqs
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-08-07T10:06:00Z"
+    mac: ENC[AES256_GCM,data:CqefODYKekrQXg1s8sZq+P1X0nC2rJjxfTZ2i6Q0tetm5AGy+1dlCh7C1fGvtJQ60VZ7UdaX94qiLAZ179InbSM8Z4dw2IK3JJsgjKQpyNg3wT/Qa1HjMxF9em1xKoGIu3Ja31f8gMs9eY+3vP3OOz5YyVUivYgO2aC1DttK3Zw=,iv:cRHNlv8p51YqhniHpPqG+7swWY7WL9TzKei9TIZ9Jig=,tag:2230EfLaUfAuLZ+p1hsI4w==,type:str]
+    version: 3.13.3


### PR DESCRIPTION
## Summary
- Adds `prometheus-pve-exporter` (standard exporter, not hand-rolled) as an in-cluster Deployment, scraped via one `VMProbe` (`apps/base/monitoring/extra-scrapes/proxmox-exporter-vmprobe.yaml`) targeting all 4 Proxmox hosts (`red` .240, `white` .241, `pve` .5, `ugos` .10) — one cluster-wide PVEAuditor token covers all of them since the exporter takes the node from the scrape-time `target` param, not from its own config.
- Fixes `.sops.yaml`: the age recipient had been replaced by a git-history-rewrite placeholder (`REMOVED_BY_HISTORY_REWRITE`) on `origin/main` itself, blocking creation of any new SOPS secret repo-wide. Recovered the real public key from the private key already deployed in-cluster (`flux-system/sops-age`) and verified an encrypt/decrypt round-trip.

## ⚠️ Before merging
`apps/overlays/main/proxmox-exporter.secret.yaml` currently has a **placeholder** `PVE_TOKEN_VALUE`. Create the real token on any one node (cluster-wide user DB):
```
pveum user add prometheus@pve --comment "VictoriaMetrics monitoring"
pveum aclmod / -user prometheus@pve -role PVEAuditor
pveum user token add prometheus@pve monitoring --privsep 0
```
then `nix develop -c sops apps/overlays/main/proxmox-exporter.secret.yaml` and replace `PVE_TOKEN_VALUE`.

## Test plan
- [x] `just validate` passes (kustomize + kubeconform + helm-render)
- [x] `kustomize build apps/overlays/main/monitoring-rules` renders the VMProbe correctly
- [x] All 4 hosts respond on :8006
- [x] sops encrypt/decrypt round-trip verified against the in-cluster key
- [ ] Replace placeholder token, confirm `kubectl -n monitoring get pods -l app=proxmox-exporter` is Running/Ready
- [ ] `pve_up` shows 4 `node/*` series in VictoriaMetrics after Flux reconcile

🤖 Generated with [Claude Code](https://claude.com/claude-code)