### PR TITLE
feat(authentik): sieben weitere Provider per Blueprint verwalten

### DIFF
--- a/apps/base/authentik/blueprints/kavita-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/kavita-oauth.configmap.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authentik-kavita-blueprint
+  namespace: authentik
+  labels:
+    app.kubernetes.io/part-of: authentik
+data:
+  kavita.yaml: |
+    version: 1
+    metadata:
+      name: Homelab Kavita OIDC
+      labels:
+        blueprints.goauthentik.io/description: OAuth2 provider and application for Kavita
+    entries:
+      - model: authentik_providers_oauth2.oauth2provider
+        id: kavita-provider
+        # Match on client_id, not name: the name is an attribute the blueprint
+        # itself sets, so any rename turns the update into a create and hits the
+        # unique constraint.
+        identifiers:
+          client_id: Hnu5Ga56tXciE5q5I9qCZOa7eYHw2uD0n5IT9jsk
+        attrs:
+          name: Provider for Kavita
+          client_type: confidential
+          client_id: Hnu5Ga56tXciE5q5I9qCZOa7eYHw2uD0n5IT9jsk
+          # Injected into the worker from the authentik-oidc-client-secrets Secret.
+          # Never hardcode it here: every reconcile would overwrite the real
+          # secret in Authentik and break the login with invalid_client.
+          client_secret: !Env OIDC_KAVITA_CLIENT_SECRET
+          # Attributes mirror the live provider, which was created by hand.
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+          redirect_uris:
+            - matching_mode: strict
+              url: https://books.f4mily.net/signin-oidc
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+      - model: authentik_core.application
+        identifiers:
+          slug: kavita
+        attrs:
+          name: Kavita
+          slug: kavita
+          provider: !KeyOf kavita-provider
+          group: Media
+          launch_url: https://books.f4mily.net
+          meta_launch_url: https://books.f4mily.net

--- a/apps/base/authentik/blueprints/kite-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/kite-oauth.configmap.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authentik-kite-blueprint
+  namespace: authentik
+  labels:
+    app.kubernetes.io/part-of: authentik
+data:
+  kite.yaml: |
+    version: 1
+    metadata:
+      name: Homelab Kite OIDC
+      labels:
+        blueprints.goauthentik.io/description: OAuth2 provider and application for Kite
+    entries:
+      - model: authentik_providers_oauth2.oauth2provider
+        id: kite-provider
+        # Match on client_id, not name: the name is an attribute the blueprint
+        # itself sets, so any rename turns the update into a create and hits the
+        # unique constraint.
+        identifiers:
+          client_id: eyTHSl7Cgi6ThIyGWSi7RE63m4bAHPOl7axQH7e3
+        attrs:
+          name: Provider for Kite
+          client_type: confidential
+          client_id: eyTHSl7Cgi6ThIyGWSi7RE63m4bAHPOl7axQH7e3
+          # Injected into the worker from the authentik-oidc-client-secrets Secret.
+          # Never hardcode it here: every reconcile would overwrite the real
+          # secret in Authentik and break the login with invalid_client.
+          client_secret: !Env OIDC_KITE_CLIENT_SECRET
+          # Attributes mirror the live provider, which was created by hand.
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+          redirect_uris:
+            - matching_mode: strict
+              url: https://kite.cluster.f4mily.net/api/auth/callback
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+      - model: authentik_core.application
+        identifiers:
+          slug: kite
+        attrs:
+          name: Kite
+          slug: kite
+          provider: !KeyOf kite-provider
+          group: Administration
+          launch_url: https://kite.cluster.f4mily.net
+          meta_launch_url: https://kite.cluster.f4mily.net

