### PR TITLE
feat(authentik): letzte vier Provider samt Scope-Mappings verwalten

### DIFF
--- a/apps/base/authentik/blueprints/audiobookshelf-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/audiobookshelf-oauth.configmap.yaml
@@ -1,0 +1,79 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authentik-audiobookshelf-blueprint
+  namespace: authentik
+  labels:
+    app.kubernetes.io/part-of: authentik
+data:
+  audiobookshelf.yaml: |
+    version: 1
+    metadata:
+      name: Homelab Audiobookshelf OIDC
+      labels:
+        blueprints.goauthentik.io/description: OAuth2 provider, application and scope mapping for Audiobookshelf
+    entries:
+      # Managed here as well, not just referenced: the mapping carries the
+      # group logic this provider depends on, and a blueprint that only
+      # points at it breaks the moment someone deletes it.
+      - model: authentik_providers_oauth2.scopemapping
+        id: audiobookshelf-scope
+        identifiers:
+          scope_name: "audiobookshelf-group-mapping"
+        attrs:
+          name: "Audiobookshelf Group mapping"
+          scope_name: "audiobookshelf-group-mapping"
+          description: "Mapps default groups to audiobookshelf group."
+          expression: |-
+            audbshlf_claims = {}
+
+            if request.user.ak_groups.filter(name="Familie").exists():
+                audbshlf_claims["audiobookshelf"]= "user"
+            if request.user.ak_groups.filter(name="Admin").exists():
+                audbshlf_claims["audiobookshelf"]= "admin"
+            if request.user.ak_groups.filter(name="authentik Admins").exists():
+                audbshlf_claims["audiobookshelf"]= "admin"
+
+            return audbshlf_claims
+      - model: authentik_providers_oauth2.oauth2provider
+        id: audiobookshelf-provider
+        # Match on client_id, not name: the name is an attribute the blueprint
+        # itself sets, so any rename turns the update into a create and hits the
+        # unique constraint.
+        identifiers:
+          client_id: Cw6xIezlTTKxGyPt8uNGFqWG7HgvGcxw2eHqQ8H4
+        attrs:
+          name: "Provider for Audiobookshelf"
+          client_type: confidential
+          client_id: Cw6xIezlTTKxGyPt8uNGFqWG7HgvGcxw2eHqQ8H4
+          # Injected into the worker from the authentik-oidc-client-secrets Secret.
+          # Never hardcode it here: every reconcile would overwrite the real
+          # secret in Authentik and break the login with invalid_client.
+          client_secret: !Env OIDC_AUDIOBOOKSHELF_CLIENT_SECRET
+          # explicit-consent for every provider by policy: consent is stored for
+          # 4 weeks, so it is one dialog per app and month, not per login.
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-explicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+          redirect_uris:
+            - matching_mode: strict
+              url: audiobookshelf://oauth
+            - matching_mode: strict
+              url: https://audible.f4mily.net/audiobookshelf/auth/openid/callback
+            - matching_mode: strict
+              url: https://audible.f4mily.net/audiobookshelf/auth/openid/mobile-redirect
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+            - !KeyOf audiobookshelf-scope
+      - model: authentik_core.application
+        identifiers:
+          slug: audiobookshelf
+        attrs:
+          name: "Audiobookshelf"
+          slug: audiobookshelf
+          provider: !KeyOf audiobookshelf-provider
+          group: "Media"
+          launch_url: https://audible.f4mily.net/
+          meta_launch_url: https://audible.f4mily.net/

