### PR TITLE
fix(monitoring): FluxSuspended legte die komplette VMRule lahm

### DIFF
--- a/apps/base/monitoring/rules/flux-vmrule.yaml
+++ b/apps/base/monitoring/rules/flux-vmrule.yaml
@@ -96,5 +96,10 @@ spec:
             homelab_owner: platform
           annotations:
             summary: "Flux: {{ $labels.kind }}/{{ $labels.name }} ist suspendiert"
-            description: "{{ $labels.kind }} {{ $labels.name }} in {{ $labels.namespace }} ist seit ueber einer Stunde suspendiert. Aenderungen aus Git werden fuer dieses Objekt nicht angewendet — der Cluster driftet stillschweigend von Git weg. Falls das eine Notmassnahme war: flux resume {{ $labels.kind | lower }} -n {{ $labels.namespace }} {{ $labels.name }}"
+            # Keine Template-Funktionen in Annotations: die Engine kennt weder
+            # `lower` noch die meisten Sprig-Helfer. Ein unbekannter Aufruf
+            # laesst die Validierung der GANZEN VMRule scheitern, nicht nur
+            # dieser einen Regel — dann ist keine der vier Flux-Regeln aktiv.
+            # Der Objekttyp wird deshalb ausgeschrieben statt kleingerechnet.
+            description: "{{ $labels.kind }} {{ $labels.name }} in {{ $labels.namespace }} ist seit ueber einer Stunde suspendiert. Aenderungen aus Git werden fuer dieses Objekt nicht angewendet — der Cluster driftet stillschweigend von Git weg. Falls das eine Notmassnahme war, den Typ kleingeschrieben einsetzen: flux resume kustomization|helmrelease|source git -n {{ $labels.namespace }} {{ $labels.name }}"
             runbook_url: "https://git.f4mily.net/homelab/gitops-homelab/blob/main/docs/runbooks/flux-reconcile.md"

--- a/docs/runbooks/flux-reconcile.md
+++ b/docs/runbooks/flux-reconcile.md
@@ -246,10 +246,20 @@ getrennte Regeln statt einer gemeinsamen `!= "True"`-Regel.
    `FluxReconcileFailing`, um langsame Helm-Installationen nicht
    fälschlicherweise als Stall zu melden — ein sehr kurzer echter Hang bleibt
    in diesem Fenster unbemerkt.
