### PR TITLE
fix(authentik): Client-Secrets per !Env statt Platzhalter im Blueprint

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,8 +1,11 @@
 creation_rules:
   # Regel: Alle Dateien, die auf .secret.yaml oder .secret.yml enden, werden verschlüsselt
   - path_regex: .*\.secret\.ya?ml$
-    # Der LOKALE Age Public Key (Beginnt meist mit age1...)
-    # Der zugehörige Private Key wurde über Terraform ins Cluster deployt
-    age: "REMOVED_BY_HISTORY_REWRITE"
+    # Age Public Key des Clusters. Der zugehörige Private Key liegt als Secret
+    # sops-age in flux-system und wird von Terraform deployt; er verlässt den
+    # Cluster nicht. Recipient prüfen mit:
+    #   kubectl -n flux-system get secret sops-age \
+    #     -o jsonpath='{.data.age\.agekey}' | base64 -d | age-keygen -y
+    age: "age1u5lcvuuwd4lk7f3xewjk70j75yuh68myr89qkd0e8d44zgyjleeqw03vqs"
     # Nur Werte in data und stringData verschlüsseln, nicht die YAML-Struktur
     encrypted_regex: '^(data|stringData)$'

--- a/apps/base/authentik/blueprints/dawarich-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/dawarich-oauth.configmap.yaml
@@ -21,7 +21,10 @@ data:
           name: Provider for Dawarich
           client_type: confidential
           client_id: homelab-dawarich
-          client_secret: <placeholder-change-me>
+          # Injected into the worker from the authentik-oidc-client-secrets Secret.
+          # Never hardcode it here: every reconcile would overwrite the real
+          # secret in Authentik and break the login with invalid_client.
+          client_secret: !Env OIDC_DAWARICH_CLIENT_SECRET
           grant_types:
             - authorization_code
             - refresh_token

--- a/apps/base/authentik/blueprints/gatus-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/gatus-oauth.configmap.yaml
@@ -16,11 +16,14 @@ data:
       - model: authentik_providers_oauth2.oauth2provider
         id: gatus-provider
         identifiers:
-          client_id: homelab-gatus
+          # The live provider (and the gatus-authentik-oauth secret) use this
+          # generated id — `homelab-gatus` never existed, so this blueprint had
+          # been failing to create a duplicate provider all along.
+          client_id: Pp2APHT3Zh9LBwC2qVMK3n9YmyCujamFiPzZbAwQ
         attrs:
           name: Provider for Gatus
           client_type: confidential
-          client_id: homelab-gatus
+          client_id: Pp2APHT3Zh9LBwC2qVMK3n9YmyCujamFiPzZbAwQ
           # Injected into the worker from the authentik-oidc-client-secrets Secret,
           # which mirrors apps/base/gatus/gatus-authentik-oauth.secret.yaml (client-secret).
           # Never hardcode it here: every reconcile would overwrite the real

--- a/apps/base/authentik/blueprints/gatus-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/gatus-oauth.configmap.yaml
@@ -21,8 +21,11 @@ data:
           name: Provider for Gatus
           client_type: confidential
           client_id: homelab-gatus
-          # Must match apps/base/gatus/gatus-authentik-oauth.secret.yaml (client-secret).
-          client_secret: homelab-gatus-change-me
+          # Injected into the worker from the authentik-oidc-client-secrets Secret,
+          # which mirrors apps/base/gatus/gatus-authentik-oauth.secret.yaml (client-secret).
+          # Never hardcode it here: every reconcile would overwrite the real
+          # secret in Authentik and break the login with invalid_client.
+          client_secret: !Env OIDC_GATUS_CLIENT_SECRET
           authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
           invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
           signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]

--- a/apps/base/authentik/blueprints/grafana-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/grafana-oauth.configmap.yaml
@@ -15,10 +15,13 @@ data:
     entries:
       - model: authentik_providers_oauth2.oauth2provider
         id: grafana-provider
+        # Match on client_id, not name: the name is an attribute the blueprint
+        # itself sets, so any rename turns the update into a create and hits the
+        # unique constraint.
         identifiers:
-          name: Provider for Grafana
+          client_id: homelab-grafana
         attrs:
-          name: Provider for Grafana
+          name: Provider for Grafana Talos Cluster
           client_type: confidential
           client_id: homelab-grafana
           # Injected into the worker from the authentik-oidc-client-secrets Secret,
@@ -26,9 +29,12 @@ data:
           # Never hardcode it here: every reconcile would overwrite the real
           # secret in Authentik and break the login with invalid_client.
           client_secret: !Env OIDC_GRAFANA_CLIENT_SECRET
-          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          # Flow and signing key mirror the live provider, which was maintained
+          # by hand while this blueprint never applied. Keeps the first apply a
+          # no-op; change deliberately, not as a side effect.
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-explicit-consent]]
           invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