--- a/apps/base/authentik/blueprints/forgejo-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/forgejo-oauth.configmap.yaml
@@ -1,0 +1,74 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authentik-forgejo-blueprint
+  namespace: authentik
+  labels:
+    app.kubernetes.io/part-of: authentik
+data:
+  forgejo.yaml: |
+    version: 1
+    metadata:
+      name: Homelab Forgejo OIDC
+      labels:
+        blueprints.goauthentik.io/description: OAuth2 provider, application and scope mapping for Forgejo
+    entries:
+      # Managed here as well, not just referenced: the mapping carries the
+      # group logic this provider depends on, and a blueprint that only
+      # points at it breaks the moment someone deletes it.
+      - model: authentik_providers_oauth2.scopemapping
+        id: forgejo-scope
+        identifiers:
+          scope_name: "gitea"
+        attrs:
+          name: "authentik forgejo OAuth Mapping: OpenID 'gitea'"
+          scope_name: "gitea"
+          expression: |-
+            gitea_claims = {}
+
+            if request.user.ak_groups.filter(name="gituser").exists():
+                gitea_claims["gitea"]= "user"
+            if request.user.ak_groups.filter(name="gitadmin").exists():
+                gitea_claims["gitea"]= "admin"
+            if request.user.ak_groups.filter(name="gitrestricted").exists():
+                gitea_claims["gitea"]= "restricted"
+
+            return gitea_claims
+      - model: authentik_providers_oauth2.oauth2provider
+        id: forgejo-provider
+        # Match on client_id, not name: the name is an attribute the blueprint
+        # itself sets, so any rename turns the update into a create and hits the
+        # unique constraint.
+        identifiers:
+          client_id: qr0GEPwcRUrsgGhm26dThRDS7yG37uCiUAN1xGi0
+        attrs:
+          name: "Provider for Forgejo"
+          client_type: confidential
+          client_id: qr0GEPwcRUrsgGhm26dThRDS7yG37uCiUAN1xGi0
+          # Injected into the worker from the authentik-oidc-client-secrets Secret.
+          # Never hardcode it here: every reconcile would overwrite the real
+          # secret in Authentik and break the login with invalid_client.
+          client_secret: !Env OIDC_FORGEJO_CLIENT_SECRET
+          # explicit-consent for every provider by policy: consent is stored for
+          # 4 weeks, so it is one dialog per app and month, not per login.
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-explicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+          redirect_uris:
+            - matching_mode: strict
+              url: https://git.f4mily.net/user/oauth2/Authentik/callback
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+            - !KeyOf forgejo-scope
+      - model: authentik_core.application
+        identifiers:
+          slug: forgejo
+        attrs:
+          name: "Forgejo"
+          slug: forgejo
+          provider: !KeyOf forgejo-provider
+          group: "Core"
+          launch_url: https://git.f4mily.net
+          meta_launch_url: https://git.f4mily.net

--- a/apps/base/authentik/blueprints/immich-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/immich-oauth.configmap.yaml
@@ -1,0 +1,74 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authentik-immich-blueprint
+  namespace: authentik
+  labels:
+    app.kubernetes.io/part-of: authentik
+data:
+  immich.yaml: |
+    version: 1
+    metadata:
+      name: Homelab Immich OIDC
+      labels:
+        blueprints.goauthentik.io/description: OAuth2 provider, application and scope mapping for Immich
+    entries:
+      # Managed here as well, not just referenced: the mapping carries the
+      # group logic this provider depends on, and a blueprint that only
+      # points at it breaks the moment someone deletes it.
+      - model: authentik_providers_oauth2.scopemapping
+        id: immich-scope
+        identifiers:
+          scope_name: "immich_quota"
+        attrs:
+          name: "Immich Quota"
+          scope_name: "immich_quota"
+          description: "Set the storage size for immich foto app."
+          expression: |-
+            return user.group_attributes().get("immich_quota", "5 GB")
+      - model: authentik_providers_oauth2.oauth2provider
+        id: immich-provider
+        # Match on client_id, not name: the name is an attribute the blueprint
+        # itself sets, so any rename turns the update into a create and hits the
+        # unique constraint.
+        identifiers:
+          client_id: ptcYsOPq403TgqMX3FunCUaZkZ2PtoMVUjBo0WXM
+        attrs:
+          name: "Provider for Immich"
+          client_type: confidential
+          client_id: ptcYsOPq403TgqMX3FunCUaZkZ2PtoMVUjBo0WXM
+          # Injected into the worker from the authentik-oidc-client-secrets Secret.
+          # Never hardcode it here: every reconcile would overwrite the real
+          # secret in Authentik and break the login with invalid_client.
+          client_secret: !Env OIDC_IMMICH_CLIENT_SECRET
+          # explicit-consent for every provider by policy: consent is stored for
+          # 4 weeks, so it is one dialog per app and month, not per login.
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-explicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+          redirect_uris:
+            - matching_mode: strict
+              url: app.immich:///oauth-callback
+            - matching_mode: strict
+              url: https://immich.f4mily.net/auth/login
+            - matching_mode: strict
+              url: https://immich.f4mily.net/user-settings
+            - matching_mode: strict
+              url: https://immich.cluster.f4mily.net/auth/login
+            - matching_mode: strict
+              url: https://immich.cluster.f4mily.net/user-settings
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+            - !KeyOf immich-scope
+      - model: authentik_core.application
+        identifiers:
+          slug: immich
+        attrs:
+          name: "Immich"
+          slug: immich
+          provider: !KeyOf immich-provider
+          group: "Media"
+          launch_url: https://immich.f4mily.net
+          meta_launch_url: https://immich.f4mily.net

