### PR TITLE
feat(authentik): alle Provider auf explicit consent

### DIFF
--- a/apps/base/authentik/blueprints/dawarich-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/dawarich-oauth.configmap.yaml
@@ -28,7 +28,7 @@ data:
           grant_types:
             - authorization_code
             - refresh_token
-          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-explicit-consent]]
           invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
           signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
           encryption_key: null

--- a/apps/base/authentik/blueprints/gatus-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/gatus-oauth.configmap.yaml
@@ -29,7 +29,7 @@ data:
           # Never hardcode it here: every reconcile would overwrite the real
           # secret in Authentik and break the login with invalid_client.
           client_secret: !Env OIDC_GATUS_CLIENT_SECRET
-          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-explicit-consent]]
           invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
           signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
           encryption_key: null

--- a/apps/base/authentik/blueprints/goloom-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/goloom-oauth.configmap.yaml
@@ -32,7 +32,7 @@ data:
           # Every attribute below mirrors the live provider, which was created by
           # hand. Keeps the first apply a no-op — change deliberately, not as a
           # side effect of adopting this into GitOps.
-          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-explicit-consent]]
           invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
           signing_key: null
           redirect_uris:

--- a/apps/base/authentik/blueprints/grafana-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/grafana-oauth.configmap.yaml
@@ -29,9 +29,10 @@ data:
           # Never hardcode it here: every reconcile would overwrite the real
           # secret in Authentik and break the login with invalid_client.
           client_secret: !Env OIDC_GRAFANA_CLIENT_SECRET
-          # Flow and signing key mirror the live provider, which was maintained
-          # by hand while this blueprint never applied. Keeps the first apply a
-          # no-op; change deliberately, not as a side effect.
+          # signing_key mirrors the live provider, which was maintained by hand
+          # while this blueprint never applied. The flow is explicit-consent for
+          # every provider by policy — consent is stored for 4 weeks, so it is
+          # one dialog per app and month, not per login.
           authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-explicit-consent]]
           invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
           signing_key: null

--- a/apps/base/authentik/blueprints/kavita-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/kavita-oauth.configmap.yaml
@@ -29,7 +29,7 @@ data:
           # secret in Authentik and break the login with invalid_client.
           client_secret: !Env OIDC_KAVITA_CLIENT_SECRET
           # Attributes mirror the live provider, which was created by hand.
-          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-explicit-consent]]
           invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
           signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
           redirect_uris:

--- a/apps/base/authentik/blueprints/kite-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/kite-oauth.configmap.yaml
@@ -29,7 +29,7 @@ data:
           # secret in Authentik and break the login with invalid_client.
           client_secret: !Env OIDC_KITE_CLIENT_SECRET
           # Attributes mirror the live provider, which was created by hand.
-          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-explicit-consent]]
           invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
           signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
           redirect_uris:

--- a/apps/base/authentik/blueprints/linkding-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/linkding-oauth.configmap.yaml
@@ -28,7 +28,7 @@ data:
           grant_types:
             - authorization_code
             - refresh_token
-          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-explicit-consent]]
           invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
           signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
           encryption_key: null

--- a/apps/base/authentik/blueprints/linkwarden-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/linkwarden-oauth.configmap.yaml
@@ -29,9 +29,7 @@ data:
           # secret in Authentik and break the login with invalid_client.
           client_secret: !Env OIDC_LINKWARDEN_CLIENT_SECRET
           # Attributes mirror the live provider, which was created by hand.
-          # Abweichend vom Live-Zustand bewusst implicit statt explicit:
-          # Zustimmungsdialog fuer eigene Dienste, siehe #654.
-          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-explicit-consent]]
           invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
           signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
           redirect_uris:

--- a/apps/base/authentik/blueprints/outline-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/outline-oauth.configmap.yaml
@@ -29,7 +29,7 @@ data:
           # secret in Authentik and break the login with invalid_client.
           client_secret: !Env OIDC_OUTLINE_CLIENT_SECRET
           # Attributes mirror the live provider, which was created by hand.