-          signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+          signing_key: null
           redirect_uris:
             - matching_mode: strict
               url: https://grafana.cluster.f4mily.net/login/generic_oauth
@@ -38,12 +44,14 @@ data:
             - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
             - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
             - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
-            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, entitlements]]
+            # entitlements was listed here but the live provider never had it —
+            # the blueprint had never applied. Left out so the first apply is a
+            # no-op; add it back deliberately if the claim is actually wanted.
       - model: authentik_core.application
         identifiers:
           slug: grafana-talos-cluster
         attrs:
-          name: Grafana
+          name: Grafana Talos Cluster
           slug: grafana-talos-cluster
           provider: !KeyOf grafana-provider
           launch_url: https://grafana.cluster.f4mily.net

--- a/apps/base/authentik/blueprints/grafana-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/grafana-oauth.configmap.yaml
@@ -21,9 +21,11 @@ data:
           name: Provider for Grafana
           client_type: confidential
           client_id: homelab-grafana
-          # Set the same value as monitoring secret grafana-authentik-oauth (key client-secret).
-          # Run: just grafana-authentik-oauth — then paste client-secret into Authentik if the provider already exists.
-          client_secret: homelab-grafana-change-me
+          # Injected into the worker from the authentik-oidc-client-secrets Secret,
+          # which mirrors monitoring secret grafana-authentik-oauth (key client-secret).
+          # Never hardcode it here: every reconcile would overwrite the real
+          # secret in Authentik and break the login with invalid_client.
+          client_secret: !Env OIDC_GRAFANA_CLIENT_SECRET
           authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
           invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
           signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]

--- a/apps/base/authentik/blueprints/linkding-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/linkding-oauth.configmap.yaml
@@ -21,7 +21,10 @@ data:
           name: Provider for Linkding
           client_type: confidential
           client_id: homelab-linkding
-          client_secret: <placeholder-change-me>
+          # Injected into the worker from the authentik-oidc-client-secrets Secret.
+          # Never hardcode it here: every reconcile would overwrite the real
+          # secret in Authentik and break the login with invalid_client.
+          client_secret: !Env OIDC_LINKDING_CLIENT_SECRET
           grant_types:
             - authorization_code
             - refresh_token

--- a/apps/base/authentik/blueprints/paperless-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/paperless-oauth.configmap.yaml
@@ -15,10 +15,13 @@ data:
     entries:
       - model: authentik_providers_oauth2.oauth2provider
         id: paperless-provider
+        # Match on client_id, not name: the name is an attribute the blueprint
+        # itself sets, so any rename turns the update into a create and hits the
+        # unique constraint.
         identifiers:
-          name: Provider for Paperless
+          client_id: qKeg0wbITh8B8r3OUdlLCzATt6nODf8UeUnC9grv
         attrs:
-          name: Provider for Paperless
+          name: Provider for Paperless-NGX
           client_type: confidential
           client_id: qKeg0wbITh8B8r3OUdlLCzATt6nODf8UeUnC9grv
           # Injected into the worker from the authentik-oidc-client-secrets Secret,
@@ -41,7 +44,7 @@ data:
         identifiers:
           slug: paperless
         attrs:
-          name: Paperless
+          name: Paperless-NGX
           slug: paperless
           provider: !KeyOf paperless-provider
           launch_url: https://paperless.f4mily.net

--- a/apps/base/authentik/blueprints/paperless-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/paperless-oauth.configmap.yaml
@@ -21,8 +21,12 @@ data:
           name: Provider for Paperless
           client_type: confidential
           client_id: qKeg0wbITh8B8r3OUdlLCzATt6nODf8UeUnC9grv
-          # Must match apps/overlays/main/paperless-ngx-integrations.secret.yaml (Authentik OIDC secret).
-          client_secret: paperless-authentik-sync-from-integrations-secret
+          # Injected into the worker from the authentik-oidc-client-secrets Secret,
+          # which mirrors apps/overlays/main/paperless-ngx-integrations.secret.yaml
+          # (PAPERLESS_SOCIALACCOUNT_PROVIDERS → openid_connect.APPS[0].secret).
+          # Never hardcode it here: every reconcile would overwrite the real
+          # secret in Authentik and break the login with invalid_client.
+          client_secret: !Env OIDC_PAPERLESS_CLIENT_SECRET
           authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
           invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
           signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]

--- a/apps/base/authentik/blueprints/teslamate-grafana-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/teslamate-grafana-oauth.configmap.yaml
@@ -15,10 +15,13 @@ data:
     entries:
       - model: authentik_providers_oauth2.oauth2provider
         id: teslamate-grafana-provider