--- a/apps/base/authentik/blueprints/nextcloud-oauth.configmap.yaml
+++ b/apps/base/authentik/blueprints/nextcloud-oauth.configmap.yaml
@@ -1,0 +1,82 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authentik-nextcloud-blueprint
+  namespace: authentik
+  labels:
+    app.kubernetes.io/part-of: authentik
+data:
+  nextcloud.yaml: |
+    version: 1
+    metadata:
+      name: Homelab Nextcloud OIDC
+      labels:
+        blueprints.goauthentik.io/description: OAuth2 provider, application and scope mapping for Nextcloud
+    entries:
+      # Managed here as well, not just referenced: the mapping carries the
+      # group logic this provider depends on, and a blueprint that only
+      # points at it breaks the moment someone deletes it.
+      - model: authentik_providers_oauth2.scopemapping
+        id: nextcloud-scope
+        identifiers:
+          scope_name: "nextcloud"
+        attrs:
+          name: "Nextcloud Profile"
+          scope_name: "nextcloud"
+          description: "Adding properties for Nextcloud"
+          expression: |-
+            # Extract all groups the user is a member of
+            groups = [group.name for group in user.ak_groups.all()]
+
+            # In Nextcloud, administrators must be members of a fixed group called "admin".
+
+            # If a user is an admin in authentik, ensure that "admin" is appended to their group list.
+            if user.is_superuser and "admin" not in groups:
+                groups.append("admin")
+
+            return {
+                "name": request.user.name,
+                "groups": groups,
+                # Set a quota by using the "nextcloud_quota" property in the user's attributes
+                "quota": user.group_attributes().get("nextcloud_quota", None),
+                # To connect an existing Nextcloud user, set "nextcloud_user_id" to the Nextcloud username.
+                "user_id": user.attributes.get("nextcloud_user_id", str(user.uuid)),
+            }
+      - model: authentik_providers_oauth2.oauth2provider
+        id: nextcloud-provider
+        # Match on client_id, not name: the name is an attribute the blueprint
+        # itself sets, so any rename turns the update into a create and hits the
+        # unique constraint.
+        identifiers:
+          client_id: homelab-nextcloud
+        attrs:
+          name: "Provider for Nextcloud"
+          client_type: confidential
+          client_id: homelab-nextcloud
+          # Injected into the worker from the authentik-oidc-client-secrets Secret.
+          # Never hardcode it here: every reconcile would overwrite the real
+          # secret in Authentik and break the login with invalid_client.
+          client_secret: !Env OIDC_NEXTCLOUD_CLIENT_SECRET
+          # explicit-consent for every provider by policy: consent is stored for
+          # 4 weeks, so it is one dialog per app and month, not per login.
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-explicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+          redirect_uris:
+            - matching_mode: strict
+              url: https://nc.f4mily.net/apps/user_oidc/code
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+            - !KeyOf nextcloud-scope
+      - model: authentik_core.application
+        identifiers:
+          slug: nextcloud
+        attrs:
+          name: "Nextcloud"
+          slug: nextcloud
+          provider: !KeyOf nextcloud-provider
+          group: "Dokumente"
+          launch_url: https://nc.f4mily.net
+          meta_launch_url: https://nc.f4mily.net

