### PR TITLE
refactor(authentik): OIDC-Secrets per envFrom statt Eintrag pro App

### DIFF
--- a/apps/base/authentik/helmrelease.yaml
+++ b/apps/base/authentik/helmrelease.yaml
@@ -103,40 +103,16 @@ spec:
     worker:
       # OIDC client secrets for the blueprints above. Only the worker applies
       # blueprints, so only it needs them. The blueprints read these via
-      # `!Env [...]`; if a variable is missing the blueprint fails instead of
+      # `!Env NAME`; if a variable is missing the blueprint fails instead of
       # writing an empty secret into Authentik.
-      # Secret comes from the private repo (apps/overlays/main/authentik-private).
-      env:
-        - name: OIDC_LINKDING_CLIENT_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: authentik-oidc-client-secrets
-              key: linkding-client-secret
-        - name: OIDC_DAWARICH_CLIENT_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: authentik-oidc-client-secrets
-              key: dawarich-client-secret
-        - name: OIDC_GATUS_CLIENT_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: authentik-oidc-client-secrets
-              key: gatus-client-secret
-        - name: OIDC_GRAFANA_CLIENT_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: authentik-oidc-client-secrets
-              key: grafana-client-secret
-        - name: OIDC_PAPERLESS_CLIENT_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: authentik-oidc-client-secrets
-              key: paperless-client-secret
-        - name: OIDC_TESLAMATE_GRAFANA_CLIENT_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: authentik-oidc-client-secrets
-              key: teslamate-grafana-client-secret
+      #
+      # Whole Secret via envFrom, so adding an app means adding one key in the
+      # private repo (apps/overlays/main/authentik-private) — no change here and
+      # no worker rollout. The keys are already named OIDC_<APP>_CLIENT_SECRET;
+      # envFrom silently skips keys that are not valid env var names.
+      envFrom:
+        - secretRef:
+            name: authentik-oidc-client-secrets
       # 2026-06-09: limit raised 2Gi→4Gi (OOMKilled, exit 137)
       #   Previous pod ran 3.5d then OOM. DockerException spam
       #   (outpost_service_connection_monitor → Docker) on Talos


### PR DESCRIPTION
Schritt 1b von 3 für den `envFrom`-Refactor. Setzt kreativmonkey/homelab-gitops-private#9 voraus (gemergt und ausgerollt).

Jede App brauchte bisher einen eigenen `env`-Eintrag mit `secretKeyRef` — eine neue OIDC-App war damit immer auch eine HelmRelease-Änderung samt Worker-Rollout, und der Block wächst linear mit der Zahl der Apps. Bei 26 noch nicht migrierten Applications wären das 26 weitere Blöcke.

Das ganze Secret kommt jetzt per `envFrom`. Eine neue App ist damit **ein Key im privaten Repo plus der Blueprint** — hier ändert sich nichts mehr.

Voraussetzung war das Key-Rename in Schritt 1a: `envFrom` exportiert nur gültige Env-Namen und überspringt alle anderen still. Die alten dash-style Keys liegen noch parallel im Secret und werden in Schritt 1c entfernt.

## Test

Gerendert geprüft (`helm template` mit den echten Values):
- Worker: `authentik` + `authentik-oidc-client-secrets`
- Server: nur `authentik` — bekommt die Secrets korrekt **nicht**, er wendet keine Blueprints an

`just validate` grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)