### PR TITLE
feat(backup): add Storage Box offsite backups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,7 @@ You are **Senior Kubernetes System Architect** and **GitOps Automation Engineer*
 2. S3 credentials never stored plain‑text – use SealedSecrets or ExternalSecrets placeholders.
 3. DR overlay at `infrastructure/overlays/disaster-recovery/` patches CNPG `Cluster` with `spec.bootstrap.recovery` so fresh clusters restore from S3.
 4. Restoration flow: apply DR overlay → CNPG restores databases → Flux syncs apps.
+5. Immich and Nextcloud irreplaceable data also goes encrypted via Restic to the Hetzner Storage Box; manifests and restore verification live in `infrastructure/base/offsite-backup/`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Flux reconciles it every hour (or on demand). Changes land via **PRs to
 | **Security** | [cert-manager](https://github.com/cert-manager/cert-manager) | Automated TLS via Let's Encrypt (DNS-01) |
 | **Observability** | [VictoriaMetrics](https://victoriametrics.com/) Stack | High-performance monitoring and alerting |
 | **Automation** | [Renovate Bot](https://github.com/mend/renovate-ce-ee/tree/main) | Automated dependency and image updates |
-| **Data Policy** | [Velero](https://velero.io/) | Volume snapshots and offsite backups |
+| **Data Policy** | Velero + Restic | On-site Kubernetes recovery plus encrypted Immich/Nextcloud offsite backups |
 
 ---
 

--- a/docs/disaster-recovery/README.md
+++ b/docs/disaster-recovery/README.md
@@ -10,14 +10,16 @@ End-to-end recovery after control-plane loss or full cluster rebuild. **PostgreS
 | PostgreSQL | CNPG `bootstrap.recovery` from Garage S3 | [cnpg-s3-dr.md](cnpg-s3-dr.md) |
 | App manifests | Flux (`homelab-gitops` on **GitHub**) | This doc |
 | PV / namespace data | Velero (optional) | [cnpg-s3-dr.md](cnpg-s3-dr.md#velero-vs-barman) |
+| Immich + Nextcloud offsite | Encrypted Restic on Hetzner Storage Box | [Offsite restore](../runbooks/offsite-backup-restore.md) |
 
 ## Prerequisites (before you need DR)
 
 1. **CNPG backups** reaching `http://192.168.10.94:30188` — verify `kubectl get backup -n cnpg-system`.
 2. **SOPS secrets** in Git decryptable by cluster (`sops-age` in `flux-system` from OpenTofu).
-3. **pgadmin**: `pgadmin-credentials.secret.yaml` enabled in `infrastructure/overlays/main/pgadmin/kustomization.yaml` (see `just pgadmin-credentials`).
-4. **OpenTofu** access: `homelab-infrastructure/talos` (`kubeconfig`, `talosconfig`, `github_token` for Flux bootstrap).
-5. Know that **Flux clones `https://github.com/kreativmonkey/homelab-gitops.git`** — pushes only to Forgejo do not affect the cluster until mirrored to GitHub `main`.
+3. **Offsite Restic verification** successful in `backup-offsite` — see [offsite-backup-restore.md](../runbooks/offsite-backup-restore.md).
+4. **pgadmin**: `pgadmin-credentials.secret.yaml` enabled in `infrastructure/overlays/main/pgadmin/kustomization.yaml` (see `just pgadmin-credentials`).
+5. **OpenTofu** access: `homelab-infrastructure/talos` (`kubeconfig`, `talosconfig`, `github_token` for Flux bootstrap).
+6. Know that **Flux clones `https://github.com/kreativmonkey/homelab-gitops.git`** — pushes only to Forgejo do not affect the cluster until mirrored to GitHub `main`.
 
 ## Talos control plane
 

--- a/docs/runbooks/offsite-backup-restore.md
+++ b/docs/runbooks/offsite-backup-restore.md
@@ -1,0 +1,68 @@
+# Immich and Nextcloud offsite backup
+
+## Scope
+
+Daily Restic snapshots are stored encrypted on the Hetzner Storage Box under
+`homelab-gitops/restic`:
+
+- `immich`: PostgreSQL dump plus complete `Bilder` and `Fotos` NFS trees.
+- `nextcloud`: Garage primary-object bucket, PostgreSQL dump, and a tar archive
+  of `/var/www/html` containing config, apps, themes, and compatibility data.
+
+Nextcloud enters maintenance mode before its S3 copy. A native sidecar removes
+maintenance mode on success, failure, timeout, or pod termination. The staging
+PVC is an on-site working copy, not a backup.
+
+Retention is 14 daily, 8 weekly, 12 monthly, and 3 yearly snapshots per app.
+Weekly verification reads 5% of repository data, restores both database dumps
+and Nextcloud app state, validates them with `pg_restore --list` and `tar`, then
+restores one Immich media file and one Nextcloud object and checks both against
+their backup-time SHA-256 hashes. Only then does it compact unreferenced data.
+
+## Check status
+
+```bash
+kubectl get cronjob,jobs -n backup-offsite
+kubectl logs -n backup-offsite job/<job-name> --all-containers
+kubectl get pvc -n backup-offsite nextcloud-offsite-staging
+```
+
+Trigger an additional backup or verification:
+
+```bash
+kubectl create job -n backup-offsite --from=cronjob/immich-offsite-backup immich-offsite-manual
+kubectl create job -n backup-offsite --from=cronjob/nextcloud-offsite-backup nextcloud-offsite-manual
+kubectl create job -n backup-offsite --from=cronjob/offsite-restore-verify offsite-verify-manual
+```
+
+After the first seed, require all three jobs to complete before treating the
+Storage Box as a valid offsite copy.
+
+## Full restore test
+
+Automated weekly verification proves repository readability and both database
+dumps. It does not start production applications. Before trusting retention,
+also perform this isolated restore:
+
+1. Suspend the application HelmRelease or restore into an isolated test cluster.
+2. Start from a copy of `offsite-restore-verify` with `restic restore latest`
+   for the required `--tag` and without the dump-only `--include` filter.
+3. Restore the PostgreSQL dump into a fresh CNPG cluster using `pg_restore`.
+4. Immich: mount restored `Bilder` and `Fotos`, deploy the matching Immich
+   version, then run its storage-integrity check.
+5. Nextcloud: restore `nextcloud-app.tar.gz`, upload the staged `objects/`
+   directory to an empty Garage bucket, restore its database, and keep the
+   restored bucket exclusive to that instance.
+6. Run `php occ maintenance:data-fingerprint`, `php occ status`, and download
+   several known files through Nextcloud. Never run `files:scan --all` against
+   primary object storage.
+
+Record restore date, snapshot IDs, tested files, and result in the operations
+log. A failed verification blocks pruning or storage migrations until fixed.
+
+## Lost credentials
+
+Storage Box login and Restic repository password live only in the SOPS Secret
+`infrastructure/base/offsite-backup/storagebox-credentials.secret.yaml`.
+Loss of the Restic password makes every snapshot unrecoverable; keep a second
+copy in the offline password manager.

--- a/infrastructure/AGENTS.md
+++ b/infrastructure/AGENTS.md
@@ -23,8 +23,9 @@ Cluster-wide services: database operator, storage, networking/ingress, backup + 
 
 # Verification
 
-- `just fmt && just lint && just test` locally before PR.
+- `just validate` locally before PR.
+- Run `just validate-full` when changing workload or controller manifests.
 
 # Child DOX Index
 
-No child AGENTS.md. Subfolders inherit this contract.
+- `base/offsite-backup/AGENTS.md` — encrypted Storage Box backups, retention, consistency, and restore verification.

--- a/infrastructure/base/kustomization.yaml
+++ b/infrastructure/base/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - system-upgrade-controller
   - blackbox-exporter
   - backup
+  - offsite-backup
   - database
   - remediation-api
   - mcp-server

--- a/infrastructure/base/offsite-backup/AGENTS.md
+++ b/infrastructure/base/offsite-backup/AGENTS.md
@@ -1,0 +1,33 @@
+# Purpose
+
+Encrypted offsite backups of irreplaceable Immich and Nextcloud data to the Hetzner Storage Box.
+
+# Ownership
+
+- Owns: Storage Box credentials, Restic repository jobs, Nextcloud backup staging, restore verification, and namespace-scoped backup RBAC.
+- Parent `infrastructure/AGENTS.md` owns cluster-wide storage and backup policy.
+
+# Local Contracts
+
+- Storage Box credentials and Restic password stay SOPS-encrypted in `storagebox-credentials.secret.yaml`.
+- Restic is the durable backup format; rclone only exposes the SFTP target and stages Nextcloud S3 objects.
+- Immich backups include `Bilder`, `Fotos`, and a fresh PostgreSQL dump.
+- Nextcloud backups run in maintenance mode and include the primary S3 bucket, PostgreSQL dump, and app/config state.
+- Backup containers mount source volumes read-only. Staging is disposable and remains on-site.
+- Weekly verification must check repository data, restore both database dumps, validate Nextcloud app/config state, and hash-check restored Immich and Nextcloud user-data samples.
+
+# Work Guidance
+
+- Preserve Nextcloud object IDs and database together; never reconstruct `oc_filecache` from object names.
+- Keep Storage Box transfers below its ten-connection limit.
+- Run a full isolated application restore after initial seeding and after restore-contract changes.
+
+# Verification
+
+- `just lint`
+- `just kustomize-validate`
+- Server-side dry-run of decrypted output before merge.
+
+# Child DOX Index
+
+No child AGENTS.md.

--- a/infrastructure/base/offsite-backup/immich.cronjob.yaml
+++ b/infrastructure/base/offsite-backup/immich.cronjob.yaml
@@ -1,0 +1,130 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: immich-offsite-backup
+  namespace: backup-offsite
+spec:
+  schedule: "30 3 * * *"
+  timeZone: Europe/Berlin
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 28800
+      template:
+        spec:
+          serviceAccountName: offsite-backup
+          restartPolicy: Never
+          terminationGracePeriodSeconds: 60
+          initContainers:
+            - name: prepare-rclone
+              image: docker.io/rclone/rclone:1.74.2
+              command: ["/bin/sh", "/scripts/prepare-rclone.sh"]
+              env:
+                - name: STORAGEBOX_HOST
+                  valueFrom:
+                    secretKeyRef: {name: storagebox-credentials, key: STORAGEBOX_HOST}
+                - name: STORAGEBOX_USERNAME
+                  valueFrom:
+                    secretKeyRef: {name: storagebox-credentials, key: STORAGEBOX_USERNAME}
+                - name: STORAGEBOX_PASSWORD
+                  valueFrom:
+                    secretKeyRef: {name: storagebox-credentials, key: STORAGEBOX_PASSWORD}
+              volumeMounts:
+                - name: config
+                  mountPath: /config
+                - name: scripts
+                  mountPath: /scripts
+                  readOnly: true
+            - name: restic-server
+              image: docker.io/rclone/rclone:1.74.2
+              restartPolicy: Always
+              args:
+                - serve
+                - restic
+                - storagebox:homelab-gitops/restic
+                - --addr=127.0.0.1:8080
+                - --config=/config/rclone.conf
+                - --cache-objects=false
+              volumeMounts:
+                - name: config
+                  mountPath: /config
+                  readOnly: true
+            - name: database-dump
+              image: docker.io/alpine/k8s:1.36.0
+              command:
+                - /bin/sh
+                - -ec
+                - |
+                  mkdir -p /staging/database
+                  primary="$(kubectl get pods -n cnpg-system \
+                    -l cnpg.io/cluster=immich-postgres,role=primary \
+                    -o jsonpath='{.items[0].metadata.name}')"
+                  kubectl exec -n cnpg-system "${primary}" -- \
+                    pg_dump -d immich -Fc > /staging/database/immich.dump
+              volumeMounts:
+                - name: staging
+                  mountPath: /staging
+          containers:
+            - name: backup
+              image: docker.io/restic/restic:0.19.1
+              command:
+                - /bin/sh
+                - -ec
+                - |
+                  /bin/sh /scripts/record-sample.sh immich /data /fotos
+                  exec /bin/sh /scripts/restic-backup.sh \
+                    immich /data /fotos /staging
+              env:
+                - name: RESTIC_REPOSITORY
+                  value: rest:http://127.0.0.1:8080/
+                - name: EXIT_ON_FAILURE
+                  value: "true"
+                - name: RESTIC_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: storagebox-credentials
+                      key: restic-password
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+                limits:
+                  memory: 2Gi
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+                  readOnly: true
+                - name: work
+                  mountPath: /work
+                - name: staging
+                  mountPath: /staging
+                - name: media
+                  mountPath: /data
+                  subPath: Bilder
+                  readOnly: true
+                - name: media
+                  mountPath: /fotos
+                  subPath: Fotos
+                  readOnly: true
+          volumes:
+            - name: config
+              emptyDir: {}
+            - name: work
+              emptyDir: {}
+            - name: staging
+              emptyDir:
+                sizeLimit: 2Gi
+            - name: scripts
+              configMap:
+                name: offsite-backup-scripts
+                defaultMode: 0555
+            # Inline NFS is required because PVCs cannot cross namespaces.
+            # Paths match the existing static Immich PVs.
+            - name: media
+              nfs:
+                server: 192.168.10.94
+                path: /mnt/Storagepool/Media
+                readOnly: true

--- a/infrastructure/base/offsite-backup/kustomization.yaml
+++ b/infrastructure/base/offsite-backup/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - storagebox-credentials.secret.yaml
+  - rbac.yaml
+  - nextcloud-staging.pvc.yaml
+  - scripts.configmap.yaml
+  - immich.cronjob.yaml
+  - nextcloud.cronjob.yaml
+  - verify.cronjob.yaml

--- a/infrastructure/base/offsite-backup/namespace.yaml
+++ b/infrastructure/base/offsite-backup/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: backup-offsite

--- a/infrastructure/base/offsite-backup/nextcloud-staging.pvc.yaml
+++ b/infrastructure/base/offsite-backup/nextcloud-staging.pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nextcloud-offsite-staging
+  namespace: backup-offsite
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: truenas-iscsi
+  resources:
+    requests:
+      storage: 250Gi

--- a/infrastructure/base/offsite-backup/nextcloud.cronjob.yaml
+++ b/infrastructure/base/offsite-backup/nextcloud.cronjob.yaml
@@ -1,0 +1,197 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: nextcloud-offsite-backup
+  namespace: backup-offsite
+spec:
+  schedule: "30 4 * * *"
+  timeZone: Europe/Berlin
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 28800
+      template:
+        spec:
+          serviceAccountName: offsite-backup
+          restartPolicy: Never
+          terminationGracePeriodSeconds: 120
+          initContainers:
+            - name: fetch-garage-credentials
+              image: docker.io/alpine/k8s:1.36.0
+              command:
+                - /bin/sh
+                - -ec
+                - |
+                  umask 077
+                  kubectl get secret -n nextcloud nextcloud-s3-credentials \
+                    -o jsonpath='{.data.access-key}' > /config/garage-access-key.b64
+                  kubectl get secret -n nextcloud nextcloud-s3-credentials \
+                    -o jsonpath='{.data.secret-key}' > /config/garage-secret-key.b64
+              volumeMounts:
+                - name: config
+                  mountPath: /config
+            - name: prepare-rclone
+              image: docker.io/rclone/rclone:1.74.2
+              command: ["/bin/sh", "/scripts/prepare-rclone.sh"]
+              env:
+                - name: STORAGEBOX_HOST
+                  valueFrom:
+                    secretKeyRef: {name: storagebox-credentials, key: STORAGEBOX_HOST}
+                - name: STORAGEBOX_USERNAME
+                  valueFrom:
+                    secretKeyRef: {name: storagebox-credentials, key: STORAGEBOX_USERNAME}
+                - name: STORAGEBOX_PASSWORD
+                  valueFrom:
+                    secretKeyRef: {name: storagebox-credentials, key: STORAGEBOX_PASSWORD}
+              volumeMounts:
+                - name: config
+                  mountPath: /config
+                - name: scripts
+                  mountPath: /scripts
+                  readOnly: true
+            - name: restic-server
+              image: docker.io/rclone/rclone:1.74.2
+              restartPolicy: Always
+              args:
+                - serve
+                - restic
+                - storagebox:homelab-gitops/restic
+                - --addr=127.0.0.1:8080
+                - --config=/config/rclone.conf
+                - --cache-objects=false
+              volumeMounts:
+                - name: config
+                  mountPath: /config
+                  readOnly: true
+            - name: maintenance
+              image: docker.io/alpine/k8s:1.36.0
+              restartPolicy: Always
+              command: ["/bin/sh", "/scripts/nextcloud-maintenance.sh"]
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+                  readOnly: true
+                - name: work
+                  mountPath: /work
+            - name: wait-maintenance
+              image: docker.io/rclone/rclone:1.74.2
+              command:
+                - /bin/sh
+                - -ec
+                - |
+                  for _ in $(seq 1 60); do
+                    [ -f /work/maintenance-ready ] && exit 0
+                    [ -f /work/maintenance-failed ] && exit 0
+                    sleep 5
+                  done
+                  touch /work/maintenance-failed
+              volumeMounts:
+                - name: work
+                  mountPath: /work
+            - name: stage-objects
+              image: docker.io/rclone/rclone:1.74.2
+              command:
+                - /bin/sh
+                - -ec
+                - |
+                  if [ ! -f /work/maintenance-ready ]; then
+                    touch /work/nextcloud-stage.failed
+                    exit 0
+                  fi
+                  if rclone sync garage:nextcloud /staging/objects \
+                    --config=/config/rclone.conf --fast-list \
+                    --transfers=4 --checkers=8 --delete-during; then
+                    touch /work/nextcloud-stage.ok
+                  else
+                    touch /work/nextcloud-stage.failed
+                  fi
+              volumeMounts:
+                - name: config
+                  mountPath: /config
+                  readOnly: true
+                - name: work
+                  mountPath: /work
+                - name: staging
+                  mountPath: /staging
+            - name: capture-state
+              image: docker.io/alpine/k8s:1.36.0
+              command:
+                - /bin/sh
+                - -ec
+                - |
+                  if [ ! -f /work/nextcloud-stage.ok ]; then
+                    touch /work/nextcloud-capture.failed
+                    exit 0
+                  fi
+                  exec /bin/sh /scripts/nextcloud-capture.sh
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+                  readOnly: true
+                - name: work
+                  mountPath: /work
+                - name: staging
+                  mountPath: /staging
+            - name: backup
+              image: docker.io/restic/restic:0.19.1
+              command:
+                - /bin/sh
+                - -ec
+                - |
+                  if [ ! -f /work/nextcloud-stage.ok ] || \
+                     [ ! -f /work/nextcloud-capture.ok ]; then
+                    touch /work/nextcloud.failed
+                    exit 0
+                  fi
+                  /bin/sh /scripts/record-sample.sh nextcloud /staging/objects
+                  exec /bin/sh /scripts/restic-backup.sh nextcloud /staging
+              env:
+                - name: RESTIC_REPOSITORY
+                  value: rest:http://127.0.0.1:8080/
+                - name: RESTIC_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: storagebox-credentials
+                      key: restic-password
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+                  readOnly: true
+                - name: work
+                  mountPath: /work
+                - name: staging
+                  mountPath: /staging
+          containers:
+            - name: finalize
+              image: docker.io/rclone/rclone:1.74.2
+              command:
+                - /bin/sh
+                - -ec
+                - |
+                  touch /work/backup-done
+                  for _ in $(seq 1 60); do
+                    [ -f /work/maintenance-off ] && break
+                    sleep 2
+                  done
+                  test -f /work/maintenance-off
+                  test -f /work/nextcloud-stage.ok
+                  test -f /work/nextcloud-capture.ok
+                  test -f /work/nextcloud.ok
+              volumeMounts:
+                - name: work
+                  mountPath: /work
+          volumes:
+            - name: config
+              emptyDir: {}
+            - name: work
+              emptyDir: {}
+            - name: scripts
+              configMap:
+                name: offsite-backup-scripts
+                defaultMode: 0555
+            - name: staging
+              persistentVolumeClaim:
+                claimName: nextcloud-offsite-staging

--- a/infrastructure/base/offsite-backup/rbac.yaml
+++ b/infrastructure/base/offsite-backup/rbac.yaml
@@ -1,0 +1,67 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: offsite-backup
+  namespace: backup-offsite
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: offsite-backup-nextcloud
+  namespace: nextcloud
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    resourceNames: ["nextcloud"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["nextcloud-s3-credentials"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: offsite-backup-nextcloud
+  namespace: nextcloud
+subjects:
+  - kind: ServiceAccount
+    name: offsite-backup
+    namespace: backup-offsite
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: offsite-backup-nextcloud
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: offsite-backup-cnpg
+  namespace: cnpg-system
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: offsite-backup-cnpg
+  namespace: cnpg-system
+subjects:
+  - kind: ServiceAccount
+    name: offsite-backup
+    namespace: backup-offsite
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: offsite-backup-cnpg

--- a/infrastructure/base/offsite-backup/scripts.configmap.yaml
+++ b/infrastructure/base/offsite-backup/scripts.configmap.yaml
@@ -1,0 +1,190 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: offsite-backup-scripts
+  namespace: backup-offsite
+data:
+  prepare-rclone.sh: |
+    #!/bin/sh
+    set -eu
+    umask 077
+
+    # Hetzner Storage Box ED25519 fingerprint:
+    # SHA256:XqONwb1S0zuj5A1CDxpOSuD2hnAArV1A3wKY7Z3sdgM
+    printf '[%s]:23 ssh-ed25519 %s\n' "${STORAGEBOX_HOST}" \
+      'AAAAC3NzaC1lZDI1NTE5AAAAIICf9svRenC/PLKIL9nk6K/pxQgoiFC41wTNvoIncOxs' \
+      > /config/storagebox-known-hosts
+    storagebox_password="$(rclone obscure "${STORAGEBOX_PASSWORD}")"
+    rclone config create storagebox sftp \
+      host "${STORAGEBOX_HOST}" \
+      user "${STORAGEBOX_USERNAME}" \
+      port 23 \
+      pass "${storagebox_password}" \
+      shell_type unix \
+      known_hosts_file /config/storagebox-known-hosts \
+      host_key_algorithms ssh-ed25519 \
+      --config /config/rclone.conf >/dev/null
+
+    if [ -s /config/garage-access-key.b64 ]; then
+      garage_access_key="$(base64 -d </config/garage-access-key.b64)"
+      garage_secret_key="$(base64 -d </config/garage-secret-key.b64)"
+      rclone config create garage s3 \
+        provider Other \
+        env_auth false \
+        access_key_id "${garage_access_key}" \
+        secret_access_key "${garage_secret_key}" \
+        endpoint http://192.168.10.94:30188 \
+        region garage \
+        force_path_style true \
+        --config /config/rclone.conf >/dev/null
+    fi
+
+  restic-backup.sh: |
+    #!/bin/sh
+    set -u
+
+    tag="$1"
+    shift
+    result=0
+
+    for delay in 1 2 4 8 16; do
+      restic snapshots >/dev/null 2>&1 && break
+      sleep "${delay}"
+    done
+    if ! restic snapshots >/dev/null 2>&1; then
+      restic init || result=1
+    fi
+    if [ "${result}" -eq 0 ]; then
+      restic backup --host homelab --tag "${tag}" "$@" || result=1
+    fi
+    if [ "${result}" -eq 0 ]; then
+      restic forget --host homelab --tag "${tag}" \
+        --keep-daily 14 --keep-weekly 8 --keep-monthly 12 --keep-yearly 3 \
+        || result=1
+    fi
+
+    if [ "${result}" -eq 0 ]; then
+      touch "/work/${tag}.ok"
+    else
+      touch "/work/${tag}.failed"
+    fi
+    if [ "${EXIT_ON_FAILURE:-false}" = "true" ]; then
+      exit "${result}"
+    fi
+    exit 0
+
+  record-sample.sh: |
+    #!/bin/sh
+    set -eu
+
+    tag="$1"
+    shift
+    sample_path="$(find "$@" -type f -print -quit)"
+    test -n "${sample_path}"
+    mkdir -p /staging/verify
+    printf '%s\n' "${sample_path}" > "/staging/verify/${tag}-sample.path"
+    sha256sum "${sample_path}" | cut -d ' ' -f 1 \
+      > "/staging/verify/${tag}-sample.sha256"
+
+  nextcloud-maintenance.sh: |
+    #!/bin/sh
+    set -u
+
+    disable_maintenance() {
+      kubectl exec -n nextcloud deploy/nextcloud -- \
+        php occ maintenance:mode --off >/dev/null 2>&1 || true
+      touch /work/maintenance-off
+    }
+    trap 'disable_maintenance; exit 0' TERM INT EXIT
+
+    if kubectl exec -n nextcloud deploy/nextcloud -- \
+      php occ maintenance:mode --on; then
+      touch /work/maintenance-ready
+    else
+      touch /work/maintenance-failed
+    fi
+
+    while [ ! -f /work/backup-done ]; do
+      sleep 5
+    done
+    disable_maintenance
+    trap - TERM INT EXIT
+    while true; do sleep 3600; done
+
+  nextcloud-capture.sh: |
+    #!/bin/sh
+    set -u
+    result=0
+    mkdir -p /staging/database
+
+    primary="$(kubectl get pods -n cnpg-system \
+      -l cnpg.io/cluster=homelab-postgres,role=primary \
+      -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)"
+    if [ -z "${primary}" ] || ! kubectl exec -n cnpg-system "${primary}" -- \
+      pg_dump -d nextcloud -Fc > /staging/database/nextcloud.dump; then
+      result=1
+    fi
+
+    if ! kubectl exec -n nextcloud deploy/nextcloud -- \
+      tar -C /var/www/html -czf - . > /staging/nextcloud-app.tar.gz; then
+      result=1
+    fi
+
+    if [ "${result}" -eq 0 ]; then
+      touch /work/nextcloud-capture.ok
+    else
+      touch /work/nextcloud-capture.failed
+    fi
+    exit 0
+
+  verify.sh: |
+    #!/bin/sh
+    set -u
+    result=0
+
+    for delay in 1 2 4 8 16; do
+      restic snapshots >/dev/null 2>&1 && break
+      sleep "${delay}"
+    done
+    restic check --read-data-subset=5% || result=1
+    restic restore latest --host homelab --tag immich \
+      --include '/staging/database/immich.dump' \
+      --include '/staging/verify/immich-sample.path' \
+      --include '/staging/verify/immich-sample.sha256' \
+      --target /restore/immich \
+      || result=1
+    restic restore latest --host homelab --tag nextcloud \
+      --include '/staging/database/nextcloud.dump' \
+      --include '/staging/nextcloud-app.tar.gz' \
+      --include '/staging/verify/nextcloud-sample.path' \
+      --include '/staging/verify/nextcloud-sample.sha256' \
+      --target /restore/nextcloud \
+      || result=1
+    for tag in immich nextcloud; do
+      manifest_root="/restore/${tag}/staging/verify"
+      sample_path="$(cat "${manifest_root}/${tag}-sample.path" 2>/dev/null)" \
+        || result=1
+      expected="$(cat "${manifest_root}/${tag}-sample.sha256" 2>/dev/null)" \
+        || result=1
+      if [ -n "${sample_path:-}" ] && [ -n "${expected:-}" ]; then
+        restic restore latest --host homelab --tag "${tag}" \
+          --include "${sample_path}" --target "/restore/${tag}-sample" \
+          || result=1
+        restored_path="/restore/${tag}-sample${sample_path}"
+        actual="$(sha256sum "${restored_path}" 2>/dev/null | cut -d ' ' -f 1)" \
+          || result=1
+        [ "${actual:-}" = "${expected}" ] || result=1
+      else
+        result=1
+      fi
+    done
+    if [ "${result}" -eq 0 ]; then
+      restic prune || result=1
+    fi
+
+    if [ "${result}" -eq 0 ]; then
+      touch /work/restore.ok
+    else
+      touch /work/restore.failed
+    fi
+    exit 0

--- a/infrastructure/base/offsite-backup/storagebox-credentials.secret.yaml
+++ b/infrastructure/base/offsite-backup/storagebox-credentials.secret.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: storagebox-credentials
+    namespace: backup-offsite
+type: Opaque
+stringData:
+    STORAGEBOX_HOST: ENC[AES256_GCM,data:psW+1K0cQUmhtqvLVp9CEpyMCwP4EDKZr0o=,iv:/AN8I8dnbGJHoQKDJuQu4M9aPj5lgZHItbDpEd1s624=,tag:IHskTOtC8+AufMfoIY0daw==,type:str]
+    STORAGEBOX_USERNAME: ENC[AES256_GCM,data:RH9OLvi9gHy/BT9z,iv:dxqU9HGwXKNPeRN22mvG5xFmYm4yrz1gBAyGqnybAwY=,tag:6t0HSHDgt+OYy1K/jLgShA==,type:str]
+    STORAGEBOX_PASSWORD: ENC[AES256_GCM,data:JmwgW9XoAaT2/tH30Qj0,iv:s3BcN6XN3I1q3vCaB3l+Um2Khpb4X1H9fYesEXB9dBg=,tag:YMQVW8sddy2i/+gkjxncig==,type:str]
+    restic-password: ENC[AES256_GCM,data:oBtA2Y5hUVKEjqYuqeyStwKyMii//bV73vxpX8ScMX3yHP5Q5QL/cjntfATvns4Y0WziRcHZ3EX7E8LPMfk1Dg==,iv:3VMQka/YDaGNBJ3HjG+h9b6ztQrgw/7bAGClWOg1m/w=,tag:wA2ak4bvQJzAXAoRjKJn2A==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGMjFSckxjV09hVDNHVitR
+            RnJMNVpyTVhaZzQ0QzUydXRzbXo5SnFxZm53Ck9QNFRNOWMrcGVGS0cyc1k4SWxR
+            alRXWTZhemdkM05WVXVkTDc4d04rODQKLS0tIG54bHoySi90SVVNdVBzN0xZcDA0
+            ZkN5STVRRnhUR2Nic25CanRxcHpUelkKEKzax9wvspmmP2/BNjyDcerDn0ti7wyO
+            Ai3urd6RcMhduAgBHfJxkZpT3CpOk2pggndVou0dkRCXlN5qcmZFyg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1u5lcvuuwd4lk7f3xewjk70j75yuh68myr89qkd0e8d44zgyjleeqw03vqs
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-08-14T08:33:17Z"
+    mac: ENC[AES256_GCM,data:qwYSXDA0Z5TEvq14o9HWs/vcCp7BzZ8f4QhQW+7hfjktUcKcpCdjhNYzfZAnUZdFzSWMdy+KkxY80xfqufIVI0DATQoRos8WrXtGpelpdrxxImo18zglKd4Cjhu+a6yOBxjjJYcpspHcgifVjeAzky/yhhuRQ5mYqQoW38IsUr8=,iv:09pHRKecuWCQxczyxCu5SCnpzmOHTCy5CWF++qTPCxE=,tag:NXHumJ9+eZ9iFQOsCnc2XA==,type:str]
+    version: 3.13.3

--- a/infrastructure/base/offsite-backup/verify.cronjob.yaml
+++ b/infrastructure/base/offsite-backup/verify.cronjob.yaml
@@ -1,0 +1,108 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: offsite-restore-verify
+  namespace: backup-offsite
+spec:
+  schedule: "0 8 * * 0"
+  timeZone: Europe/Berlin
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 21600
+      template:
+        spec:
+          restartPolicy: Never
+          terminationGracePeriodSeconds: 60
+          initContainers:
+            - name: prepare-rclone
+              image: docker.io/rclone/rclone:1.74.2
+              command: ["/bin/sh", "/scripts/prepare-rclone.sh"]
+              env:
+                - name: STORAGEBOX_HOST
+                  valueFrom:
+                    secretKeyRef: {name: storagebox-credentials, key: STORAGEBOX_HOST}
+                - name: STORAGEBOX_USERNAME
+                  valueFrom:
+                    secretKeyRef: {name: storagebox-credentials, key: STORAGEBOX_USERNAME}
+                - name: STORAGEBOX_PASSWORD
+                  valueFrom:
+                    secretKeyRef: {name: storagebox-credentials, key: STORAGEBOX_PASSWORD}
+              volumeMounts:
+                - name: config
+                  mountPath: /config
+                - name: scripts
+                  mountPath: /scripts
+                  readOnly: true
+            - name: restic-server
+              image: docker.io/rclone/rclone:1.74.2
+              restartPolicy: Always
+              args:
+                - serve
+                - restic
+                - storagebox:homelab-gitops/restic
+                - --addr=127.0.0.1:8080
+                - --config=/config/rclone.conf
+                - --cache-objects=false
+              volumeMounts:
+                - name: config
+                  mountPath: /config
+                  readOnly: true
+            - name: restore
+              image: docker.io/restic/restic:0.19.1
+              command: ["/bin/sh", "/scripts/verify.sh"]
+              env:
+                - name: RESTIC_REPOSITORY
+                  value: rest:http://127.0.0.1:8080/
+                - name: RESTIC_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: storagebox-credentials
+                      key: restic-password
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+                  readOnly: true
+                - name: work
+                  mountPath: /work
+                - name: restore
+                  mountPath: /restore
+          containers:
+            - name: validate
+              image: docker.io/library/postgres:18-alpine
+              command:
+                - /bin/sh
+                - -ec
+                - |
+                  test -f /work/restore.ok
+                  immich_dump=/restore/immich/staging/database/immich.dump
+                  nextcloud_dump=/restore/nextcloud/staging/database/nextcloud.dump
+                  nextcloud_app=/restore/nextcloud/staging/nextcloud-app.tar.gz
+                  test -s "${immich_dump}"
+                  test -s "${nextcloud_dump}"
+                  test -s "${nextcloud_app}"
+                  pg_restore --list "${immich_dump}" >/dev/null
+                  pg_restore --list "${nextcloud_dump}" >/dev/null
+                  tar -tzf "${nextcloud_app}" >/dev/null
+              volumeMounts:
+                - name: work
+                  mountPath: /work
+                  readOnly: true
+                - name: restore
+                  mountPath: /restore
+                  readOnly: true
+          volumes:
+            - name: config
+              emptyDir: {}
+            - name: work
+              emptyDir: {}
+            - name: restore
+              emptyDir:
+                sizeLimit: 10Gi
+            - name: scripts
+              configMap:
+                name: offsite-backup-scripts
+                defaultMode: 0555


### PR DESCRIPTION
## Summary

- add encrypted Restic backups for Immich and Nextcloud to Hetzner Storage Box
- preserve Nextcloud consistency with maintenance mode, staged Garage objects, DB dump, and app state
- add retention, repository checks, database validation, and SHA-256 verified user-data sample restores
- add scoped RBAC, pinned Hetzner SSH host key, SOPS credentials, and restore runbook

## Verification

- just validate
- focused yamllint, Kustomize, and kubeconform checks
- live Kubernetes server-side dry-run
- live read-only Storage Box connection with pinned host key
- local Restic backup/restore roundtrip for Immich and Nextcloud samples
- independent blocker review: no findings