+        # Match on client_id, not name: the name is an attribute the blueprint
+        # itself sets, so any rename turns the update into a create and hits the
+        # unique constraint.
         identifiers:
-          name: Provider for TeslaMate Grafana
+          client_id: fa6de72374e823c83b6d5aa0f209a9a29a01b6ba
         attrs:
-          name: Provider for TeslaMate Grafana
+          name: Provider for Teslamate Grafana
           client_type: confidential
           client_id: fa6de72374e823c83b6d5aa0f209a9a29a01b6ba
           # Injected into the worker from the authentik-oidc-client-secrets Secret,
@@ -32,19 +35,24 @@ data:
           redirect_uris:
             - matching_mode: strict
               url: https://teslamate.f4mily.net/grafana/login/generic_oauth
-          post_logout_redirect_uris:
-            - https://teslamate.f4mily.net/grafana/logout
+            # Second host the provider is reachable under. Listed here because
+            # the blueprint replaces the whole list — dropping it would break
+            # that login path.
+            - matching_mode: strict
+              url: https://teslamate-grafana.cluster.f4mily.net/grafana/login/generic_oauth
           property_mappings:
             - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
             - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
             - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
-            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, entitlements]]
+            # entitlements was listed here but the live provider never had it —
+            # the blueprint had never applied. Left out so the first apply is a
+            # no-op; add it back deliberately if the claim is actually wanted.
       - model: authentik_core.application
         identifiers:
-          slug: tesla-grafana
+          slug: teslamate-grafana
         attrs:
-          name: TeslaMate Grafana
-          slug: tesla-grafana
+          name: Teslamate Grafana
+          slug: teslamate-grafana
           provider: !KeyOf teslamate-grafana-provider
-          launch_url: https://teslamate.f4mily.net/grafana/
-          meta_launch_url: https://teslamate.f4mily.net/grafana/
+          launch_url: https://teslamate.f4mily.net/grafana
+          meta_launch_url: https://teslamate.f4mily.net/grafana

--- a/apps/base/authentik/blueprints/teslamate-grafana-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/teslamate-grafana-oauth.configmap.yaml
@@ -21,8 +21,11 @@ data:
           name: Provider for TeslaMate Grafana
           client_type: confidential
           client_id: fa6de72374e823c83b6d5aa0f209a9a29a01b6ba
-          # Set to teslamate-grafana-oauth secret client-secret after reconcile (see docs/integrations/teslamate-grafana-authentik.md)
-          client_secret: teslamate-grafana-change-me
+          # Injected into the worker from the authentik-oidc-client-secrets Secret,
+          # which mirrors teslamate secret teslamate-grafana-oauth (key client-secret).
+          # Never hardcode it here: every reconcile would overwrite the real
+          # secret in Authentik and break the login with invalid_client.
+          client_secret: !Env OIDC_TESLAMATE_GRAFANA_CLIENT_SECRET
           authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
           invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
           signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]

--- a/apps/base/authentik/helmrelease.yaml
+++ b/apps/base/authentik/helmrelease.yaml
@@ -66,6 +66,8 @@ spec:
         - authentik-gatus-blueprint
         - authentik-linkding-blueprint
         - authentik-dawarich-blueprint
+        - authentik-grafana-blueprint
+        - authentik-teslamate-grafana-blueprint
     server:
       ingress:
         enabled: false

--- a/apps/base/authentik/helmrelease.yaml
+++ b/apps/base/authentik/helmrelease.yaml
@@ -99,6 +99,42 @@ spec:
         - name: data
           mountPath: /data
     worker:
+      # OIDC client secrets for the blueprints above. Only the worker applies
+      # blueprints, so only it needs them. The blueprints read these via
+      # `!Env [...]`; if a variable is missing the blueprint fails instead of
+      # writing an empty secret into Authentik.
+      # Secret comes from the private repo (apps/overlays/main/authentik-private).
+      env:
+        - name: OIDC_LINKDING_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: authentik-oidc-client-secrets
+              key: linkding-client-secret
+        - name: OIDC_DAWARICH_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: authentik-oidc-client-secrets
+              key: dawarich-client-secret
+        - name: OIDC_GATUS_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: authentik-oidc-client-secrets
+              key: gatus-client-secret
+        - name: OIDC_GRAFANA_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: authentik-oidc-client-secrets
+              key: grafana-client-secret
+        - name: OIDC_PAPERLESS_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: authentik-oidc-client-secrets
+              key: paperless-client-secret
+        - name: OIDC_TESLAMATE_GRAFANA_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: authentik-oidc-client-secrets
+              key: teslamate-grafana-client-secret
       # 2026-06-09: limit raised 2Gi→4Gi (OOMKilled, exit 137)
       #   Previous pod ran 3.5d then OOM. DockerException spam
       #   (outpost_service_connection_monitor → Docker) on Talos