-3. **Kein CI-Check der Alert-Queries.** Wie beim Job-Watchdog gibt es keinen
-   VMRule-Admission-Webhook und keine Expression-Validierung in der
-   CI-Pipeline. Nach jeder Änderung an diesem VMRule die vmalert-Rules-API
-   prüfen:
+3. **Kein CI-Check der Alert-Queries.** Wie beim Job-Watchdog validiert die
+   CI-Pipeline kein MetricsQL. Nach jeder Änderung **zuerst** prüfen, ob der
+   VM-Operator die Regel akzeptiert hat — schlägt eine einzige Annotation fehl,
+   wird die komplette VMRule abgelehnt und keine ihrer vier Regeln ist aktiv
+   (am 15.08.2026 genau so passiert, ein `{{ $labels.kind | lower }}` in
+   `FluxSuspended` legte alle vier still; die Template-Engine kennt `lower`
+   nicht):
+
+   ```bash
+   kubectl -n monitoring get vmrule homelab-flux            # STATUS: operational
+   kubectl -n monitoring get vmrule homelab-flux -o jsonpath='{.status.reason}'
+   ```
+
+   Danach die vmalert-Rules-API:
    ```bash
    kubectl -n monitoring exec deploy/vmalert-vm-k8s-stack-victoria-metrics-k8s-stack -c vmalert -- \
      wget -qO- http://127.0.0.1:8080/api/v1/rules

--- a/docs/runbooks/job-watchdog.md
+++ b/docs/runbooks/job-watchdog.md
@@ -370,10 +370,29 @@ kubectl -n backup-offsite label --overwrite cronjob watchdog-selftest \
 5. **Group-by ohne `cronjob`.** Die Root-`group_by` in der Alertmanager-Route
    enthält kein `cronjob`-Label. Drei gleichzeitig stale Backups ergeben deshalb
    eine ntfy-Nachricht mit drei Zeilen statt drei Nachrichten — das ist gewollt.
-6. **Keine CI-Prüfung der Queries.** Es gibt keinen VMRule-Admission-Webhook und
-   keine Expression-Validierung in der CI-Pipeline. Eine kaputte Query landet
-   still im Cluster. Nach jeder Änderung an diesem VMRule die vmalert-Rules-API
-   prüfen (Befehl siehe oben, Abschnitt 3).
+6. **Keine CI-Prüfung der Queries.** Die CI-Pipeline validiert nur YAML und
+   Kubernetes-Schema, keine MetricsQL. Eine semantisch leere Query — eine, die
+   syntaktisch stimmt, aber nie Daten liefert — landet still im Cluster. Nach
+   jeder Änderung an diesem VMRule die vmalert-Rules-API prüfen (Befehl siehe
+   Abschnitt 3).
+
+   **Zwei getrennte Prüfstellen, beide nötig:**
+
+   ```bash
+   # 1. Hat der VM-Operator die Regel ueberhaupt akzeptiert?
+   kubectl -n monitoring get vmrule
+   # STATUS muss "operational" sein. Bei "failed" den Grund lesen:
+   kubectl -n monitoring get vmrule <name> -o jsonpath='{.status.reason}'
+
+   # 2. Wertet vmalert sie fehlerfrei aus?  (health/lastError, siehe Abschnitt 3)
+   ```
+
+   Die erste Stelle fängt Syntaxfehler und **unbekannte Template-Funktionen in
+   den Annotations** — und zwar hart: schlägt eine einzige Annotation fehl,
+   wird die **komplette VMRule** abgelehnt und keine ihrer Regeln ist aktiv.
+   Am 15.08.2026 hat ein `{{ $labels.kind | lower }}` so alle vier Flux-Regeln
+   auf einen Schlag stillgelegt. Die Template-Engine kennt `lower` nicht — in
+   Annotations grundsätzlich ohne Funktionsaufrufe auskommen.
 
 ## Abgelöst
 


### PR DESCRIPTION
Direkter Nachzug zu #672. Nach dem Merge zeigte `kubectl get vmrule` für `homelab-flux` den Status **`failed`**:

```
invalid annotations for rule "FluxSuspended": error parsing template:
template: :1: function "lower" not defined
```

Die Annotation nutzte `{{ $labels.kind | lower }}`. Die Template-Engine kennt `lower` nicht — und der VM-Operator lehnt bei **einer** kaputten Annotation die **gesamte** VMRule ab. Es war also keine der vier Flux-Regeln aktiv, nicht bloß diese eine.

Der Objekttyp wird jetzt ausgeschrieben statt kleingerechnet; in Annotations grundsätzlich ohne Funktionsaufrufe.

## Was daran lehrreich ist

Der Fehler war **nur** über `kubectl get vmrule` sichtbar. Die vmalert-Rules-API — die ich bisher als alleinigen Post-Deploy-Check dokumentiert hatte — hätte nichts gemeldet: was der Operator gar nicht erst annimmt, taucht dort nie auf.

Beide Runbooks sind korrigiert. Dort stand bisher sinngemäß „es gibt keinen Admission-Webhook, kaputte Regeln landen still im Cluster". Das stimmt so nicht: es gibt **zwei** Prüfstellen, und man braucht beide.

| Stelle | Fängt | Befehl |
|---|---|---|
| VM-Operator | Syntax + unbekannte Template-Funktionen; lehnt die ganze VMRule ab | `kubectl -n monitoring get vmrule` → STATUS `operational` |
| vmalert | Auswertungsfehler zur Laufzeit | Rules-API → `health=ok`, `lastError` leer |

Was weiterhin durch beide Netze fällt: eine syntaktisch korrekte Query, die schlicht nie Daten liefert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)