### PR TITLE
fix(monitoring): Flux-Alerts + fünf Korrekturen aus dem Live-Test

### DIFF
--- a/KI-ALERT-PLAN.md
+++ b/KI-ALERT-PLAN.md
@@ -76,12 +76,22 @@ Runbooks für alle P0-Alerts angelegt.
 
 ---
 
-### Phase 4 — Flux-GitOps-Alerts (offen)
+### Phase 4 — Flux-GitOps-Alerts
+
+Anlass (14.08.2026): PR #661 hat die PVC `backup-offsite/nextcloud-offsite-staging`
+eingeführt; TrueNAS lehnte die Provisionierung ab (`>80% VOLUME`), die PVC blieb
+`Pending`. Der Health-Check der Kustomization `infra-base` lief dadurch dauerhaft
+in den 5-Minuten-Timeout und blieb auf `Ready=Unknown`. Weil `infra-main`, `apps`
+und `apps-monitoring-rules` per `dependsOn` daran hängen, standen die drei auf
+`Ready=False` mit `dependency ... is not ready`. Flux hat fünf Stunden lang nichts
+mehr aus Git ausgerollt, ohne jede Meldung.
 
 | Task | Status |
 |------|--------|
-| `infrastructure/base/flux-notifications/` Provider + Alert | ⬜ |
-| Eigener ntfy-Receiver `homelab-gitops` | ⬜ |
+| `apps/base/monitoring/extra-scrapes/flux-vmpodscrape.yaml` (gotk-Metriken, `honorLabels: true`) | ✅ |
+| `apps/base/monitoring/rules/flux-vmrule.yaml` (4 Alerts: `FluxControllerDown`, `FluxReconcileFailing`, `FluxReconcileStalled`, `FluxSuspended`) | ✅ |
+| Eigener ntfy-Receiver | nicht nötig — bestehende Route über `severity` + `homelab_owner: platform` greift bereits |
+| Runbook `docs/runbooks/flux-reconcile.md` | ✅ |
 
 ---
 
@@ -177,10 +187,13 @@ apps/base/monitoring/
 ├── notifications/
 │   ├── alertmanager-ntfy-credentials.secret.yaml
 │   └── alertmanager-n8n-webhook.secret.yaml  # nach sops-create
-└── rules/
-    ├── platform-p0-vmrule.yaml
-    ├── job-watchdog-vmrule.yaml           # generischer Job-Watchdog (Phase 7)
-    └── dead-mans-switch-vmrule.yaml       # Watchdog/vector(1) -> HA-Webhook (Phase 7)
+├── rules/
+│   ├── platform-p0-vmrule.yaml
+│   ├── job-watchdog-vmrule.yaml        # generischer Job-Watchdog (Phase 7)
+│   ├── dead-mans-switch-vmrule.yaml    # Watchdog/vector(1) -> HA-Webhook (Phase 7)
+│   └── flux-vmrule.yaml                # Flux-GitOps-Alerts (Phase 4)
+└── extra-scrapes/
+    └── flux-vmpodscrape.yaml           # gotk_* Metriken (Phase 4)
 
 docs/runbooks/
 ├── cnpg-cluster-offline.md
@@ -188,7 +201,8 @@ docs/runbooks/
 ├── velero-backup.md
 ├── node-resources.md
 ├── monitoring-stack.md
-└── job-watchdog.md                        # Phase 7
+├── job-watchdog.md                        # Phase 7
+└── flux-reconcile.md                      # Phase 4
 
 docs/integrations/
 └── dead-mans-switch-homeassistant.md       # Phase 7
@@ -209,6 +223,7 @@ docs/integrations/
 
 | Datum | Änderung |
 |-------|----------|
+| 2026-08-14 | Flux-GitOps-Alerts (Phase 4): PR #661 hat eine Pending-PVC eingeführt (TrueNAS >80%-VOLUME-Limit), `infra-base` hing 5h im Health-Check-Timeout (`Ready=Unknown`), `infra-main`/`apps`/`apps-monitoring-rules` dadurch `Ready=False` — Flux rollte fünf Stunden lang nichts mehr aus Git aus, ohne Meldung. Fix: `flux-vmpodscrape.yaml` + 4 Alerts (`FluxControllerDown`, `FluxReconcileFailing`, `FluxReconcileStalled`, `FluxSuspended`) in `flux-vmrule.yaml`, Runbook `flux-reconcile.md` |
 | 2026-08-14 | Generischer Job-Watchdog (7 Alerts, Opt-in per Label) + Dead-Man's-Switch über Home Assistant (Phase 7); `rules/authentik-vmrule.yaml` entfernt, in Watchdog aufgegangen |
 | 2026-05-30 | kubeApiServer-Scrape aus; Script `purge-chart-vmrules.sh` für verwaiste VMRules |
 | 2026-06-02 | `defaultRules.enabled: false` — `create: false` allein ließ Chart-VMRules (ScrapePoolHasNoTargets) |

--- a/apps/base/monitoring/extra-scrapes/flux-vmpodscrape.yaml
+++ b/apps/base/monitoring/extra-scrapes/flux-vmpodscrape.yaml
@@ -1,0 +1,33 @@
+# Flux-Controller-Metriken (gotk_*). Ohne diesen Scrape gibt es keine einzige
+# gotk-Serie und die Regeln in rules/flux-vmrule.yaml sind blind — geprueft:
+# vor diesem Objekt lieferte __name__=~"gotk.*" null Ergebnisse.
+#
+# Die Controller haben keinen Service, nur den Container-Port http-prom (8080).
+# Die bestehende NetworkPolicy flux-system/allow-scraping erlaubt Ingress auf
+# 8080 aus allen Namespaces, es ist also nichts weiter freizuschalten.
+#
+# honorLabels: true ist hier bewusst gesetzt. gotk_reconcile_condition traegt
+# ein eigenes `namespace`-Label: den Namespace des ueberwachten OBJEKTS (eine
+# HelmRelease liegt z. B. in monitoring oder cnpg-system), nicht den des
+# Controller-Pods. Ohne honorLabels ueberschreibt das Scrape-Relabeling das mit
+# "flux-system" und verschiebt das Original nach exported_namespace — damit
+# zeigt jeder Alert auf den falschen Namespace.
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMPodScrape
+metadata:
+  name: flux-controllers
+  namespace: flux-system
+  labels:
+    release: victoriametrics
+spec:
+  namespaceSelector:
+    matchNames:
+      - flux-system
+  selector:
+    matchLabels:
+      app.kubernetes.io/part-of: flux
+  podMetricsEndpoints:
+    - port: http-prom
+      interval: 30s
+      path: /metrics
+      honorLabels: true