--- a/apps/base/authentik/blueprints/linkwarden-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/linkwarden-oauth.configmap.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authentik-linkwarden-blueprint
+  namespace: authentik
+  labels:
+    app.kubernetes.io/part-of: authentik
+data:
+  linkwarden.yaml: |
+    version: 1
+    metadata:
+      name: Homelab Linkwarden OIDC
+      labels:
+        blueprints.goauthentik.io/description: OAuth2 provider and application for Linkwarden
+    entries:
+      - model: authentik_providers_oauth2.oauth2provider
+        id: linkwarden-provider
+        # Match on client_id, not name: the name is an attribute the blueprint
+        # itself sets, so any rename turns the update into a create and hits the
+        # unique constraint.
+        identifiers:
+          client_id: 65q5IWebzPxkDYjaFOI5gJufwFpeTcN9YLUC6FA4
+        attrs:
+          name: Provider for Linkwarden
+          client_type: confidential
+          client_id: 65q5IWebzPxkDYjaFOI5gJufwFpeTcN9YLUC6FA4
+          # Injected into the worker from the authentik-oidc-client-secrets Secret.
+          # Never hardcode it here: every reconcile would overwrite the real
+          # secret in Authentik and break the login with invalid_client.
+          client_secret: !Env OIDC_LINKWARDEN_CLIENT_SECRET
+          # Attributes mirror the live provider, which was created by hand.
+          # Abweichend vom Live-Zustand bewusst implicit statt explicit:
+          # Zustimmungsdialog fuer eigene Dienste, siehe #654.
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+          redirect_uris:
+            - matching_mode: strict
+              url: http://linkwarden.f4mily.net/api/v1/auth/callback/authentik
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+      - model: authentik_core.application
+        identifiers:
+          slug: linkwarden
+        attrs:
+          name: Linkwarden
+          slug: linkwarden
+          provider: !KeyOf linkwarden-provider
+          group: Media
+          # Live-Provider hat keine Launch-URL gesetzt. Bewusst weggelassen
+          # statt leer gesetzt: ein leerer Wert wird zu None und scheitert am
+          # Serializer; weglassen laesst das Feld unveraendert.

--- a/apps/base/authentik/blueprints/outline-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/outline-oauth.configmap.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authentik-outline-blueprint
+  namespace: authentik
+  labels:
+    app.kubernetes.io/part-of: authentik
+data:
+  outline.yaml: |
+    version: 1
+    metadata:
+      name: Homelab outline OIDC
+      labels:
+        blueprints.goauthentik.io/description: OAuth2 provider and application for outline
+    entries:
+      - model: authentik_providers_oauth2.oauth2provider
+        id: outline-provider
+        # Match on client_id, not name: the name is an attribute the blueprint
+        # itself sets, so any rename turns the update into a create and hits the
+        # unique constraint.
+        identifiers:
+          client_id: nj4Pmp5zMftJEESaFBZAUmwWRbqtSBJaoKzNAmen
+        attrs:
+          name: Provider for outline
+          client_type: confidential
+          client_id: nj4Pmp5zMftJEESaFBZAUmwWRbqtSBJaoKzNAmen
+          # Injected into the worker from the authentik-oidc-client-secrets Secret.
+          # Never hardcode it here: every reconcile would overwrite the real
+          # secret in Authentik and break the login with invalid_client.
+          client_secret: !Env OIDC_OUTLINE_CLIENT_SECRET
+          # Attributes mirror the live provider, which was created by hand.
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          signing_key: null
+          redirect_uris:
+            - matching_mode: strict
+              url: https://outline.f4mily.net/auth/oidc.callback
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+      - model: authentik_core.application
+        identifiers:
+          slug: outline
+        attrs:
+          name: outline
+          slug: outline
+          provider: !KeyOf outline-provider
+          group: Dokumente
+          launch_url: https://outline.f4mily.net
+          meta_launch_url: https://outline.f4mily.net