--- a/apps/base/authentik/helmrelease.yaml
+++ b/apps/base/authentik/helmrelease.yaml
@@ -76,6 +76,10 @@ spec:
         - authentik-sparky-fitness-blueprint
         - authentik-tandoor-blueprint
         - authentik-outline-blueprint
+        - authentik-audiobookshelf-blueprint
+        - authentik-forgejo-blueprint
+        - authentik-immich-blueprint
+        - authentik-nextcloud-blueprint
     server:
       ingress:
         enabled: false

--- a/apps/base/authentik/kustomization.yaml
+++ b/apps/base/authentik/kustomization.yaml
@@ -17,6 +17,10 @@ resources:
   - blueprints/sparky-fitness-oauth.configmap.yaml
   - blueprints/tandoor-oauth.configmap.yaml
   - blueprints/outline-oauth.configmap.yaml
+  - blueprints/audiobookshelf-oauth.configmap.yaml
+  - blueprints/forgejo-oauth.configmap.yaml
+  - blueprints/immich-oauth.configmap.yaml
+  - blueprints/nextcloud-oauth.configmap.yaml
   - media-pvc.yaml
   - helmrelease.yaml
   - ingress.yaml


### PR DESCRIPTION
Schluss von Schritt 3. Setzt kreativmonkey/homelab-gitops-private#13 voraus (18 Keys ausgerollt).

audiobookshelf, forgejo, immich und nextcloud — die vier Provider mit eigenen Scope-Mappings.

## Scope-Mappings sind jetzt mitverwaltet

Zur Frage, ob Blueprints das können: **ja.** Die Mappings liegen als eigener Entry (`model: authentik_providers_oauth2.scopemapping`) samt Expression mit im Blueprint, statt nur referenziert zu werden.

Das ist hier keine Kosmetik — die Mappings tragen die Logik, von der die Rollenvergabe abhängt:

| Scope | was es steuert |
|---|---|
| `gitea` | user / admin / restricted, je nach Authentik-Gruppe |
| `audiobookshelf-group-mapping` | user / admin |
| `nextcloud` | Gruppenliste inkl. `admin`-Sonderfall für Superuser, plus Quota |
| `immich_quota` | Speicherlimit, Default 5 GB |

Nur zu referenzieren hieße: ein gelöschtes Mapping bricht den Blueprint, und die Rollen verschwinden still.

## Zwei Fallen unterwegs

**Doppelpunkt im Namen.** Das forgejo-Mapping heißt `authentik forgejo OAuth Mapping: OpenID 'gitea'`. Unquoted bricht das die YAML-Struktur — und der Fehler taucht erst als Folgefehler beim `!KeyOf` der Application auf, nicht an der Ursache. Namen sind jetzt durchgängig gequotet.

**Block-Scalar `|` vs `|-`.** `|` hängt ein Newline an, wodurch die Expression vom Bestand abweicht. Die Validierung fängt das **nicht** — sie meldet `True`. Erst ein Vergleich gegen die Live-DB zeigte, dass alle vier Expressions abwichen. Mit `|-` sind sie jetzt zeichengenau identisch (per Hash geprüft).

## Test

| Prüfung | Ergebnis |
|---|---|
| Blueprints gegen Live-DB validiert | alle vier `True` |
| Expressions vs. Bestand | zeichengenau identisch |
| `just validate` | grün |

Damit sind 18 von 26 Providern deklarativ. Offen bleibt nur teslamate-dashboard (Proxy-Provider, anderes Schema) — die 12 externen bleiben extern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)