### PR TITLE
feat(authentik): Blueprint-Fehler überwachen

### DIFF
--- a/apps/base/authentik/blueprint-check.cronjob.yaml
+++ b/apps/base/authentik/blueprint-check.cronjob.yaml
@@ -1,0 +1,79 @@
+# Watchdog for Authentik blueprint reconciliation.
+#
+# A blueprint that fails to apply is invisible otherwise: Flux reports Ready
+# (the ConfigMap rolled out fine), the apply task raises no exception, and no
+# Authentik event is created — the failure only lives in the BlueprintInstance
+# status. Two blueprints sat in `error` for weeks that way, which is how the
+# Linkding login stayed broken.
+#
+# Runs `ak shell` against the same database as the worker, so it needs no API
+# token and no RBAC. Exits non-zero on any blueprint that is not `successful`;
+# the failed Job is what the AuthentikBlueprintCheckFailed alert fires on.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: authentik-blueprint-check
+  namespace: authentik
+  labels:
+    app.kubernetes.io/name: authentik
+    app.kubernetes.io/component: blueprint-check
+spec:
+  schedule: "17 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  # Keep failed runs around — the alert reads the Job, and the pod logs name
+  # which blueprint broke.
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 600
+  jobTemplate:
+    spec:
+      # No retries: a real failure should stay failed and visible, not be
+      # papered over by a lucky rerun.
+      backoffLimit: 0
+      ttlSecondsAfterFinished: 86400
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: authentik
+            app.kubernetes.io/component: blueprint-check
+        spec:
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: check
+              # Must track the chart version in helmrelease.yaml — a mismatched
+              # image talks to a different Django schema. Renovate keeps both on
+              # the same pin (see renovate.json).
+              image: ghcr.io/goauthentik/server:2026.5.6
+              args:
+                - shell
+                - -c
+                - |
+                  from authentik.blueprints.models import BlueprintInstance
+                  bad = [(b.name, b.status) for b in BlueprintInstance.objects.exclude(status="successful")]
+                  total = BlueprintInstance.objects.count()
+                  if bad:
+                      for name, status in sorted(bad):
+                          print(f"BLUEPRINT NOT OK: {name} -> {status}")
+                      raise SystemExit(1)
+                  print(f"OK: all {total} blueprints successful")
+              # Database and Redis credentials, same Secret the chart gives the
+              # server and worker.
+              envFrom:
+                - secretRef:
+                    name: authentik
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 256Mi
+                limits:
+                  memory: 1Gi

--- a/apps/base/authentik/kustomization.yaml
+++ b/apps/base/authentik/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - media-pvc.yaml
   - helmrelease.yaml
   - ingress.yaml
+  - blueprint-check.cronjob.yaml

--- a/apps/base/monitoring/rules/authentik-vmrule.yaml
+++ b/apps/base/monitoring/rules/authentik-vmrule.yaml
@@ -1,0 +1,44 @@
+# Authentik alerts. The `homelab_owner: platform` alert label routes to
+# ntfy + n8n triage.
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMRule
+metadata:
+  name: homelab-authentik
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/part-of: homelab-monitoring
+    homelab/owner: platform
+spec:
+  groups:
+    - name: homelab.platform.authentik
+      interval: 60s
+      rules:
+        - alert: AuthentikBlueprintCheckFailed
+          # The hourly CronJob in the authentik namespace exits non-zero when a
+          # blueprint is not `successful`. Nothing else surfaces this: the apply
+          # task swallows the error, writes no event, and Flux still reports
+          # Ready because the ConfigMap itself rolled out fine.
+          expr: |
+            kube_job_status_failed{namespace="authentik", job_name=~"authentik-blueprint-check.*"} > 0
+          for: 5m
+          labels:
+            severity: warning
+            cluster: homelab
+            homelab_owner: platform
+          annotations:
+            summary: "Authentik: Blueprint nicht angewendet"
+            description: "Mindestens ein Blueprint steht nicht auf successful. Betroffener Provider wird nicht mehr deklarativ verwaltet — Client-Secrets und Redirect-URIs können auseinanderlaufen, im Zweifel bricht der OIDC-Login. Namen im Job-Log: kubectl -n authentik logs job/<name>"
+
+        - alert: AuthentikBlueprintCheckStale
+          # The watchdog itself going silent must not look like "all good".
+          expr: |
+            time() - kube_cronjob_status_last_successful_time{namespace="authentik", cronjob="authentik-blueprint-check"} > 10800
+            or absent(kube_cronjob_status_last_successful_time{namespace="authentik", cronjob="authentik-blueprint-check"})
+          for: 15m
+          labels:
+            severity: warning
+            cluster: homelab
+            homelab_owner: platform
+          annotations:
+            summary: "Authentik: Blueprint-Check läuft nicht mehr"
+            description: "Der stündliche Blueprint-Check war seit über 3 Stunden nicht erfolgreich (oder die Metrik fehlt ganz). Blueprint-Fehler bleiben damit wieder unbemerkt."