--- a/apps/base/authentik/blueprints/pcm-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/pcm-oauth.configmap.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authentik-pcm-blueprint
+  namespace: authentik
+  labels:
+    app.kubernetes.io/part-of: authentik
+data:
+  pcm.yaml: |
+    version: 1
+    metadata:
+      name: Homelab PCM OIDC
+      labels:
+        blueprints.goauthentik.io/description: OAuth2 provider and application for PCM
+    entries:
+      - model: authentik_providers_oauth2.oauth2provider
+        id: pcm-provider
+        # Match on client_id, not name: the name is an attribute the blueprint
+        # itself sets, so any rename turns the update into a create and hits the
+        # unique constraint.
+        identifiers:
+          client_id: LuP7Fms1jlDM46ubR99rTCoaUdpCA7ZzFfcsSTSc
+        attrs:
+          name: Provider for PCM
+          client_type: confidential
+          client_id: LuP7Fms1jlDM46ubR99rTCoaUdpCA7ZzFfcsSTSc
+          # Injected into the worker from the authentik-oidc-client-secrets Secret.
+          # Never hardcode it here: every reconcile would overwrite the real
+          # secret in Authentik and break the login with invalid_client.
+          client_secret: !Env OIDC_PCM_CLIENT_SECRET
+          # Attributes mirror the live provider, which was created by hand.
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+          redirect_uris:
+            - matching_mode: strict
+              url: http://192.168.10.231:8000/api/auth/callback/oidc
+            - matching_mode: strict
+              url: https://pcm.srv1.f4mily.net/api/auth/callback/oidc
+            - matching_mode: strict
+              url: https://pcm.f4mily.net/api/auth/callback/oidc
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+      - model: authentik_core.application
+        identifiers:
+          slug: pcm
+        attrs:
+          name: PCM
+          slug: pcm
+          provider: !KeyOf pcm-provider
+          launch_url: https://pcm.f4mily.net
+          meta_launch_url: https://pcm.f4mily.net

--- a/apps/base/authentik/blueprints/sparky-fitness-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/sparky-fitness-oauth.configmap.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authentik-sparky-fitness-blueprint
+  namespace: authentik
+  labels:
+    app.kubernetes.io/part-of: authentik
+data:
+  sparky-fitness.yaml: |
+    version: 1
+    metadata:
+      name: Homelab SparkyFitness OIDC
+      labels:
+        blueprints.goauthentik.io/description: OAuth2 provider and application for SparkyFitness
+    entries:
+      - model: authentik_providers_oauth2.oauth2provider
+        id: sparky-fitness-provider
+        # Match on client_id, not name: the name is an attribute the blueprint
+        # itself sets, so any rename turns the update into a create and hits the
+        # unique constraint.
+        identifiers:
+          client_id: 2JkhxH9hj90BLQNgNKq9uXUCtlr7ZNWhgmg6O64N
+        attrs:
+          name: Provider for SparkyFitness
+          client_type: confidential
+          client_id: 2JkhxH9hj90BLQNgNKq9uXUCtlr7ZNWhgmg6O64N
+          # Injected into the worker from the authentik-oidc-client-secrets Secret.
+          # Never hardcode it here: every reconcile would overwrite the real
+          # secret in Authentik and break the login with invalid_client.
+          client_secret: !Env OIDC_SPARKY_FITNESS_CLIENT_SECRET
+          # Attributes mirror the live provider, which was created by hand.
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          signing_key: null
+          redirect_uris:
+            - matching_mode: strict
+              url: https://fitness.f4mily.net/api/auth/sso/callback/authentik
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+      - model: authentik_core.application
+        identifiers:
+          slug: sparky-fitness
+        attrs:
+          name: SparkyFitness
+          slug: sparky-fitness
+          provider: !KeyOf sparky-fitness-provider
+          group: Tools
+          launch_url: https://fitness.f4mily.net
+          meta_launch_url: https://fitness.f4mily.net

--- a/apps/base/authentik/blueprints/tandoor-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/tandoor-oauth.configmap.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authentik-tandoor-blueprint
+  namespace: authentik
+  labels:
+    app.kubernetes.io/part-of: authentik
+data:
+  tandoor.yaml: |
+    version: 1
+    metadata:
+      name: Homelab Tandoor OIDC
+      labels:
+        blueprints.goauthentik.io/description: OAuth2 provider and application for Tandoor
+    entries:
+      - model: authentik_providers_oauth2.oauth2provider
+        id: tandoor-provider
+        # Match on client_id, not name: the name is an attribute the blueprint
+        # itself sets, so any rename turns the update into a create and hits the
+        # unique constraint.
+        identifiers:
+          client_id: o8dj4CSXU3jqhu11rm4SplIZQGnDziCsOpyngJzg
+        attrs:
+          name: Provider for Tandoor
+          client_type: confidential
+          client_id: o8dj4CSXU3jqhu11rm4SplIZQGnDziCsOpyngJzg
+          # Injected into the worker from the authentik-oidc-client-secrets Secret.
+          # Never hardcode it here: every reconcile would overwrite the real
+          # secret in Authentik and break the login with invalid_client.
+          client_secret: !Env OIDC_TANDOOR_CLIENT_SECRET
+          # Attributes mirror the live provider, which was created by hand.
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+          redirect_uris:
+            - matching_mode: strict
+              url: https://recipes.f4mily.net/accounts/oidc/authentik/login/callback/
+            - matching_mode: strict
+              url: https://rezepte.f4mily.net/accounts/oidc/authentik/login/callback/
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+      - model: authentik_core.application
+        identifiers:
+          slug: tandoor
+        attrs:
+          name: Tandoor
+          slug: tandoor
+          provider: !KeyOf tandoor-provider
+          group: Tools
+          launch_url: https://rezepte.f4mily.net
+          meta_launch_url: https://rezepte.f4mily.net