--- a/apps/base/monitoring/extra-scrapes/kustomization.yaml
+++ b/apps/base/monitoring/extra-scrapes/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - blackbox-vmprobe.yaml
   - blackbox-vmprobe-tandoor.yaml
   - truenas-exporter-vmservicescrape.yaml
+  - flux-vmpodscrape.yaml

--- a/apps/base/monitoring/ntfy-bridge/deployment.yaml
+++ b/apps/base/monitoring/ntfy-bridge/deployment.yaml
@@ -33,6 +33,13 @@ spec:
             - name: http
               containerPort: 8080
           env:
+            # Ohne das puffert Python stdout, sobald es kein TTY ist. Beim
+            # Watchdog-Rollout am 14.08.2026 hinkten die Bridge-Logs dadurch
+            # ueber eine Stunde hinterher: eine korrekt zugestellte Meldung sah
+            # im Log aus, als waere sie nie angekommen. Genau im Stoerfall, wo
+            # man der Bridge zuschauen will, ist das Log damit wertlos.
+            - name: PYTHONUNBUFFERED
+              value: "1"
             - name: HTTP_ADDRESS
               value: "0.0.0.0"
             - name: HTTP_PORT

--- a/apps/base/monitoring/rules/flux-vmrule.yaml
+++ b/apps/base/monitoring/rules/flux-vmrule.yaml
@@ -1,0 +1,100 @@
+# Flux-GitOps-Alerts (KI-ALERT-PLAN Phase 4).
+#
+# Anlass: Am 14.08.2026 hat eine Pending-PVC aus PR #661 den Health-Check der
+# Kustomization infra-base blockiert. Weil infra-main, apps und
+# apps-monitoring-rules per dependsOn daran haengen, hat Flux fuenf Stunden
+# lang NICHTS mehr aus Git ausgerollt — ohne eine einzige Meldung. Gemerkt
+# wurde es nur, weil zufaellig jemand auf ein fehlendes Deployment wartete.
+#
+# Der Fall ist derselbe wie beim Job-Watchdog: Ausbleiben von Erfolg ist ein
+# Signal, nicht nur ein Fehler.
+#
+# Voraussetzung: extra-scrapes/flux-vmpodscrape.yaml. Ohne den Scrape gibt es
+# keine gotk-Serien und nur FluxControllerDown feuert (fail loud).
+#
+# gotk_reconcile_condition ist eine Serie je (kind, name, namespace, type,
+# status) mit Wert 0/1. "Ready ist False" heisst also
+# {type="Ready", status="False"} == 1 — nicht etwa == 0.
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMRule
+metadata:
+  name: homelab-flux
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/part-of: homelab-monitoring
+    homelab/owner: platform
+spec:
+  groups:
+    - name: homelab.platform.flux
+      interval: 60s
+      rules:
+        - alert: FluxControllerDown
+          # Meta-Alert: keine einzige gotk-Serie. Entweder sind die Controller
+          # weg oder der VMPodScrape wurde entfernt. Ohne diesen Alert saehe
+          # beides wie "alles gruen" aus.
+          expr: |
+            absent(gotk_reconcile_condition)
+          for: 15m
+          labels:
+            severity: critical
+            cluster: homelab
+            homelab_owner: platform
+          annotations:
+            summary: "Flux liefert keine Metriken mehr"
+            description: "Es existiert keine einzige gotk_reconcile_condition-Serie. Entweder laufen die Flux-Controller nicht mehr, oder der VMPodScrape flux-controllers fehlt. Solange dieser Alert steht, ist unbekannt, ob Git ueberhaupt noch ausgerollt wird."
+            runbook_url: "https://git.f4mily.net/homelab/gitops-homelab/blob/main/docs/runbooks/flux-reconcile.md"
+
+        - alert: FluxReconcileFailing
+          # Ready=False: der haeufigere Fall — fehlgeschlagener Apply, kaputtes
+          # Manifest, oder (wie am 14.08.) "dependency is not ready" bei allen
+          # nachgelagerten Kustomizations.
+          expr: |
+            gotk_reconcile_condition{type="Ready", status="False"} == 1
+            unless on (kind, name, namespace)
+            (gotk_suspend_status == 1)
+          for: 15m
+          labels:
+            severity: critical
+            cluster: homelab
+            homelab_owner: platform
+          annotations:
+            summary: "Flux: {{ $labels.kind }}/{{ $labels.name }} nicht Ready"
+            description: "{{ $labels.kind }} {{ $labels.name }} in {{ $labels.namespace }} steht seit ueber 15 Minuten auf Ready=False. Aenderungen aus Git landen fuer dieses Objekt — und alles was per dependsOn daran haengt — nicht mehr im Cluster. Details: flux get all -A --status-selector ready=false"
+            runbook_url: "https://git.f4mily.net/homelab/gitops-homelab/blob/main/docs/runbooks/flux-reconcile.md"
+
+        - alert: FluxReconcileStalled
+          # Ready=Unknown, also "Reconciliation in progress", die nie endet.
+          # Genau so sah infra-base am 14.08. aus: der Health-Check lief in eine
+          # 5-Minuten-Timeout-Schleife und blieb dauerhaft Unknown. Ein Alert
+          # nur auf status="False" haette die Ursache NICHT gesehen, nur die
+          # Folgefehler weiter unten in der Kette.
+          # 30 Minuten, damit langsame Helm-Installationen nicht anschlagen.
+          expr: |
+            gotk_reconcile_condition{type="Ready", status="Unknown"} == 1
+            unless on (kind, name, namespace)
+            (gotk_suspend_status == 1)
+          for: 30m
+          labels:
+            severity: critical
+            cluster: homelab
+            homelab_owner: platform
+          annotations:
+            summary: "Flux: {{ $labels.kind }}/{{ $labels.name }} haengt im Reconcile"
+            description: "{{ $labels.kind }} {{ $labels.name }} in {{ $labels.namespace }} steht seit ueber 30 Minuten auf Ready=Unknown. Typisch: ein Health-Check laeuft dauerhaft in den Timeout (z. B. eine Pending-PVC). Alles was per dependsOn dahinter liegt, wird nicht mehr ausgerollt. Ursache: kubectl -n flux-system get kustomization; kubectl -n flux-system logs deploy/kustomize-controller | grep -i 'health check'"
+            runbook_url: "https://git.f4mily.net/homelab/gitops-homelab/blob/main/docs/runbooks/flux-reconcile.md"
+
+        - alert: FluxSuspended
+          # Ein suspendiertes Objekt ist der GitOps-Zwilling des suspendierten
+          # CronJobs: Git und Cluster laufen still auseinander, ohne Fehler.
+          # Meist eine Notmassnahme, die niemand zurueckgenommen hat.
+          expr: |
+            gotk_suspend_status == 1
+          for: 1h
+          labels:
+            severity: warning
+            cluster: homelab
+            homelab_owner: platform
+          annotations:
+            summary: "Flux: {{ $labels.kind }}/{{ $labels.name }} ist suspendiert"
+            description: "{{ $labels.kind }} {{ $labels.name }} in {{ $labels.namespace }} ist seit ueber einer Stunde suspendiert. Aenderungen aus Git werden fuer dieses Objekt nicht angewendet — der Cluster driftet stillschweigend von Git weg. Falls das eine Notmassnahme war: flux resume {{ $labels.kind | lower }} -n {{ $labels.namespace }} {{ $labels.name }}"
+            runbook_url: "https://git.f4mily.net/homelab/gitops-homelab/blob/main/docs/runbooks/flux-reconcile.md"

