### PR TITLE
feat(authentik): Linkding und Dawarich ohne Consent-Screen

### DIFF
--- a/apps/base/authentik/blueprints/dawarich-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/dawarich-oauth.configmap.yaml
@@ -28,7 +28,7 @@ data:
           grant_types:
             - authorization_code
             - refresh_token
-          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-explicit-consent]]
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
           invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
           signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
           encryption_key: null

--- a/apps/base/authentik/blueprints/linkding-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/linkding-oauth.configmap.yaml
@@ -28,7 +28,7 @@ data:
           grant_types:
             - authorization_code
             - refresh_token
-          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-explicit-consent]]
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
           invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
           signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
           encryption_key: null


### PR DESCRIPTION
Beide liefen auf `default-provider-authorization-explicit-consent`, also mit Zustimmungsdialog bei **jedem** Login. Für eigene Dienste im Homelab ist das reine Reibung — die übrigen Provider (gatus, paperless, teslamate-grafana, goloom) nutzen längst `implicit-consent`.

| Provider | vorher | nachher |
|---|---|---|
| linkding | explicit-consent | implicit-consent |
| dawarich | explicit-consent | implicit-consent |
| grafana | explicit-consent | **unverändert** |

**Grafana bleibt bewusst außen vor:** dort war `explicit` der gepflegte Live-Zustand, den der Blueprint in #650 gerade erst abgebildet hat. Das umzustellen ist eine eigene Entscheidung, kein Nebeneffekt dieses PRs — sag Bescheid, wenn es mit soll.

Zur Einordnung: `implicit-consent` überspringt den Zustimmungsdialog, die Authentifizierung selbst und die Zugriffssteuerung über Application-Bindings bleiben unverändert.

## Test

Beide Blueprints gegen die Live-DB validiert (`VALIDATE: True`, Flow auflösbar). `just validate` grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)