--- a/apps/base/monitoring/rules/kustomization.yaml
+++ b/apps/base/monitoring/rules/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - blackbox-vmrule.yaml
   - truenas-vmrule.yaml
   - iscsi-storage-vmrule.yaml
+  - authentik-vmrule.yaml

--- a/renovate.json
+++ b/renovate.json
@@ -141,10 +141,12 @@
       "enabled": false
     },
     {
-      "description": "Authentik: CalVer, gepinnt auf 2026.5.x — für ein Upgrade den Pin anheben",
+      "description": "Authentik: CalVer, gepinnt auf 2026.5.x — für ein Upgrade den Pin anheben. Chart und Server-Image gemeinsam, weil der Blueprint-Check-CronJob mit dem Image gegen dieselbe DB spricht wie der Worker — ein Versatz bedeutet ein anderes Django-Schema.",
       "matchDepNames": [
-        "authentik"
+        "authentik",
+        "ghcr.io/goauthentik/server"
       ],
+      "groupName": "authentik",
       "allowedVersions": "/^2026\\.5\\./"
     },
     {


### PR DESCRIPTION
Schritt 2 des Ausbaus. Schließt die Lücke, durch die der Linkding-Login wochenlang kaputt bleiben konnte.

## Warum

Ein fehlgeschlagener Blueprint ist derzeit unsichtbar:
- Flux meldet `Ready` — die ConfigMap ist ja sauber ausgerollt
- der `apply_blueprint`-Task wirft **keine** Exception (`authentik_tasks_errors_total` steht für ihn auf 0, obwohl heute zwei Blueprints fehlschlugen)
- ein Authentik-Event entsteht nicht, die eingebauten Notification-Rules haben also nichts, worauf sie reagieren könnten

Der Fehler lebt ausschließlich im `status`-Feld der `BlueprintInstance`. Gatus und Paperless standen so wochenlang auf `error`.

## Wie

Stündlicher CronJob, der den Status prüft und ungleich null exitet, sobald ein Blueprint nicht `successful` ist. Er läuft mit dem authentik-Image per `ak shell` gegen dieselbe DB wie der Worker — **kein API-Token, kein zusätzliches Secret, kein RBAC**. Die Namen der betroffenen Blueprints stehen im Job-Log.

Dazu zwei Alerts in einer eigenen VMRule, im Muster der bestehenden Regeln (`homelab_owner: platform` → ntfy):
- `AuthentikBlueprintCheckFailed` auf den fehlgeschlagenen Job
- `AuthentikBlueprintCheckStale`, damit ein stumm gewordener Wächter nicht wie „alles gut" aussieht

`renovate.json`: Image-Tag und Chart-Version müssen zusammenpassen, sonst spricht der Check gegen ein anderes Django-Schema. Beide hängen jetzt an demselben Pin in einer Gruppe.

## Tests gegen den Live-Cluster

| Test | Ergebnis |
|---|---|
| Positivfall als eigenständiger Job | `OK: all 34 blueprints successful`, Job `Complete` |
| Negativfall (invertierter Filter) | Job `Failed`, `status.failed=1`, betroffene Namen im Log |
| `kube_job_status_failed` für den Job | liefert `1` — die Alert-Expression matcht |
| `kube_cronjob_status_last_successful_time` | wird von kube-state-metrics geliefert (2 bestehende CronJobs) |
| `just validate` | grün |

Testjobs wurden wieder entfernt.

**Beim Rollout** triggere ich einmal manuell einen Job, damit `last_successful_time` sofort existiert — sonst könnte der Stale-Alert im Fenster bis zum ersten regulären Lauf (`17 * * * *`) kurz anschlagen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)