### PR TITLE
feat(authentik): Goloom-Provider per Blueprint verwalten

### DIFF
--- a/apps/base/authentik/blueprints/goloom-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/goloom-oauth.configmap.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authentik-goloom-blueprint
+  namespace: authentik
+  labels:
+    app.kubernetes.io/part-of: authentik
+data:
+  goloom.yaml: |
+    version: 1
+    metadata:
+      name: Homelab Goloom OIDC
+      labels:
+        blueprints.goauthentik.io/description: OAuth2 provider and application for Goloom
+    entries:
+      - model: authentik_providers_oauth2.oauth2provider
+        id: goloom-provider
+        # Match on client_id, not name: the name is an attribute the blueprint
+        # itself sets, so any rename turns the update into a create and hits the
+        # unique constraint.
+        identifiers:
+          client_id: puyEXnuOwuIWyTaTMI0Cx290jlfbklmNJFKe4xGJ
+        attrs:
+          name: Provider for Goloom
+          client_type: confidential
+          client_id: puyEXnuOwuIWyTaTMI0Cx290jlfbklmNJFKe4xGJ
+          # Injected into the worker from the authentik-oidc-client-secrets Secret,
+          # which mirrors goloom secret goloom-app (key OIDC_CLIENT_SECRET).
+          # Never hardcode it here: every reconcile would overwrite the real
+          # secret in Authentik and break the login with invalid_client.
+          client_secret: !Env OIDC_GOLOOM_CLIENT_SECRET
+          # Every attribute below mirrors the live provider, which was created by
+          # hand. Keeps the first apply a no-op — change deliberately, not as a
+          # side effect of adopting this into GitOps.
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          signing_key: null
+          redirect_uris:
+            - matching_mode: strict
+              url: https://goloom.f4mily.net/v1/oauth/oidc/callback
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+      - model: authentik_core.application
+        identifiers:
+          slug: goloom
+        attrs:
+          name: Goloom
+          slug: goloom
+          provider: !KeyOf goloom-provider
+          group: Media
+          launch_url: https://goloom.f4mily.net
+          meta_launch_url: https://goloom.f4mily.net

--- a/apps/base/authentik/helmrelease.yaml
+++ b/apps/base/authentik/helmrelease.yaml
@@ -68,6 +68,7 @@ spec:
         - authentik-dawarich-blueprint
         - authentik-grafana-blueprint
         - authentik-teslamate-grafana-blueprint
+        - authentik-goloom-blueprint
     server:
       ingress:
         enabled: false

--- a/apps/base/authentik/kustomization.yaml
+++ b/apps/base/authentik/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - blueprints/dawarich-oauth.configmap.yaml
   - blueprints/grafana-oauth.configmap.yaml
   - blueprints/teslamate-grafana-oauth.configmap.yaml
+  - blueprints/goloom-oauth.configmap.yaml
   - media-pvc.yaml
   - helmrelease.yaml
   - ingress.yaml


### PR DESCRIPTION
Schritt 3b — erster der 26 bisher manuell gepflegten Provider, als Muster für die weiteren.

Setzt kreativmonkey/homelab-gitops-private#11 voraus (Key im Secret, bereits ausgerollt).

## Muster

- `identifiers` auf `client_id` — nicht auf `name`, sonst wird aus dem Update ein Create
- `client_secret` per `!Env`, nie hartkodiert
- **alle** Attribute am Live-Zustand ausgerichtet, damit der erste Apply ein No-Op ist

Abgeglichen: Flow, Invalidation-Flow, `signing_key` (null), Redirect-URI, Scope-Mappings sowie Name, Slug, Gruppe (`Media`) und Launch-URL der Application. Das App-Secret in `goloom/goloom-app` stimmt mit dem Provider überein (128 Zeichen, identisch) — der Blueprint schreibt denselben Wert, den die App ohnehin sendet.

## Test

Gegen die Live-DB validiert: `VALIDATE: True`, `!Env` löst auf (Sentinel). `just validate` grün.

## Nach dem Merge

Worker-Restart nötig: `envFrom` löst Secrets beim Pod-Start auf, neue Keys erreichen laufende Pods nicht. Das korrigiert eine zu optimistische Formulierung in #651 — der Refactor spart die HelmRelease-Änderung, nicht den Restart. Ohne Restart fällt der Blueprint ins Fail-Safe: sichtbar (der Wächter meldet es), aber unnötig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)