--- a/apps/base/authentik/kustomization.yaml
+++ b/apps/base/authentik/kustomization.yaml
@@ -7,6 +7,8 @@ resources:
   - blueprints/gatus-oauth.configmap.yaml
   - blueprints/linkding-oauth.configmap.yaml
   - blueprints/dawarich-oauth.configmap.yaml
+  - blueprints/grafana-oauth.configmap.yaml
+  - blueprints/teslamate-grafana-oauth.configmap.yaml
   - media-pvc.yaml
   - helmrelease.yaml
   - ingress.yaml

--- a/apps/base/gatus/gatus-authentik-oauth.secret.yaml.template
+++ b/apps/base/gatus/gatus-authentik-oauth.secret.yaml.template
@@ -3,5 +3,7 @@
 # From gitops-homelab/ with SOPS_AGE_KEY_FILE set:
 #   just gatus-authentik-oauth
 #
-# Then sync client-secret into Authentik (Provider for Gatus) if the blueprint
-# was already applied with the placeholder.
+# Do NOT paste the secret into the Authentik UI — a blueprint reconcile would
+# overwrite it again. Instead mirror the same client-secret into the private repo
+# (apps/overlays/main/authentik-private/oidc-client-secrets.secret.yaml, key
+# gatus-client-secret); the blueprint reads it from there via !Env.

--- a/apps/base/linkding/linkding-authentik-oauth.secret.yaml.template
+++ b/apps/base/linkding/linkding-authentik-oauth.secret.yaml.template
@@ -3,5 +3,7 @@
 # From gitops-homelab/ with SOPS_AGE_KEY_FILE set:
 #   just linkding-authentik-oauth
 #
-# Then sync client-secret into Authentik (Provider for Linkding) if the blueprint
-# was already applied with the placeholder.
+# Do NOT paste the secret into the Authentik UI — a blueprint reconcile would
+# overwrite it again. Instead mirror the same client-secret into the private repo
+# (apps/overlays/main/authentik-private/oidc-client-secrets.secret.yaml, key
+# linkding-client-secret); the blueprint reads it from there via !Env.


### PR DESCRIPTION
Behebt den Linkding-Login: 500 am `/oidc/callback/`, danach 400 beim Reload (verbrauchter `state`).

## Ursache

Der Token-Endpoint antwortete mit `invalid_client`. Die Blueprints hatten `client_secret` als Platzhalter fest im YAML — jeder Reconcile schrieb den Platzhalter in den Authentik-Provider, zuletzt am 12.07. Der manuelle Nachtrag des echten Secrets in der UI hielt jeweils nur bis zum nächsten Reconcile.

| App | App-Secret | in Authentik |
|---|---|---|
| linkding | 44 Zeichen | `<placeholder-change-me>` |
| dawarich | 44 Zeichen | `<placeholder-change-me>` |

## Änderungen

**Secrets** — alle sechs Blueprints lesen `client_secret` per `!Env` aus `authentik-oidc-client-secrets`, das der Worker als Env bekommt (nur er wendet Blueprints an). Fehlt die Variable, schlägt der Blueprint fehl statt ein leeres Secret zu schreiben. Scalar-Form `!Env VAR` statt `!Env [VAR]`: der Sequence-Zweig im Loader greift zwingend auf `node.value[1]` zu.

**Identifier-Drift** — vier Blueprints identifizierten ihren Provider über `name` statt `client_id`. Der Name ist aber ein Attribut, das der Blueprint selbst setzt; weicht er ab, wird aus dem Update ein Create und läuft in den Unique-Constraint. Alle vier schlugen still fehl. gatus hatte zusätzlich die falsche client_id. Attribute sind an den Live-Zustand angeglichen, damit der erste Apply ein No-Op ist — u.a. wäre bei teslamate sonst eine Redirect-URI gelöscht und über den abweichenden Slug eine zweite Application angelegt worden.

**Ausrollung** — grafana und teslamate-grafana waren in keiner kustomization und keiner `blueprints.configMaps`-Liste, also gar nicht deployed.

**`.sops.yaml`** — Recipient war seit dem History-Rewrite `REMOVED_BY_HISTORY_REWRITE`, konnte also keine neuen Secrets verschlüsseln.

## Verifiziert

- `!Env` löst im Worker korrekt auf (Sentinel-Test)
- alle sechs Blueprints validieren gegen die Live-DB (vorher 4 von 6 mit Unique-Constraint-Fehler)
- `just validate` grün

## Reihenfolge

**kreativmonkey/homelab-gitops-private#8 muss zuerst mergen** — sonst startet der Worker mit `PLACEHOLDER` und schreibt den in die Provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)