--- a/apps/base/monitoring/rules/job-watchdog-vmrule.yaml
+++ b/apps/base/monitoring/rules/job-watchdog-vmrule.yaml
@@ -81,9 +81,22 @@ spec:
           # nachgewiesen an nextcloud-cron-29768115, 7,4 Tage alt und weiterhin
           # failed=1. Danach uebernimmt WatchdogJobStale mit derselben
           # Schwelle, die Uebergabe ist also lueckenlos.
+          #
+          # Aggregiert bewusst OHNE job_name: Kubernetes loescht den alten
+          # fehlgeschlagenen Job, sobald der naechste scheitert
+          # (failedJobsHistoryLimit). Mit job_name im Label-Set entstuende bei
+          # jedem Lauf eine neue Alert-Serie und das for: 10m finge jedes Mal
+          # von vorn an - bei einem 5-Minuten-CronJob koennte der Alert nie
+          # feuern. Im Test am 14.08.2026 blieb er so 20 Minuten auf pending.
+          # Ohne job_name ist die Serie je CronJob stabil.
+          #
+          # min statt max: der Wert ist Job-Alter / max-age, ein frischer
+          # Fehlschlag hat also den KLEINSTEN Wert. max wuerde von einer alten
+          # Karteileiche ueber die Schwelle gezogen und den frischen Fehlschlag
+          # verdecken.
           expr: |
             (
-              max by (namespace, cronjob, job_name) (
+              min by (namespace, cronjob) (
                 label_replace(
                     (kube_job_failed{condition="true"} == 1)
                   * on (namespace, job_name) group_left (owner_name)
@@ -110,7 +123,7 @@ spec:
             homelab_owner: platform
           annotations:
             summary: "Job fehlgeschlagen: {{ $labels.namespace }}/{{ $labels.cronjob }}"
-            description: "Job {{ $labels.job_name }} ist fehlgeschlagen. Logs: kubectl -n {{ $labels.namespace }} logs job/{{ $labels.job_name }} --all-containers --prefix"
+            description: "Ein Lauf von {{ $labels.cronjob }} ist fehlgeschlagen. Betroffenen Job finden und Logs lesen: kubectl -n {{ $labels.namespace }} get jobs --sort-by=.status.startTime | tail -3 && kubectl -n {{ $labels.namespace }} logs job/<name> --all-containers --prefix"
             runbook_url: "https://git.f4mily.net/homelab/gitops-homelab/blob/main/docs/runbooks/job-watchdog.md"
 
         - alert: WatchdogJobStale

--- a/apps/base/monitoring/rules/kustomization.yaml
+++ b/apps/base/monitoring/rules/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   # generischen Job-Watchdog aufgegangen (Labels am CronJob statt eigener Regeln).
   - job-watchdog-vmrule.yaml
   - dead-mans-switch-vmrule.yaml
+  - flux-vmrule.yaml

--- a/apps/base/monitoring/vm-k8s-stack/helmrelease.yaml
+++ b/apps/base/monitoring/vm-k8s-stack/helmrelease.yaml
@@ -224,7 +224,13 @@ spec:
                 - alertname="Watchdog"
               receiver: homeassistant-watchdog
               group_wait: 0s
-              group_interval: 5m
+              # group_interval bewusst 1m, nicht 5m: Alertmanager prueft die
+              # Wiederholung NUR an group_interval-Ticks. Bei
+              # group_interval == repeat_interval verfehlt der erste Tick die
+              # Bedingung knapp, und der Herzschlag kommt erst beim zweiten —
+              # gemessen 11 statt 5 Minuten. Mit 1m liegt der Takt dort, wo ihn
+              # repeat_interval hinlegen soll.
+              group_interval: 1m
               repeat_interval: 5m
             # Bypass bridge when it is down (JSON to ntfy — only this alert gets through)
             - matchers:

--- a/docs/integrations/dead-mans-switch-homeassistant.md
+++ b/docs/integrations/dead-mans-switch-homeassistant.md
@@ -29,7 +29,15 @@ flowchart LR
   darf nur den Herzschlag auslösen, nicht dauerhaft pushen.
 - **Alertmanager-Route**: erste Kind-Route unter der Root-Route,
   `matchers: [alertname="Watchdog"]` → Receiver `homeassistant-watchdog`,
-  `group_wait: 0s`, `group_interval: 5m`, `repeat_interval: 5m`,
+  `group_wait: 0s`, `group_interval: 1m`, `repeat_interval: 5m`,
+
+  > `group_interval` steht bewusst auf `1m`. Alertmanager prüft die
+  > Wiederholung **nur an `group_interval`-Ticks**. Steht `group_interval` auf
+  > demselben Wert wie `repeat_interval`, verfehlt der erste Tick die Bedingung
+  > knapp und der Herzschlag kommt erst beim zweiten — am 14.08.2026 gemessen:
+  > 11 Minuten Abstand statt der konfigurierten 5. Mit `1m` liegt der Takt da,
+  > wo `repeat_interval` ihn hinlegen soll.
+
   `send_resolved: false`. Der Receiver ruft
   `url_file: /etc/vm/secrets/alertmanager-homeassistant-webhook/url` auf — das
   SOPS-Secret `alertmanager-homeassistant-webhook` (Key `url`) liegt in
@@ -61,10 +69,22 @@ flowchart LR
     > Herzschlag, der Timer blieb seit Erstellung `idle` und die Automation
     > pushte 2,5 Stunden lang alle 15 Minuten. `timer.finished` setzt dagegen
     > voraus, dass der Timer tatsächlich lief.
+  - `input_boolean.k8s_heartbeat_alarm_aktiv` — Merker „es steht ein
+    Heartbeat-Alarm". Automation B schaltet ihn ein, Automation C wieder aus.
   - `automation.k8s_watchdog_herzschlag_zuruck` — Trigger: `timer.started`
     (feuert nur beim Übergang idle→active, nicht bei jedem Neustart des
-    Timers). Condition: `persistent_notification.k8s_heartbeat_missing` ist
-    im Zustand `notifying`. Aktion: Entwarnung + Dismiss der Notification.
+    Timers). Condition: `input_boolean.k8s_heartbeat_alarm_aktiv` ist `on`.
+    Aktion: Entwarnung + Dismiss der Notification + Merker aus.
+
+    > **Nicht auf `persistent_notification.<id>` prüfen.** Naheliegend wäre,
+    > als Merker die Notification selbst zu nehmen
+    > (`persistent_notification.k8s_heartbeat_missing == notifying`). Home
+    > Assistant führt persistent notifications aber seit Jahren **nicht mehr
+    > als Entitäten** im State-Machine — die Bedingung ist damit dauerhaft
+    > falsch, die Entwarnung käme nie und die Meldung bliebe für immer stehen.
+    > Die Notification wird sehr wohl erzeugt (sichtbar über den
+    > WebSocket-Befehl `persistent_notification/get`), sie hat nur keinen
+    > Zustand, den eine Condition lesen kann. Deshalb der `input_boolean`.
 
 ## Warum `restore: true`
 

--- a/docs/integrations/dead-mans-switch-homeassistant.md
+++ b/docs/integrations/dead-mans-switch-homeassistant.md
@@ -14,13 +14,13 @@ flowchart LR
   VM[VMRule Watchdog<br/>expr: vector(1)]
   AM[Alertmanager<br/>Route alertname=Watchdog]
   HA[Home Assistant<br/>Webhook]
-  Timer[timer.k8s_watchdog_herzschlag<br/>15 Min, restore: true]
+  Timer[timer.k8s_watchdog_herzschlag<br/>60 Min, restore: true]
   Push[Mobile Push +<br/>persistent_notification]
 
   VM -->|alle 60s| AM
   AM -->|alle 5 Min, POST| HA
   HA -->|timer.start| Timer
-  Timer -->|timer.finished ODER<br/>time_pattern /15, idle| Push
+  Timer -->|timer.finished| Push
 ```
 
 - **VMRule** `apps/base/monitoring/rules/dead-mans-switch-vmrule.yaml`: Alert
@@ -39,14 +39,28 @@ flowchart LR
   in Klartext in Git.
 - **Home Assistant** (separates System, nicht in diesem Repo, nicht per GitOps
   verwaltet):
-  - `timer.k8s_watchdog_herzschlag` — Dauer 15 Minuten, `restore: true`.
+  - `timer.k8s_watchdog_herzschlag` — Dauer 60 Minuten, `restore: true`. Bei
+    einem Herzschlag alle 5 Minuten toleriert das 11 verpasste Zustellungen,
+    bevor alarmiert wird — kurze Reconciles, AM-Neustarts und Netz-Blips lösen
+    also keinen Fehlalarm aus.
   - `automation.k8s_watchdog_herzschlag_empfangen` — Trigger: Webhook (POST,
     `local_only: true`) → Aktion: `timer.start`.
-  - `automation.k8s_watchdog_herzschlag_fehlt` — Trigger: `timer.finished` **und**
-    `time_pattern` `/15` als wiederholende Erinnerung; Condition: Timer-Zustand
-    ist `idle`. Aktion: Push an `notify.mobile_app_pixel_10_pro_xl_sebastian` +
+  - `automation.k8s_watchdog_herzschlag_fehlt` — Trigger: **ausschließlich**
+    `timer.finished`, ohne Condition. Aktion: Push an
+    `notify.mobile_app_pixel_10_pro_xl_sebastian` +
     `persistent_notification.create` mit fester `notification_id:
-    k8s_heartbeat_missing`.
+    k8s_heartbeat_missing`. Es gibt bewusst **eine** Meldung pro Ausfall und
+    keine Wiederholung.
+
+    > **Nicht wieder einbauen:** Ein zusätzlicher `time_pattern`-Trigger mit
+    > Condition „Timer ist `idle`" als Erinnerung sieht naheliegend aus, ist
+    > aber falsch. Ein Timer, der **nie gestartet** wurde, steht ebenfalls auf
+    > `idle` — die Condition kann „abgelaufen" und „noch nie gelaufen" nicht
+    > unterscheiden. Genau das ist am 14.08.2026 passiert: die HA-Seite stand,
+    > die Cluster-Seite hing noch im Flux-Reconcile, also kam nie ein
+    > Herzschlag, der Timer blieb seit Erstellung `idle` und die Automation
+    > pushte 2,5 Stunden lang alle 15 Minuten. `timer.finished` setzt dagegen
+    > voraus, dass der Timer tatsächlich lief.
   - `automation.k8s_watchdog_herzschlag_zuruck` — Trigger: `timer.started`
     (feuert nur beim Übergang idle→active, nicht bei jedem Neustart des
     Timers). Condition: `persistent_notification.k8s_heartbeat_missing` ist
@@ -82,7 +96,7 @@ Zerstörungsfrei, ohne auf den echten 5-Minuten-Zyklus zu warten:
 
 1. In Home Assistant `timer.finish` auf `timer.k8s_watchdog_herzschlag`
    aufrufen (Entwickler-Tools → Aktionen, oder `ha_call_service`). Das
-   entspricht dem Ablauf eines echten Timers, ohne 15 Minuten zu warten.
+   entspricht dem Ablauf eines echten Timers, ohne eine Stunde zu warten.
 2. Erwartung: Push-Benachrichtigung an `notify.mobile_app_pixel_10_pro_xl_sebastian`
    und eine `persistent_notification` mit ID `k8s_heartbeat_missing` erscheinen
    sofort.

--- a/docs/rulebook.md
+++ b/docs/rulebook.md
@@ -201,6 +201,17 @@ loop.
 
 ## 5. GitOps / reconciliation
 
+- **Monitor the deploy pipeline itself, not just what it deploys.** A GitOps
+  controller (or any pull-based deploy automation) that stops reconciling does
+  not raise an error — it simply stops doing anything, while the cluster's
+  last-applied state keeps looking healthy on every other dashboard. Alert
+  directly on the controller's own reconcile-condition metrics, and treat a
+  hard failure and a reconcile that never finishes as two different failure
+  modes needing separate alerts: a stuck health-check wedged in a permanent
+  timeout (e.g. one blocked on a `Pending` PVC) reports as "still in
+  progress", not as an error, and a dependency chain built on top of it fails
+  loudly downstream while the true cause sits quietly upstream reporting
+  neither success nor failure.
 - **All changes land via Git — never `kubectl edit` a managed resource.** A
   pruning reconciler reverts live edits on its interval; a live patch is an
   emergency unblock only, and must be converged back into Git or it silently

--- a/docs/runbooks/flux-reconcile.md
+++ b/docs/runbooks/flux-reconcile.md
@@ -1,0 +1,267 @@
+# Flux-Reconcile-Alerts
+
+## 1. Warum es diese Alerts gibt
+
+Am 14.08.2026 hat PR #661 die PVC `backup-offsite/nextcloud-offsite-staging`
+(250Gi, StorageClass `truenas-iscsi`) eingeführt. TrueNAS lehnte die
+Provisionierung ab (`It is not recommended to use more than 80% of your
+available space for VOLUME`), die PVC blieb `Pending`. Der Health-Check der
+Kustomization `infra-base` wartet auf genau diese PVC und lief dadurch alle
+fünf Minuten erneut in den Timeout:
+
+```
+health check failed: timeout waiting for: [PersistentVolumeClaim/backup-offsite/nextcloud-offsite-staging status: 'InProgress']
+```
+
+`infra-base` blieb dauerhaft auf `Ready=Unknown` stehen. Weil `infra-main`,
+`apps` und `apps-monitoring-rules` per `dependsOn` an `infra-base` hängen,
+standen die drei auf `Ready=False` mit `dependency ... is not ready`.
+Ergebnis: Flux hat fünf Stunden lang nichts mehr aus Git ausgerollt — ohne
+jede Meldung. Aufgefallen ist es nur, weil zufällig jemand auf ein
+ausbleibendes Deployment wartete.
+
+Der Fall ist derselbe wie beim Job-Watchdog (siehe
+[job-watchdog.md](job-watchdog.md)): Ausbleiben von Erfolg ist ein Signal,
+nicht nur ein expliziter Fehler. Bis zu diesem Vorfall gab es für die
+GitOps-Pipeline selbst kein Alerting — ein Kustomization- oder
+HelmRelease-Objekt konnte beliebig lange `False` oder `Unknown` stehen, ohne
+dass irgendwer benachrichtigt wurde.
+
+Alle vier Alerts liegen in `apps/base/monitoring/rules/flux-vmrule.yaml`,
+Gruppe `homelab.platform.flux`, im Namespace `monitoring`. Voraussetzung ist
+der `VMPodScrape` in `apps/base/monitoring/extra-scrapes/flux-vmpodscrape.yaml`
+— ohne ihn gibt es keine `gotk_*`-Serien und nur `FluxControllerDown` würde
+feuern.
+
+**Technischer Hintergrund, wichtig beim Anpassen der Regeln:**
+`gotk_reconcile_condition` ist eine Serie je (`kind`, `name`, `namespace`,
+`type`, `status`) mit Wert 0/1. "Ready ist False" heißt in MetricsQL
+`{type="Ready", status="False"} == 1` — **nicht** `{type="Ready"} == 0`. Das
+ist die häufigste Fehlerquelle, wenn hier jemand eine weitere Regel ergänzt.
+
+Der `VMPodScrape` setzt außerdem `honorLabels: true`, weil
+`gotk_reconcile_condition` ein eigenes `namespace`-Label trägt: den Namespace
+des überwachten Objekts (eine HelmRelease liegt z. B. in `monitoring` oder
+`cnpg-system`), nicht den des Controller-Pods (`flux-system`). Ohne
+`honorLabels` überschreibt das Scrape-Relabeling dieses Label mit
+`flux-system` und schiebt das Original nach `exported_namespace` — jeder
+Alert hätte dann auf den falschen Namespace gezeigt.
+
+Die Flux-Controller haben keinen Service, nur den Container-Port
+`http-prom` (8080). Die bestehende NetworkPolicy `flux-system/allow-scraping`
+erlaubt Ingress auf 8080 aus allen Namespaces — für den Scrape war nichts
+weiter freizuschalten.
+
+**Routing:** unverändert gegenüber allen anderen Platform-Alerts. `severity`
++ `homelab_owner: platform` greifen in die bestehenden Alertmanager-Routen →
+ntfy-Topic `monitoring` sowie n8n/Telegram-Triage. Es gibt keinen eigenen
+Receiver für Flux — siehe [monitoring-stack.md](monitoring-stack.md).
+
+## 2. Nützliche Basisbefehle für jede Diagnose
+
+```bash
+flux get all -A --status-selector ready=false
+kubectl -n flux-system get kustomization
+kubectl -n flux-system get kustomization <name> -o jsonpath='{.status.conditions}'
+kubectl -n flux-system logs deploy/kustomize-controller | grep -i "health check"
+kubectl -n flux-system logs deploy/helm-controller --tail=100
+flux reconcile source git flux-system
+flux reconcile kustomization <name> --timeout=5m
+flux resume kustomization <name>
+```
+
+**Wichtig:** Der Kustomization-Status selbst zeigt bei einem hängenden
+Health-Check meist nur `"Reconciliation in progress"` — die eigentliche
+Ursache (welche Ressource, welcher Timeout) steht fast nie im Status, sondern
+nur im Log des `kustomize-controller`. Der `grep -i "health check"` oben ist
+deshalb der entscheidende Schritt, nicht ein Nice-to-have.
+
+## 3. Die Alerts
+
+### FluxControllerDown — critical, `for: 15m`
+
+**Bedeutung:** `absent(gotk_reconcile_condition)` — es existiert keine
+einzige gotk-Serie mehr. Entweder sind die Flux-Controller weg, oder der
+`VMPodScrape flux-controllers` wurde entfernt. Solange dieser Alert steht,
+ist unbekannt, ob Git überhaupt noch ausgerollt wird — er ist der
+wichtigste Alert im Set, analog zu `WatchdogBlind` beim Job-Watchdog.
+
+**Sofortdiagnose:**
+
+```bash
+kubectl -n flux-system get pods
+kubectl get vmpodscrape -n flux-system flux-controllers
+```
+
+**Typische Ursachen:**
+
+- Flux-Controller-Pods sind gecrasht oder das Deployment ist auf 0 skaliert.
+- Der `VMPodScrape` wurde aus Git entfernt oder das Selector-Label
+  `app.kubernetes.io/part-of: flux` stimmt nach einem Flux-Upgrade nicht mehr.
+- Die NetworkPolicy `flux-system/allow-scraping` wurde geändert und blockiert
+  jetzt den Scrape auf Port 8080.
+
+**Behebung:** Controller-Pods reparieren (Logs prüfen, ggf. Deployment
+neu starten) bzw. den `VMPodScrape`/die NetworkPolicy in Git wiederherstellen
+und Flux reconcilen lassen. Danach prüfen, dass
+`gotk_reconcile_condition` wieder Serien liefert.
+
+### FluxReconcileFailing — critical, `for: 15m`
+
+**Bedeutung:** `gotk_reconcile_condition{type="Ready", status="False"} == 1`,
+suspendierte Objekte ausgenommen. Der häufigere Fall: ein fehlgeschlagener
+Apply, ein kaputtes Manifest, oder — wie am 14.08. bei `infra-main`, `apps`
+und `apps-monitoring-rules` — `dependency ... is not ready`, weil ein
+vorgelagertes Objekt hängt.
+
+**Sofortdiagnose:**
+
+```bash
+flux get all -A --status-selector ready=false
+kubectl -n flux-system get kustomization <name> -o jsonpath='{.status.conditions}'
+```
+
+**Typische Ursachen:**
+
+- Ein Manifest ist syntaktisch oder semantisch ungültig (Apply schlägt fehl).
+- Eine HelmRelease-Installation/-Upgrade ist fehlgeschlagen (siehe
+  `helm-controller`-Logs).
+- Die Ursache ist gar nicht in diesem Objekt, sondern in einer
+  vorgelagerten Abhängigkeit, die auf `Ready=Unknown` oder `Ready=False`
+  steht — siehe Abschnitt "Ursache vs. Folge" unten.
+
+**Behebung:** Fehlermeldung aus den Kustomization-Conditions bzw. den
+Controller-Logs lesen, Manifest in Git korrigieren, `flux reconcile
+kustomization <name> --timeout=5m`. Steht die Ursache bei einer
+Abhängigkeit, dort zuerst reparieren — dieses Objekt löst sich dann meist
+von selbst.
+
+### FluxReconcileStalled — critical, `for: 30m`
+
+**Bedeutung:** `gotk_reconcile_condition{type="Ready", status="Unknown"} ==
+1`, suspendierte Objekte ausgenommen — ein Reconcile, das nie endet. Genau
+so sah `infra-base` am 14.08. aus: der Health-Check auf die
+`nextcloud-offsite-staging`-PVC lief alle fünf Minuten erneut in den
+Timeout und blieb dauerhaft `Unknown`. 30 Minuten `for`, damit langsame
+Helm-Installationen (die während der Installation ebenfalls kurz `Unknown`
+stehen) nicht anschlagen.
+
+**Sofortdiagnose:**
+
+```bash
+kubectl -n flux-system get kustomization
+kubectl -n flux-system logs deploy/kustomize-controller | grep -i "health check"
+```
+
+**Typische Ursachen:**
+
+- Ein Health-Check wartet auf eine Ressource, die nie in den erwarteten
+  Zustand kommt — am 14.08. eine `Pending` gebliebene PVC, weil TrueNAS die
+  Provisionierung ablehnte (`>80% VOLUME`-Grenze).
+- Ein Helm-Chart-Install/-Upgrade hängt (siehe `helm-controller`-Logs), z. B.
+  weil ein Pod nicht `Ready` wird.
+- Eine referenzierte Ressource (Secret, ConfigMap) fehlt und der Health-Check
+  wartet auf etwas, das nie erscheint.
+
+**Behebung:** Ursache über die Controller-Logs finden (**nicht** über den
+Kustomization-Status — der zeigt nur "Reconciliation in progress"), die
+blockierende Ressource reparieren (z. B. PVC-Anforderung anpassen, Storage
+freimachen), danach `flux reconcile kustomization <name> --timeout=5m`.
+
+**Bekannte Nachbar-Falle (HelmRelease `RetriesExceeded`):** Eine
+HelmRelease, die ihre Retries erschöpft hat, geht in den terminalen Zustand
+`RetriesExceeded` und **erholt sich nicht von selbst** — sie braucht einen
+manuellen `flux reconcile helmrelease <name> -n <ns>` bzw. `flux resume`,
+sonst bleibt sie dauerhaft gestallt, auch nachdem die eigentliche Ursache
+behoben wurde. Siehe die Erfahrung dazu in
+[monitoring-stack.md](monitoring-stack.md) (`vm-k8s-stack`-Reconcile nach
+Konfigänderungen).
+
+### FluxSuspended — warning, `for: 1h`
+
+**Bedeutung:** `gotk_suspend_status == 1` — ein Objekt ist suspendiert. Das
+GitOps-Pendant zum suspendierten CronJob im Job-Watchdog: Git und Cluster
+laufen still auseinander, ohne dass irgendwo ein Fehler steht. Meist eine
+Notmaßnahme aus einem Vorfall, die niemand zurückgenommen hat — genau das
+Muster, das `nextcloud-cron` während des iSCSI-Ausfalls vom 13.06.2026
+hinterlassen hat (siehe [job-watchdog.md](job-watchdog.md)).
+
+**Sofortdiagnose:**
+
+```bash
+kubectl -n flux-system get kustomization,helmrelease,gitrepository,ocirepository -A \
+  -o jsonpath='{range .items[?(@.spec.suspend==true)]}{.kind}{"/"}{.metadata.name}{" -n "}{.metadata.namespace}{"\n"}{end}'
+git log --oneline -- '<pfad-zum-manifest>'
+```
+
+**Typische Ursachen:**
+
+- Manuelle Notmaßnahme während eines Vorfalls (`flux suspend ...`), nie in
+  Git zurückgenommen.
+- `spec.suspend: true` wurde versehentlich gemerged.
+
+**Behebung:** In Git `suspend: false` setzen (bzw. das Feld entfernen),
+committen, Flux reconcilen lassen — ein manuelles `flux resume` wird beim
+nächsten Reconcile aus Git ohnehin wieder überschrieben, wenn der
+`suspend`-Wert in Git nicht ebenfalls korrigiert wird.
+
+## 4. Ursache vs. Folge: Unknown vs. False
+
+Der 14.08.2026-Vorfall zeigte sich als **eine** hängende Kustomization
+(`Ready=Unknown`) und **drei** fehlgeschlagene Folge-Kustomizations
+(`Ready=False`). Die `dependsOn`-Kette:
+
+```
+infra-sources → infra-storage → infra-base → infra-main → apps → apps-monitoring-rules
+```
+
+`infra-base` hing am Health-Check der PVC und blieb `Ready=Unknown`.
+`infra-main`, `apps` und `apps-monitoring-rules` hängen (direkt oder über
+die Kette) an `infra-base` per `dependsOn` und standen deshalb auf
+`Ready=False` mit `dependency ... is not ready` — sie selbst hatten keinen
+eigenen Fehler.
+
+**Die Regel für den Doppelschlag:** Wenn `FluxReconcileStalled` und
+`FluxReconcileFailing` gleichzeitig feuern, ist **das Unknown-Objekt die
+Ursache, die False-Objekte sind die Folge**. Zuerst das `Unknown`-Objekt
+reparieren (Health-Check-Blocker beheben), dann top-down entlang der
+`dependsOn`-Kette reconcilen — die nachgelagerten `False`-Objekte lösen sich
+danach in aller Regel selbst, ohne eigenen Eingriff.
+
+Ein Alert, der nur auf `status="False"` feuert, hätte am 14.08. ausschließlich
+die drei Folgefehler gemeldet und den Blick auf die Symptome gelenkt — die
+eigentliche Ursache (`infra-base` im Health-Check-Timeout) wäre unsichtbar
+geblieben, solange niemand auch in den `Unknown`-Zustand geschaut hätte.
+Deshalb gibt es `FluxReconcileFailing` und `FluxReconcileStalled` als zwei
+getrennte Regeln statt einer gemeinsamen `!= "True"`-Regel.
+
+## 5. Bekannte Grenzen
+
+1. **Kein eigener ntfy-Receiver.** Die vier Alerts nutzen ausschließlich die
+   bestehende Routing-Logik über `severity` + `homelab_owner: platform`. Das
+   ist bewusst so — es gibt keinen Grund, für Flux eine eigene Route zu
+   pflegen, solange die Platform-Route greift.
+2. **`for: 30m` bei `FluxReconcileStalled` heißt bis zu 30 Minuten Blindheit
+   nach einem echten Hang.** Der Wert ist bewusst höher als bei
+   `FluxReconcileFailing`, um langsame Helm-Installationen nicht
+   fälschlicherweise als Stall zu melden — ein sehr kurzer echter Hang bleibt
+   in diesem Fenster unbemerkt.
+3. **Kein CI-Check der Alert-Queries.** Wie beim Job-Watchdog gibt es keinen
+   VMRule-Admission-Webhook und keine Expression-Validierung in der
+   CI-Pipeline. Nach jeder Änderung an diesem VMRule die vmalert-Rules-API
+   prüfen:
+   ```bash
+   kubectl -n monitoring exec deploy/vmalert-vm-k8s-stack-victoria-metrics-k8s-stack -c vmalert -- \
+     wget -qO- http://127.0.0.1:8080/api/v1/rules
+   ```
+4. **Group-by ohne `name`/`namespace` in der Alertmanager-Root-Route.**
+   Mehrere gleichzeitig betroffene Flux-Objekte (wie am 14.08.: eine
+   `Unknown`- plus drei `False`-Kustomizations) ergeben deshalb eine
+   ntfy-Nachricht mit mehreren Zeilen statt mehreren Einzel-Nachrichten —
+   das ist gewollt, siehe [monitoring-stack.md](monitoring-stack.md) bzw. das
+   generelle Muster im [Rulebook](../rulebook.md).
+5. **`gotk_suspend_status` deckt keine Halb-Suspendierung ab.** Wird nur die
+   `GitRepository`-Quelle suspendiert, aber die abhängigen Kustomizations
+   nicht, feuert `FluxSuspended` nur für die Quelle — die Kustomizations
+   selbst laufen mit dem letzten bekannten Commit weiter, ohne dass das aus
+   den Alerts allein erkennbar ist.

--- a/docs/runbooks/job-watchdog.md
+++ b/docs/runbooks/job-watchdog.md
@@ -39,7 +39,15 @@ metadata:
 
 ```
 max-age-hours >= Schedule-Intervall + activeDeadlineSeconds
+max-age-hours >  10 Minuten (0.17)
 ```
+
+Die zweite Zeile ist eine harte Untergrenze, keine Empfehlung: `WatchdogJobFailed`
+hat ein Alters-Gate auf `max-age-hours` (siehe unten) **und** ein `for: 10m`.
+Liegt `max-age-hours` unter 10 Minuten, faellt die Serie aus dem Gate, bevor
+`for` erfuellt ist — der Alert kann dann nie feuern. In der Praxis ist das nie
+ein Thema (kleinster echter Wert ist 1h), aber beim Basteln mit Testwerten
+laeuft man genau da hinein.
 
 Grund: `kube_cronjob_status_last_successful_time` wird erst am **Ende** eines
 Laufs gesetzt, nicht beim Start. Ein täglicher Job mit `activeDeadlineSeconds:
@@ -323,12 +331,21 @@ laufen lassen), damit die `ownerReferences` stehen. `kubectl create job
 bricht damit den `kube_job_owner`-Join, den `WatchdogJobFailed` und
 `WatchdogJobStuck` benötigen — der Selbsttest würde dann nichts auslösen.
 
-Erwarteter Ablauf: `WatchdogConfigInvalid` bleibt aus (Werte sind gültige
-Zahlen), nach dem ersten Lauf feuert `WatchdogJobFailed` (der Job schlägt
-mit `/bin/false` fehl), nach ca. 3 Minuten `WatchdogJobStale`
-(`max-age-hours=0.05` ≈ 3 Minuten). Nach dem `delete` erscheint irgendwann im
-Fenster [+10m, +1h] `WatchdogCronJobDisappeared` und resolved danach von
-selbst.
+Erwarteter Ablauf mit `max-age-hours=0.05`: `WatchdogConfigInvalid` bleibt aus
+(Werte sind gültige Zahlen). `WatchdogJobStale` geht sofort auf `pending` und
+feuert nach 30 Minuten. Nach dem `delete` erscheint im Fenster [+10m, +1h]
+`WatchdogCronJobDisappeared` und resolved danach von selbst.
+
+**`WatchdogJobFailed` feuert mit diesem Wert absichtlich NICHT** — und das ist
+kein Fehler, sondern die Untergrenze aus Abschnitt 2 in Aktion: bei
+`max-age-hours=0.05` (3 Minuten) faellt jede Job-Serie nach 3 Minuten aus dem
+Alters-Gate, das `for: 10m` wird also nie erreicht. Um auch diesen Pfad zu
+pruefen, nach dem Stale-Test umlabeln und zehn Minuten warten:
+
+```bash
+kubectl -n backup-offsite label --overwrite cronjob watchdog-selftest \
+  homelab.f4mily.net/max-age-hours=0.5
+```
 
 ## 5. Bekannte Grenzen
 


### PR DESCRIPTION
Folge-PR zu #664. Enthält die Flux-GitOps-Alerts (Phase 4) und fünf Korrekturen, die **erst der Test im Cluster** zutage gefördert hat. Vier davon sehen im Manifest völlig plausibel aus und wären still fehlgeschlagen.

## Flux-Alerts (Phase 4)

Beim Deploy von #664 kam heraus, dass Flux seit fünf Stunden **nichts** mehr ausrollte: eine Pending-PVC aus #661 blockierte den Health-Check von `infra-base`, und `infra-main → apps → apps-monitoring-rules` hingen per `dependsOn` daran. Keine Meldung.

`gotk_*`-Metriken wurden bisher gar nicht erfasst — es fehlte das Scrape-Ziel. Die Controller haben keinen Service, daher ein VMPodScrape auf `http-prom`; die NetworkPolicy `allow-scraping` erlaubte das längst. `honorLabels: true` ist nötig, weil `gotk_reconcile_condition` ein eigenes `namespace`-Label trägt (Namespace des überwachten Objekts) — sonst zeigt jeder Alert auf `flux-system`.

Vier Regeln: `FluxControllerDown`, `FluxReconcileFailing`, `FluxReconcileStalled`, `FluxSuspended`.

**`FluxReconcileStalled` ist die wichtigste:** Die *Ursache* stand auf `Ready=Unknown` (Health-Check im Dauer-Timeout), nur die *Folgefehler* auf `Ready=False`. Ein Alert allein auf `False` hätte auf die Symptome gezeigt.

## Korrekturen aus dem Live-Test

| # | Fehler | Warum er still geblieben wäre |
|---|---|---|
| 1 | Dead-Man's-Switch pushte alle 15 Min | `time_pattern`-Trigger mit Bedingung „Timer `idle`" — ein **nie gestarteter** Timer ist auch `idle`. Jetzt nur `timer.finished`, Timer 60 Min, eine Meldung pro Ausfall. |
| 2 | Entwarnung wäre **nie** gekommen | Bedingung prüfte `persistent_notification.<id>` — HA führt die seit Jahren nicht mehr als Entitäten. Dauerhaft falsch, Meldung wäre für immer stehen geblieben. Jetzt `input_boolean` als Merker. |
| 3 | Herzschlag alle 11 statt 5 Min | Alertmanager prüft Wiederholungen nur an `group_interval`-Ticks; bei `group_interval == repeat_interval` verfehlt der erste Tick knapp. `group_interval` jetzt `1m`. |
| 4 | `WatchdogJobFailed` konnte bei häufigen CronJobs **nie** feuern | `job_name` im Label-Set + `failedJobsHistoryLimit` ⇒ jede Minute eine neue Alert-Serie, `for: 10m` fing jedes Mal von vorn an. Im Test 20 Min auf `pending`. Jetzt ohne `job_name` aggregiert, `min` statt `max` (Wert ist Alter/max-age, der frischeste Fehlschlag hat den kleinsten Wert). |
| 5 | ntfy-Bridge-Logs über eine Stunde hinterher | Python puffert stdout ohne TTY. Eine korrekt zugestellte Meldung sah im Log aus, als wäre sie nie angekommen. `PYTHONUNBUFFERED=1`. |

Zusätzlich im Runbook: **`max-age-hours` muss > 10 Minuten sein**, sonst fällt die Serie aus dem Alters-Gate, bevor `for: 10m` erfüllt ist.

## Im Cluster verifiziert (aus #664)

- Alle acht Regeln geladen, `health=ok`, `lastError` leer
- `kube_cronjob_labels` liefert die Labels **exakt** unter den hergeleiteten Namen für alle vier angemeldeten CronJobs
- `WatchdogBlind` löste sich auf, sobald die Labels da waren
- **`WatchdogJobStale` Ende-zu-Ende bewiesen:** Selbsttest-CronJob → vmalert `firing` 23:17:40 → ntfy-Push `[FIRING] WatchdogJobStale`, Priorität 5, um 23:17:46
- Herzschlag erreicht Home Assistant, Timer läuft

Nach dem Merge zu prüfen: die vier Flux-Expressions in der vmalert-Rules-API (`health=ok`, `namespace`-Label korrekt) und `WatchdogJobFailed` mit der neuen Aggregation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)