--- a/apps/base/authentik/helmrelease.yaml
+++ b/apps/base/authentik/helmrelease.yaml
@@ -69,6 +69,13 @@ spec:
         - authentik-grafana-blueprint
         - authentik-teslamate-grafana-blueprint
         - authentik-goloom-blueprint
+        - authentik-kavita-blueprint
+        - authentik-kite-blueprint
+        - authentik-linkwarden-blueprint
+        - authentik-pcm-blueprint
+        - authentik-sparky-fitness-blueprint
+        - authentik-tandoor-blueprint
+        - authentik-outline-blueprint
     server:
       ingress:
         enabled: false

--- a/apps/base/authentik/kustomization.yaml
+++ b/apps/base/authentik/kustomization.yaml
@@ -10,6 +10,13 @@ resources:
   - blueprints/grafana-oauth.configmap.yaml
   - blueprints/teslamate-grafana-oauth.configmap.yaml
   - blueprints/goloom-oauth.configmap.yaml
+  - blueprints/kavita-oauth.configmap.yaml
+  - blueprints/kite-oauth.configmap.yaml
+  - blueprints/linkwarden-oauth.configmap.yaml
+  - blueprints/pcm-oauth.configmap.yaml
+  - blueprints/sparky-fitness-oauth.configmap.yaml
+  - blueprints/tandoor-oauth.configmap.yaml
+  - blueprints/outline-oauth.configmap.yaml
   - media-pvc.yaml
   - helmrelease.yaml
   - ingress.yaml


### PR DESCRIPTION
Schritt 3, zweite Charge. Setzt kreativmonkey/homelab-gitops-private#12 voraus (Keys ausgerollt, 14 im Secret).

kavita, kite, linkwarden, pcm, sparkyfitness, tandoor und outline nach dem Goloom-Muster: `identifiers` auf `client_id`, `client_secret` per `!Env`, und alle Attribute **aus der Live-DB generiert** statt von Hand geschrieben — bei sieben Providern der einzige Weg, sie treu abzubilden.

## Eine bewusste Abweichung

**linkwarden** bekommt `implicit` statt `explicit` consent, entgegen dem Live-Zustand — der Zustimmungsdialog soll für eigene Dienste weg (wie #654). Alles andere ist ein No-Op.

Bei linkwarden ist außerdem `meta_launch_url` im Bestand leer. Ein leerer Wert wird zu `None` und scheitert am Serializer, deshalb sind die beiden Zeilen dort weggelassen — das lässt das Feld unverändert. Genau daran ist die erste Fassung gescheitert; der eigentliche Fehler war im Log-Serializer verborgen, der über das unaufgelöste `!KeyOf` stolperte.

## Bewusst nicht dabei

| App | Grund |
|---|---|
| audiobookshelf, forgejo, immich, nextcloud | referenzieren eigene Scope-Mappings (`audiobookshelf-group-mapping`, `gitea`, `immich_quota`, `nextcloud`), die selbst nicht deklarativ verwaltet sind — die gehören samt Expression ins Blueprint, sonst bricht es, sobald jemand das Mapping löscht |
| teslamate-dashboard | ist ein **Proxy**- statt OAuth2-Provider und passt nicht in dieses Schema |

## Test

Alle acht Blueprints (inkl. goloom) gegen die Live-DB validiert: `VALIDATE: True`. `just validate` grün.

Nach dem Merge: Worker-Restart plus Blueprint-Discovery, sonst werden die neuen ConfigMaps erst beim nächsten periodischen Lauf entdeckt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)