-          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-explicit-consent]]
           invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
           signing_key: null
           redirect_uris:

--- a/apps/base/authentik/blueprints/paperless-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/paperless-oauth.configmap.yaml
@@ -30,7 +30,7 @@ data:
           # Never hardcode it here: every reconcile would overwrite the real
           # secret in Authentik and break the login with invalid_client.
           client_secret: !Env OIDC_PAPERLESS_CLIENT_SECRET
-          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-explicit-consent]]
           invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
           signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
           redirect_uris:

--- a/apps/base/authentik/blueprints/pcm-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/pcm-oauth.configmap.yaml
@@ -29,7 +29,7 @@ data:
           # secret in Authentik and break the login with invalid_client.
           client_secret: !Env OIDC_PCM_CLIENT_SECRET
           # Attributes mirror the live provider, which was created by hand.
-          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-explicit-consent]]
           invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
           signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
           redirect_uris:

--- a/apps/base/authentik/blueprints/sparky-fitness-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/sparky-fitness-oauth.configmap.yaml
@@ -29,7 +29,7 @@ data:
           # secret in Authentik and break the login with invalid_client.
           client_secret: !Env OIDC_SPARKY_FITNESS_CLIENT_SECRET
           # Attributes mirror the live provider, which was created by hand.
-          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-explicit-consent]]
           invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
           signing_key: null
           redirect_uris:

--- a/apps/base/authentik/blueprints/tandoor-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/tandoor-oauth.configmap.yaml
@@ -29,7 +29,7 @@ data:
           # secret in Authentik and break the login with invalid_client.
           client_secret: !Env OIDC_TANDOOR_CLIENT_SECRET
           # Attributes mirror the live provider, which was created by hand.
-          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-explicit-consent]]
           invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
           signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
           redirect_uris:

--- a/apps/base/authentik/blueprints/teslamate-grafana-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/teslamate-grafana-oauth.configmap.yaml
@@ -29,7 +29,7 @@ data:
           # Never hardcode it here: every reconcile would overwrite the real
           # secret in Authentik and break the login with invalid_client.
           client_secret: !Env OIDC_TESLAMATE_GRAFANA_CLIENT_SECRET
-          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-explicit-consent]]
           invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
           signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
           redirect_uris:


### PR DESCRIPTION
Einheitlich `explicit-consent` für alle 14 verwalteten Provider. Das **dreht #654 um** und stellt zusätzlich die zehn Provider um, die schon vorher auf `implicit` standen.

## Grundlage ist eine Korrektur

In #654 hatte ich geschrieben, `explicit-consent` bedeute einen Zustimmungsdialog „bei jedem Login". Das stimmt nicht. Die Consent-Stage im Cluster:

```
default-provider-authorization-consent
  mode: expiring
  consent_expire_in: weeks=4
```

Der Dialog kommt also **einmal pro App und Monat**, nicht pro Anmeldung. Damit ist der Preis gering und der Nutzen real: sichtbar wird, welche Anwendung welche Daten bekommt, und ein untergeschobener Auth-Request fällt auf.

## Änderung

| vorher explicit | vorher implicit → jetzt explicit |
|---|---|
| grafana | linkding, dawarich, linkwarden, gatus, paperless, teslamate-grafana, goloom, kavita, kite, pcm, sparkyfitness, tandoor, outline |

Stale Kommentare bereinigt: die Begründung „bewusst implicit" bei linkwarden ist weg, der grafana-Kommentar nennt jetzt die Policy statt des Live-Zustands.

## Test

Alle 14 Blueprints gegen die Live-DB validiert (`True`). `just validate` grün.

Nach dem Rollout ist beim nächsten Login je App einmal zuzustimmen — danach vier Wochen Ruhe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)