### PR TITLE
fix(monitoring): Flux-Alerts auf existierende Metriken umstellen

### DIFF
--- a/KI-ALERT-PLAN.md
+++ b/KI-ALERT-PLAN.md
@@ -88,10 +88,20 @@ mehr aus Git ausgerollt, ohne jede Meldung.
 
 | Task | Status |
 |------|--------|
-| `apps/base/monitoring/extra-scrapes/flux-vmpodscrape.yaml` (gotk-Metriken, `honorLabels: true`) | ✅ |
 | `apps/base/monitoring/rules/flux-vmrule.yaml` (4 Alerts: `FluxControllerDown`, `FluxReconcileFailing`, `FluxReconcileStalled`, `FluxSuspended`) | ✅ |
 | Eigener ntfy-Receiver | nicht nötig — bestehende Route über `severity` + `homelab_owner: platform` greift bereits |
 | Runbook `docs/runbooks/flux-reconcile.md` | ✅ |
+
+**Nachtrag 15.08.2026:** Die erste Fassung dieser Phase baute auf
+`gotk_reconcile_condition`/`gotk_suspend_status` auf — diese Metriken
+existieren in Flux 2.9 (hier: v2.9.4) nicht mehr, alle vier Alerts liefen ins
+Leere. Fix: die Serien kommen jetzt aus kube-state-metrics Custom Resource
+State (`flux_resource_ready`, `flux_resource_suspended`), konfiguriert in
+`apps/base/monitoring/vm-k8s-stack/helmrelease.yaml`
+(`kube-state-metrics.customResourceState` + `rbac.extraRules`). Der
+`VMPodScrape flux-vmpodscrape.yaml` liefert weiterhin `controller_runtime_*`
+(nützlich für Reconcile-Fehlerraten/-Latenzen), aber nicht mehr die Basis der
+vier Alerts — siehe `docs/runbooks/flux-reconcile.md`.
 
 ---
 
@@ -191,9 +201,9 @@ apps/base/monitoring/
 │   ├── platform-p0-vmrule.yaml
 │   ├── job-watchdog-vmrule.yaml        # generischer Job-Watchdog (Phase 7)
 │   ├── dead-mans-switch-vmrule.yaml    # Watchdog/vector(1) -> HA-Webhook (Phase 7)
-│   └── flux-vmrule.yaml                # Flux-GitOps-Alerts (Phase 4)
+│   └── flux-vmrule.yaml                # Flux-GitOps-Alerts (Phase 4, Metriken seit 15.08. aus KSM-CRS)
 └── extra-scrapes/
-    └── flux-vmpodscrape.yaml           # gotk_* Metriken (Phase 4)
+    └── flux-vmpodscrape.yaml           # controller_runtime_* Metriken (Phase 4)
 
 docs/runbooks/
 ├── cnpg-cluster-offline.md
@@ -223,6 +233,7 @@ docs/integrations/
 
 | Datum | Änderung |
 |-------|----------|
+| 2026-08-15 | Flux-GitOps-Alerts korrigiert: `gotk_reconcile_condition`/`gotk_suspend_status` existieren in Flux 2.9 nicht mehr, alle vier Alerts aus Phase 4 waren wirkungslos. Umgestellt auf kube-state-metrics Custom Resource State (`flux_resource_ready`, `flux_resource_suspended`); RBAC via `rbac.extraRules`. `flux-vmpodscrape.yaml` bleibt (liefert `controller_runtime_*`), Kommentar korrigiert. |
 | 2026-08-14 | Flux-GitOps-Alerts (Phase 4): PR #661 hat eine Pending-PVC eingeführt (TrueNAS >80%-VOLUME-Limit), `infra-base` hing 5h im Health-Check-Timeout (`Ready=Unknown`), `infra-main`/`apps`/`apps-monitoring-rules` dadurch `Ready=False` — Flux rollte fünf Stunden lang nichts mehr aus Git aus, ohne Meldung. Fix: `flux-vmpodscrape.yaml` + 4 Alerts (`FluxControllerDown`, `FluxReconcileFailing`, `FluxReconcileStalled`, `FluxSuspended`) in `flux-vmrule.yaml`, Runbook `flux-reconcile.md` |
 | 2026-08-14 | Generischer Job-Watchdog (7 Alerts, Opt-in per Label) + Dead-Man's-Switch über Home Assistant (Phase 7); `rules/authentik-vmrule.yaml` entfernt, in Watchdog aufgegangen |
 | 2026-05-30 | kubeApiServer-Scrape aus; Script `purge-chart-vmrules.sh` für verwaiste VMRules |

--- a/apps/base/monitoring/extra-scrapes/flux-vmpodscrape.yaml
+++ b/apps/base/monitoring/extra-scrapes/flux-vmpodscrape.yaml
@@ -1,17 +1,28 @@
-# Flux-Controller-Metriken (gotk_*). Ohne diesen Scrape gibt es keine einzige
-# gotk-Serie und die Regeln in rules/flux-vmrule.yaml sind blind — geprueft:
-# vor diesem Objekt lieferte __name__=~"gotk.*" null Ergebnisse.
+# Flux-Controller-Metriken: controller_runtime_* (Reconcile-Fehlerraten,
+# -Latenzen, Workqueue-Tiefe), certwatcher_* und go_*.
+#
+# KORREKTUR 15.08.2026: Hier stand vorher, dieser Scrape liefere gotk_*-Serien
+# (insb. gotk_reconcile_condition/gotk_suspend_status). Das war falsch bzw.
+# durch das Flux-2.9-Upgrade ueberholt — diese Metriken existieren auf dem
+# Metrics-Port der Controller nicht (mehr). Verifiziert: __name__=~"gotk.*"
+# liefert null Ergebnisse, __name__=~"controller_runtime.*" liefert Daten. Die
+# Ready/Suspend-Alerts in rules/flux-vmrule.yaml haengen NICHT an diesem
+# Scrape, sondern an kube-state-metrics Custom Resource State (siehe
+# apps/base/monitoring/vm-k8s-stack/helmrelease.yaml und
+# docs/runbooks/flux-reconcile.md). Dieser VMPodScrape bleibt trotzdem
+# bestehen, weil controller_runtime_* fuer Reconcile-Fehlerraten/-Latenzen der
+# Flux-Controller selbst nuetzlich ist (kein Ersatz fuer CRS, sondern eine
+# andere Sicht: Controller-Performance statt Objekt-Status).
 #
 # Die Controller haben keinen Service, nur den Container-Port http-prom (8080).
 # Die bestehende NetworkPolicy flux-system/allow-scraping erlaubt Ingress auf
 # 8080 aus allen Namespaces, es ist also nichts weiter freizuschalten.
 #
-# honorLabels: true ist hier bewusst gesetzt. gotk_reconcile_condition traegt
-# ein eigenes `namespace`-Label: den Namespace des ueberwachten OBJEKTS (eine
-# HelmRelease liegt z. B. in monitoring oder cnpg-system), nicht den des
-# Controller-Pods. Ohne honorLabels ueberschreibt das Scrape-Relabeling das mit
-# "flux-system" und verschiebt das Original nach exported_namespace — damit
-# zeigt jeder Alert auf den falschen Namespace.
+# honorLabels: true bleibt gesetzt, obwohl controller_runtime_*-Metriken kein
+# eigenes namespace-Label tragen wie einst gotk_reconcile_condition — es
+# schadet nicht und verhindert, dass ein kuenftig hinzugefuegtes Label mit
+# eigenem `namespace` (z. B. bei einem Flux-Upgrade) stillschweigend
+# ueberschrieben wird.
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMPodScrape
 metadata:

--- a/apps/base/monitoring/rules/flux-vmrule.yaml
+++ b/apps/base/monitoring/rules/flux-vmrule.yaml
@@ -96,5 +96,10 @@ spec:
             homelab_owner: platform
           annotations:
             summary: "Flux: {{ $labels.kind }}/{{ $labels.name }} ist suspendiert"
-            description: "{{ $labels.kind }} {{ $labels.name }} in {{ $labels.namespace }} ist seit ueber einer Stunde suspendiert. Aenderungen aus Git werden fuer dieses Objekt nicht angewendet — der Cluster driftet stillschweigend von Git weg. Falls das eine Notmassnahme war: flux resume {{ $labels.kind | lower }} -n {{ $labels.namespace }} {{ $labels.name }}"
+            # Keine Template-Funktionen in Annotations: die Engine kennt weder
+            # `lower` noch die meisten Sprig-Helfer. Ein unbekannter Aufruf
+            # laesst die Validierung der GANZEN VMRule scheitern, nicht nur
+            # dieser einen Regel — dann ist keine der vier Flux-Regeln aktiv.
+            # Der Objekttyp wird deshalb ausgeschrieben statt kleingerechnet.
+            description: "{{ $labels.kind }} {{ $labels.name }} in {{ $labels.namespace }} ist seit ueber einer Stunde suspendiert. Aenderungen aus Git werden fuer dieses Objekt nicht angewendet — der Cluster driftet stillschweigend von Git weg. Falls das eine Notmassnahme war, den Typ kleingeschrieben einsetzen: flux resume kustomization|helmrelease|source git -n {{ $labels.namespace }} {{ $labels.name }}"
             runbook_url: "https://git.f4mily.net/homelab/gitops-homelab/blob/main/docs/runbooks/flux-reconcile.md"

--- a/apps/base/monitoring/rules/flux-vmrule.yaml
+++ b/apps/base/monitoring/rules/flux-vmrule.yaml
@@ -9,12 +9,28 @@
 # Der Fall ist derselbe wie beim Job-Watchdog: Ausbleiben von Erfolg ist ein
 # Signal, nicht nur ein Fehler.
 #
-# Voraussetzung: extra-scrapes/flux-vmpodscrape.yaml. Ohne den Scrape gibt es
-# keine gotk-Serien und nur FluxControllerDown feuert (fail loud).
+# gotk_reconcile_condition ist tot: Die erste Fassung dieser Datei (15.08.2026)
+# baute auf dieser Metrik auf — sie existiert in Flux 2.9 (hier: v2.9.4)
+# schlicht nicht mehr. Die Controller exportieren auf ihrem Metrics-Port nur
+# noch controller_runtime_*, certwatcher_* und go_*. Alle vier Regeln unten
+# liefen deshalb ins Leere, ohne dass der VM-Operator das ablehnte — eine
+# Regel auf einer nicht existierenden Metrik ist kein Fehler, nur dauerhaft
+# `absent()`.
 #
-# gotk_reconcile_condition ist eine Serie je (kind, name, namespace, type,
-# status) mit Wert 0/1. "Ready ist False" heisst also
-# {type="Ready", status="False"} == 1 — nicht etwa == 0.
+# Die Serien kommen jetzt stattdessen aus kube-state-metrics Custom Resource
+# State (CRS), konfiguriert in
+# apps/base/monitoring/vm-k8s-stack/helmrelease.yaml (Block
+# `kube-state-metrics.customResourceState`). Details, Beleg und Diagnose:
+# docs/runbooks/flux-reconcile.md.
+#
+# flux_resource_ready{namespace,name,kind,type,status} ist eine Info-Metrik
+# (Wert immer 1) je Eintrag in .status.conditions[] — nicht nur fuer "Ready".
+# "Ready ist False" heisst deshalb {type="Ready", status="False"}, das
+# Vorhandensein dieser Label-Kombination allein ist bereits das Signal (kein
+# zusaetzliches "== 1" noetig, anders als bei einem klassischen Gauge).
+#
+# flux_resource_suspended{namespace,name,kind} ist ein Gauge aus .spec.suspend
+# (0/1) — hier ist "== 1" weiterhin die richtige Prüfung.
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMRule
 metadata:
@@ -29,11 +45,12 @@ spec:
       interval: 60s
       rules:
         - alert: FluxControllerDown
-          # Meta-Alert: keine einzige gotk-Serie. Entweder sind die Controller
-          # weg oder der VMPodScrape wurde entfernt. Ohne diesen Alert saehe
-          # beides wie "alles gruen" aus.
+          # Meta-Alert: keine einzige flux_resource_ready-Serie. Entweder
+          # liefert kube-state-metrics nichts mehr (Pod down, RBAC entzogen),
+          # oder die customResourceState-Config wurde aus der HelmRelease
+          # entfernt. Ohne diesen Alert saehe beides wie "alles gruen" aus.
           expr: |
-            absent(gotk_reconcile_condition)
+            absent(flux_resource_ready)
           for: 15m
           labels:
             severity: critical
@@ -41,7 +58,7 @@ spec:
             homelab_owner: platform
           annotations:
             summary: "Flux liefert keine Metriken mehr"
-            description: "Es existiert keine einzige gotk_reconcile_condition-Serie. Entweder laufen die Flux-Controller nicht mehr, oder der VMPodScrape flux-controllers fehlt. Solange dieser Alert steht, ist unbekannt, ob Git ueberhaupt noch ausgerollt wird."
+            description: "Es existiert keine einzige flux_resource_ready-Serie. Entweder liefert kube-state-metrics keine Custom-Resource-State-Daten mehr (RBAC, Pod down), oder der Block kube-state-metrics.customResourceState in der HelmRelease vm-k8s-stack wurde entfernt. Solange dieser Alert steht, ist unbekannt, ob Git ueberhaupt noch ausgerollt wird."
             runbook_url: "https://git.f4mily.net/homelab/gitops-homelab/blob/main/docs/runbooks/flux-reconcile.md"
 
         - alert: FluxReconcileFailing
@@ -49,9 +66,9 @@ spec:
           # Manifest, oder (wie am 14.08.) "dependency is not ready" bei allen
           # nachgelagerten Kustomizations.
           expr: |
-            gotk_reconcile_condition{type="Ready", status="False"} == 1
+            flux_resource_ready{type="Ready", status="False"}
             unless on (kind, name, namespace)
-            (gotk_suspend_status == 1)
+            (flux_resource_suspended == 1)
           for: 15m
           labels:
             severity: critical
@@ -70,9 +87,9 @@ spec:
           # Folgefehler weiter unten in der Kette.
           # 30 Minuten, damit langsame Helm-Installationen nicht anschlagen.
           expr: |
-            gotk_reconcile_condition{type="Ready", status="Unknown"} == 1
+            flux_resource_ready{type="Ready", status="Unknown"}
             unless on (kind, name, namespace)
-            (gotk_suspend_status == 1)
+            (flux_resource_suspended == 1)
           for: 30m
           labels:
             severity: critical
@@ -88,7 +105,7 @@ spec:
           # CronJobs: Git und Cluster laufen still auseinander, ohne Fehler.
           # Meist eine Notmassnahme, die niemand zurueckgenommen hat.
           expr: |
-            gotk_suspend_status == 1
+            flux_resource_suspended == 1
           for: 1h
           labels:
             severity: warning

--- a/apps/base/monitoring/vm-k8s-stack/helmrelease.yaml
+++ b/apps/base/monitoring/vm-k8s-stack/helmrelease.yaml
@@ -337,6 +337,222 @@ spec:
       metricLabelsAllowlist:
         - cronjobs=[homelab.f4mily.net/watchdog,homelab.f4mily.net/max-age-hours,homelab.f4mily.net/max-runtime-hours]
 
+      # Custom Resource State (CRS): Flux-Reconcile-Metriken.
+      #
+      # gotk_reconcile_condition/gotk_suspend_status existieren in Flux 2.9
+      # nicht mehr (siehe docs/runbooks/flux-reconcile.md, Abschnitt "gotk_*
+      # ist tot"). Statt der Controller-Metrik generiert kube-state-metrics
+      # die Serien jetzt direkt aus den Flux-CRs. Syntax verifiziert gegen
+      # https://github.com/kubernetes/kube-state-metrics/blob/main/docs/metrics/extend/customresourcestate-metrics.md
+      # (Beispiel "status conditions on Kubernetes Controllers") sowie gegen
+      # `helm template` — siehe just-validate-Output für den Beleg, dass diese
+      # Config tatsächlich in den ConfigMap-Values landet.
+      #
+      # Metriken je abgedecktem Kind (Kustomization, HelmRelease,
+      # GitRepository, OCIRepository, HelmRepository, HelmChart):
+      #   flux_resource_ready{namespace,name,kind,type,status}  Info, Wert immer 1
+      #     -> eine Serie je Eintrag in .status.conditions[], nicht nur für
+      #        "Ready". Alert-Queries filtern deshalb explizit type="Ready".
+      #   flux_resource_suspended{namespace,name,kind}          Gauge, 0/1
+      #     -> aus .spec.suspend (bool wird von KSM zu 0.0/1.0).
+      #
+      # WICHTIG, nicht vereinfachen: status steht als LABEL, nicht als
+      # Metrikwert. Ein Gauge mit valueFrom:[status] würde "False" UND
+      # "Unknown" beide auf 0.0 abbilden (KSM-String-Konvertierung: alles
+      # außer "true"/"yes" -> 0.0) — genau die Unterscheidung, die am
+      # 14.08.2026 zwischen Ursache (Unknown) und Folgefehlern (False) den
+      # Unterschied machte, ginge damit verloren. Deshalb Info-Metrik mit
+      # type+status als Label statt Gauge mit valueFrom.
+      #
+      # Diese Metriken kommen über die Default-VMServiceScrape von
+      # kube-state-metrics selbst rein (values-Key `vmScrape`, oben im Chart
+      # bereits mit honorLabels:true aktiv) — kein separater Scrape nötig.
+      customResourceState:
+        enabled: true
+        config:
+          kind: CustomResourceStateMetrics
+          spec:
+            resources:
+              - groupVersionKind:
+                  group: kustomize.toolkit.fluxcd.io
+                  version: v1
+                  kind: Kustomization
+                metricNamePrefix: flux
+                labelsFromPath:
+                  name: [metadata, name]
+                  namespace: [metadata, namespace]
+                commonLabels:
+                  kind: Kustomization
+                metrics:
+                  - name: resource_ready
+                    help: "Ready-Bedingung eines Flux-Objekts (Info-Metrik, Wert immer 1; status als Label)."
+                    each:
+                      type: Info
+                      info:
+                        path: [status, conditions]
+                        labelsFromPath:
+                          type: ["type"]
+                          status: ["status"]
+                  - name: resource_suspended
+                    help: "spec.suspend eines Flux-Objekts (0=aktiv, 1=suspendiert)."
+                    each:
+                      type: Gauge
+                      gauge:
+                        path: [spec, suspend]
+              - groupVersionKind:
+                  group: helm.toolkit.fluxcd.io
+                  version: v2
+                  kind: HelmRelease
+                metricNamePrefix: flux
+                labelsFromPath:
+                  name: [metadata, name]
+                  namespace: [metadata, namespace]
+                commonLabels:
+                  kind: HelmRelease
+                metrics:
+                  - name: resource_ready
+                    help: "Ready-Bedingung eines Flux-Objekts (Info-Metrik, Wert immer 1; status als Label)."
+                    each:
+                      type: Info
+                      info:
+                        path: [status, conditions]
+                        labelsFromPath:
+                          type: ["type"]
+                          status: ["status"]
+                  - name: resource_suspended
+                    help: "spec.suspend eines Flux-Objekts (0=aktiv, 1=suspendiert)."
+                    each:
+                      type: Gauge
+                      gauge:
+                        path: [spec, suspend]
+              - groupVersionKind:
+                  group: source.toolkit.fluxcd.io
+                  version: v1
+                  kind: GitRepository
+                metricNamePrefix: flux
+                labelsFromPath:
+                  name: [metadata, name]
+                  namespace: [metadata, namespace]
+                commonLabels:
+                  kind: GitRepository
+                metrics:
+                  - name: resource_ready
+                    help: "Ready-Bedingung eines Flux-Objekts (Info-Metrik, Wert immer 1; status als Label)."
+                    each:
+                      type: Info
+                      info:
+                        path: [status, conditions]
+                        labelsFromPath:
+                          type: ["type"]
+                          status: ["status"]
+                  - name: resource_suspended
+                    help: "spec.suspend eines Flux-Objekts (0=aktiv, 1=suspendiert)."
+                    each:
+                      type: Gauge
+                      gauge:
+                        path: [spec, suspend]
+              - groupVersionKind:
+                  group: source.toolkit.fluxcd.io
+                  version: v1
+                  kind: OCIRepository
+                metricNamePrefix: flux
+                labelsFromPath:
+                  name: [metadata, name]
+                  namespace: [metadata, namespace]
+                commonLabels:
+                  kind: OCIRepository
+                metrics:
+                  - name: resource_ready
+                    help: "Ready-Bedingung eines Flux-Objekts (Info-Metrik, Wert immer 1; status als Label)."
+                    each:
+                      type: Info
+                      info:
+                        path: [status, conditions]
+                        labelsFromPath:
+                          type: ["type"]
+                          status: ["status"]
+                  - name: resource_suspended
+                    help: "spec.suspend eines Flux-Objekts (0=aktiv, 1=suspendiert)."
+                    each:
+                      type: Gauge
+                      gauge:
+                        path: [spec, suspend]
+              - groupVersionKind:
+                  group: source.toolkit.fluxcd.io
+                  version: v1
+                  kind: HelmRepository
+                metricNamePrefix: flux
+                labelsFromPath:
+                  name: [metadata, name]
+                  namespace: [metadata, namespace]
+                commonLabels:
+                  kind: HelmRepository
+                metrics:
+                  - name: resource_ready
+                    help: "Ready-Bedingung eines Flux-Objekts (Info-Metrik, Wert immer 1; status als Label)."
+                    each:
+                      type: Info
+                      info:
+                        path: [status, conditions]
+                        labelsFromPath:
+                          type: ["type"]
+                          status: ["status"]
+                  - name: resource_suspended
+                    help: "spec.suspend eines Flux-Objekts (0=aktiv, 1=suspendiert)."
+                    each:
+                      type: Gauge
+                      gauge:
+                        path: [spec, suspend]
+              - groupVersionKind:
+                  group: source.toolkit.fluxcd.io
+                  version: v1
+                  kind: HelmChart
+                metricNamePrefix: flux
+                labelsFromPath:
+                  name: [metadata, name]
+                  namespace: [metadata, namespace]
+                commonLabels:
+                  kind: HelmChart
+                metrics:
+                  - name: resource_ready
+                    help: "Ready-Bedingung eines Flux-Objekts (Info-Metrik, Wert immer 1; status als Label)."
+                    each:
+                      type: Info
+                      info:
+                        path: [status, conditions]
+                        labelsFromPath:
+                          type: ["type"]
+                          status: ["status"]
+                  - name: resource_suspended
+                    help: "spec.suspend eines Flux-Objekts (0=aktiv, 1=suspendiert)."
+                    each:
+                      type: Gauge
+                      gauge:
+                        path: [spec, suspend]
+
+      # Ohne List/Watch auf die Flux-CRDs liefert die CRS-Config oben still
+      # keine Daten — kein Fehler, einfach leere Metriken (Belegpflicht siehe
+      # just-validate-Output). rbac.customResourceState.createClusterRoleRules
+      # gibt es in dieser Chart-Version (kube-state-metrics 7.5.3, gebündelt
+      # in victoria-metrics-k8s-stack 0.90.1) noch NICHT (geprüft mit
+      # `helm show values` gegen die tatsächlich gepinnte Version) — der
+      # Weg für Custom-Resource-RBAC ist hier ausschließlich rbac.extraRules.
+      rbac:
+        extraRules:
+          - apiGroups: ["kustomize.toolkit.fluxcd.io"]
+            resources: ["kustomizations"]
+            verbs: ["list", "watch"]
+          - apiGroups: ["helm.toolkit.fluxcd.io"]
+            resources: ["helmreleases"]
+            verbs: ["list", "watch"]
+          - apiGroups: ["source.toolkit.fluxcd.io"]
+            resources:
+              - gitrepositories
+              - ocirepositories
+              - helmrepositories
+              - helmcharts
+            verbs: ["list", "watch"]
+
     # ============================================
     # DEFAULT DASHBOARDS & RULES
     # ============================================

--- a/docs/runbooks/flux-reconcile.md
+++ b/docs/runbooks/flux-reconcile.md
@@ -28,36 +28,73 @@ HelmRelease-Objekt konnte beliebig lange `False` oder `Unknown` stehen, ohne
 dass irgendwer benachrichtigt wurde.
 
 Alle vier Alerts liegen in `apps/base/monitoring/rules/flux-vmrule.yaml`,
-Gruppe `homelab.platform.flux`, im Namespace `monitoring`. Voraussetzung ist
-der `VMPodScrape` in `apps/base/monitoring/extra-scrapes/flux-vmpodscrape.yaml`
-— ohne ihn gibt es keine `gotk_*`-Serien und nur `FluxControllerDown` würde
-feuern.
+Gruppe `homelab.platform.flux`, im Namespace `monitoring`.
 
-**Technischer Hintergrund, wichtig beim Anpassen der Regeln:**
-`gotk_reconcile_condition` ist eine Serie je (`kind`, `name`, `namespace`,
-`type`, `status`) mit Wert 0/1. "Ready ist False" heißt in MetricsQL
-`{type="Ready", status="False"} == 1` — **nicht** `{type="Ready"} == 0`. Das
-ist die häufigste Fehlerquelle, wenn hier jemand eine weitere Regel ergänzt.
+## 2. `gotk_*` ist tot — nicht wieder einbauen
 
-Der `VMPodScrape` setzt außerdem `honorLabels: true`, weil
-`gotk_reconcile_condition` ein eigenes `namespace`-Label trägt: den Namespace
-des überwachten Objekts (eine HelmRelease liegt z. B. in `monitoring` oder
-`cnpg-system`), nicht den des Controller-Pods (`flux-system`). Ohne
-`honorLabels` überschreibt das Scrape-Relabeling dieses Label mit
-`flux-system` und schiebt das Original nach `exported_namespace` — jeder
-Alert hätte dann auf den falschen Namespace gezeigt.
+Die erste Fassung dieser Alerts (14.08.2026) basierte auf
+`gotk_reconcile_condition` und `gotk_suspend_status`, angeblich geliefert vom
+`VMPodScrape flux-vmpodscrape.yaml`. Das war falsch: **diese Metriken
+existieren in Flux 2.9 (hier: v2.9.4) nicht mehr.** Die Flux-Controller
+exportieren auf ihrem Metrics-Port (`http-prom`, 8080) ausschließlich
+`controller_runtime_*`, `certwatcher_*` und `go_*`. Der Scrape war korrekt
+konfiguriert, die Targets standen auf `up`, andere Metriken kamen an — die
+Serie gab es einfach nicht (mehr). Ergebnis: alle vier Regeln liefen seit
+Einführung ins Leere, ohne dass der VM-Operator das ablehnte (eine Regel auf
+einer nicht existierenden Metrik ist kein Config-Fehler, nur dauerhaft
+`absent()`).
 
-Die Flux-Controller haben keinen Service, nur den Container-Port
-`http-prom` (8080). Die bestehende NetworkPolicy `flux-system/allow-scraping`
-erlaubt Ingress auf 8080 aus allen Namespaces — für den Scrape war nichts
-weiter freizuschalten.
+**Fix (15.08.2026):** Die Serien kommen jetzt aus **kube-state-metrics Custom
+Resource State (CRS)** — kube-state-metrics liest die Flux-Custom-Resources
+direkt über die Kubernetes-API (list/watch), nicht über den Metrics-Port der
+Controller. Konfiguriert in
+`apps/base/monitoring/vm-k8s-stack/helmrelease.yaml`, Block
+`kube-state-metrics.customResourceState` (+ `kube-state-metrics.rbac.extraRules`
+für die nötigen Leserechte auf die Flux-API-Gruppen). Abgedeckte Kinds:
+`Kustomization`, `HelmRelease`, `GitRepository`, `OCIRepository`,
+`HelmRepository`, `HelmChart`.
+
+Neue Metriken:
+
+- **`flux_resource_ready{namespace, name, kind, type, status}`** — Info-Metrik
+  (Wert immer `1`), eine Serie je Eintrag in `.status.conditions[]` des
+  Flux-Objekts. `status` ist bewusst ein **Label** und nicht der Metrikwert:
+  ein klassisches Gauge mit `valueFrom: [status]` würde laut
+  KSM-Typkonvertierung sowohl `"False"` als auch `"Unknown"` auf `0.0`
+  abbilden (alles außer `"true"`/`"yes"` wird `0.0`) — genau die
+  Unterscheidung, die am 14.08. den Unterschied zwischen Ursache
+  (`Ready=Unknown`) und Folgefehlern (`Ready=False`) ausmachte, ginge damit
+  verloren.
+- **`flux_resource_suspended{namespace, name, kind}`** — Gauge (`0`/`1`) aus
+  `.spec.suspend`.
+
+"Ready ist False" heißt in MetricsQL jetzt
+`flux_resource_ready{type="Ready", status="False"}` — das reine Vorhandensein
+dieser Label-Kombination ist bereits das Signal, ein zusätzliches `== 1` ist
+bei dieser Info-Metrik nicht nötig (anders als früher bei einem klassischen
+Gauge). Bei `flux_resource_suspended` bleibt `== 1` weiterhin die richtige
+Prüfung.
+
+**Diese Metriken kommen automatisch über die Default-`VMServiceScrape` von
+kube-state-metrics selbst rein** (chart-eigener `vmScrape`-Wert, bereits mit
+`honorLabels: true`) — es gibt dafür keinen eigenen Scrape. Der
+`VMPodScrape flux-vmpodscrape.yaml` bleibt trotzdem bestehen, liefert aber nur
+noch `controller_runtime_*`/`certwatcher_*`/`go_*` (Controller-Performance,
+kein Ersatz für CRS) — siehe Kommentar in der Datei.
+
+**Beleg, dass die Values-Pfade stimmen:** `nix develop -c just validate` im
+`helm-render`-Schritt prüfen — dort muss sowohl der
+`customResourceState.config`-Block (als ConfigMap-Inhalt) als auch die
+`rbac.extraRules`-Regeln im gerenderten kube-state-metrics-`ClusterRole`
+auftauchen. Ohne die RBAC-Regeln liefert CRS still keine Daten — kein Fehler,
+einfach leere Metriken.
 
 **Routing:** unverändert gegenüber allen anderen Platform-Alerts. `severity`
 + `homelab_owner: platform` greifen in die bestehenden Alertmanager-Routen →
 ntfy-Topic `monitoring` sowie n8n/Telegram-Triage. Es gibt keinen eigenen
 Receiver für Flux — siehe [monitoring-stack.md](monitoring-stack.md).
 
-## 2. Nützliche Basisbefehle für jede Diagnose
+## 3. Nützliche Basisbefehle für jede Diagnose
 
 ```bash
 flux get all -A --status-selector ready=false
@@ -68,6 +105,10 @@ kubectl -n flux-system logs deploy/helm-controller --tail=100
 flux reconcile source git flux-system
 flux reconcile kustomization <name> --timeout=5m
 flux resume kustomization <name>
+
+# Direkt an den neuen Metriken prüfen (kube-state-metrics CRS statt gotk_*):
+kubectl -n monitoring exec deploy/vm-k8s-stack-kube-state-metrics -- \
+  wget -qO- http://127.0.0.1:8080/metrics | grep ^flux_resource_
 ```
 
 **Wichtig:** Der Kustomization-Status selbst zeigt bei einem hängenden
@@ -76,39 +117,46 @@ Ursache (welche Ressource, welcher Timeout) steht fast nie im Status, sondern
 nur im Log des `kustomize-controller`. Der `grep -i "health check"` oben ist
 deshalb der entscheidende Schritt, nicht ein Nice-to-have.
 
-## 3. Die Alerts
+## 4. Die Alerts
 
 ### FluxControllerDown — critical, `for: 15m`
 
-**Bedeutung:** `absent(gotk_reconcile_condition)` — es existiert keine
-einzige gotk-Serie mehr. Entweder sind die Flux-Controller weg, oder der
-`VMPodScrape flux-controllers` wurde entfernt. Solange dieser Alert steht,
-ist unbekannt, ob Git überhaupt noch ausgerollt wird — er ist der
-wichtigste Alert im Set, analog zu `WatchdogBlind` beim Job-Watchdog.
+**Bedeutung:** `absent(flux_resource_ready)` — es existiert keine einzige
+CRS-Serie mehr. Entweder liefert kube-state-metrics keine
+Custom-Resource-State-Daten mehr (Pod down, RBAC entzogen), oder der Block
+`kube-state-metrics.customResourceState` wurde aus der HelmRelease
+`vm-k8s-stack` entfernt. Solange dieser Alert steht, ist unbekannt, ob Git
+überhaupt noch ausgerollt wird — er ist der wichtigste Alert im Set, analog
+zu `WatchdogBlind` beim Job-Watchdog.
 
 **Sofortdiagnose:**
 
 ```bash
-kubectl -n flux-system get pods
-kubectl get vmpodscrape -n flux-system flux-controllers
+kubectl -n monitoring get pods -l app.kubernetes.io/name=kube-state-metrics
+kubectl -n monitoring exec deploy/vm-k8s-stack-kube-state-metrics -- \
+  wget -qO- http://127.0.0.1:8080/metrics | grep ^flux_resource_
+kubectl -n monitoring logs deploy/vm-k8s-stack-kube-state-metrics | grep -i "customresourcestate\|forbidden"
 ```
 
 **Typische Ursachen:**
 
-- Flux-Controller-Pods sind gecrasht oder das Deployment ist auf 0 skaliert.
-- Der `VMPodScrape` wurde aus Git entfernt oder das Selector-Label
-  `app.kubernetes.io/part-of: flux` stimmt nach einem Flux-Upgrade nicht mehr.
-- Die NetworkPolicy `flux-system/allow-scraping` wurde geändert und blockiert
-  jetzt den Scrape auf Port 8080.
+- kube-state-metrics-Pod ist gecrasht oder das Deployment ist auf 0 skaliert.
+- Der Block `kube-state-metrics.customResourceState` wurde aus
+  `apps/base/monitoring/vm-k8s-stack/helmrelease.yaml` entfernt oder die
+  `rbac.extraRules` fehlen — dann läuft kube-state-metrics zwar, aber CRS
+  liefert still keine Daten (kein Fehler im Log, einfach leere Serien).
+- Die Flux-CRDs wurden umbenannt/migriert (API-Group/Version-Wechsel) und die
+  `groupVersionKind`-Einträge in `customResourceState.config` stimmen nicht
+  mehr.
 
-**Behebung:** Controller-Pods reparieren (Logs prüfen, ggf. Deployment
-neu starten) bzw. den `VMPodScrape`/die NetworkPolicy in Git wiederherstellen
-und Flux reconcilen lassen. Danach prüfen, dass
-`gotk_reconcile_condition` wieder Serien liefert.
+**Behebung:** kube-state-metrics-Pod reparieren (Logs prüfen, ggf. Deployment
+neu starten) bzw. `customResourceState`/`rbac.extraRules` in Git
+wiederherstellen und Flux reconcilen lassen. Danach prüfen, dass
+`flux_resource_ready` wieder Serien liefert.
 
 ### FluxReconcileFailing — critical, `for: 15m`
 
-**Bedeutung:** `gotk_reconcile_condition{type="Ready", status="False"} == 1`,
+**Bedeutung:** `flux_resource_ready{type="Ready", status="False"}`,
 suspendierte Objekte ausgenommen. Der häufigere Fall: ein fehlgeschlagener
 Apply, ein kaputtes Manifest, oder — wie am 14.08. bei `infra-main`, `apps`
 und `apps-monitoring-rules` — `dependency ... is not ready`, weil ein
@@ -138,8 +186,8 @@ von selbst.
 
 ### FluxReconcileStalled — critical, `for: 30m`
 
-**Bedeutung:** `gotk_reconcile_condition{type="Ready", status="Unknown"} ==
-1`, suspendierte Objekte ausgenommen — ein Reconcile, das nie endet. Genau
+**Bedeutung:** `flux_resource_ready{type="Ready", status="Unknown"}`,
+suspendierte Objekte ausgenommen — ein Reconcile, das nie endet. Genau
 so sah `infra-base` am 14.08. aus: der Health-Check auf die
 `nextcloud-offsite-staging`-PVC lief alle fünf Minuten erneut in den
 Timeout und blieb dauerhaft `Unknown`. 30 Minuten `for`, damit langsame
@@ -179,7 +227,7 @@ Konfigänderungen).
 
 ### FluxSuspended — warning, `for: 1h`
 
-**Bedeutung:** `gotk_suspend_status == 1` — ein Objekt ist suspendiert. Das
+**Bedeutung:** `flux_resource_suspended == 1` — ein Objekt ist suspendiert. Das
 GitOps-Pendant zum suspendierten CronJob im Job-Watchdog: Git und Cluster
 laufen still auseinander, ohne dass irgendwo ein Fehler steht. Meist eine
 Notmaßnahme aus einem Vorfall, die niemand zurückgenommen hat — genau das
@@ -205,7 +253,7 @@ committen, Flux reconcilen lassen — ein manuelles `flux resume` wird beim
 nächsten Reconcile aus Git ohnehin wieder überschrieben, wenn der
 `suspend`-Wert in Git nicht ebenfalls korrigiert wird.
 
-## 4. Ursache vs. Folge: Unknown vs. False
+## 5. Ursache vs. Folge: Unknown vs. False
 
 Der 14.08.2026-Vorfall zeigte sich als **eine** hängende Kustomization
 (`Ready=Unknown`) und **drei** fehlgeschlagene Folge-Kustomizations
@@ -235,7 +283,7 @@ geblieben, solange niemand auch in den `Unknown`-Zustand geschaut hätte.
 Deshalb gibt es `FluxReconcileFailing` und `FluxReconcileStalled` als zwei
 getrennte Regeln statt einer gemeinsamen `!= "True"`-Regel.
 
-## 5. Bekannte Grenzen
+## 6. Bekannte Grenzen
 
 1. **Kein eigener ntfy-Receiver.** Die vier Alerts nutzen ausschließlich die
    bestehende Routing-Logik über `severity` + `homelab_owner: platform`. Das
@@ -270,7 +318,7 @@ getrennte Regeln statt einer gemeinsamen `!= "True"`-Regel.
    ntfy-Nachricht mit mehreren Zeilen statt mehreren Einzel-Nachrichten —
    das ist gewollt, siehe [monitoring-stack.md](monitoring-stack.md) bzw. das
    generelle Muster im [Rulebook](../rulebook.md).
-5. **`gotk_suspend_status` deckt keine Halb-Suspendierung ab.** Wird nur die
+5. **`flux_resource_suspended` deckt keine Halb-Suspendierung ab.** Wird nur die
    `GitRepository`-Quelle suspendiert, aber die abhängigen Kustomizations
    nicht, feuert `FluxSuspended` nur für die Quelle — die Kustomizations
    selbst laufen mit dem letzten bekannten Commit weiter, ohne dass das aus

--- a/docs/runbooks/flux-reconcile.md
+++ b/docs/runbooks/flux-reconcile.md
@@ -246,10 +246,20 @@ getrennte Regeln statt einer gemeinsamen `!= "True"`-Regel.
    `FluxReconcileFailing`, um langsame Helm-Installationen nicht
    fälschlicherweise als Stall zu melden — ein sehr kurzer echter Hang bleibt
    in diesem Fenster unbemerkt.
-3. **Kein CI-Check der Alert-Queries.** Wie beim Job-Watchdog gibt es keinen
-   VMRule-Admission-Webhook und keine Expression-Validierung in der
-   CI-Pipeline. Nach jeder Änderung an diesem VMRule die vmalert-Rules-API
-   prüfen:
+3. **Kein CI-Check der Alert-Queries.** Wie beim Job-Watchdog validiert die
+   CI-Pipeline kein MetricsQL. Nach jeder Änderung **zuerst** prüfen, ob der
+   VM-Operator die Regel akzeptiert hat — schlägt eine einzige Annotation fehl,
+   wird die komplette VMRule abgelehnt und keine ihrer vier Regeln ist aktiv
+   (am 15.08.2026 genau so passiert, ein `{{ $labels.kind | lower }}` in
+   `FluxSuspended` legte alle vier still; die Template-Engine kennt `lower`
+   nicht):
+
+   ```bash
+   kubectl -n monitoring get vmrule homelab-flux            # STATUS: operational
+   kubectl -n monitoring get vmrule homelab-flux -o jsonpath='{.status.reason}'
+   ```
+
+   Danach die vmalert-Rules-API:
    ```bash
    kubectl -n monitoring exec deploy/vmalert-vm-k8s-stack-victoria-metrics-k8s-stack -c vmalert -- \
      wget -qO- http://127.0.0.1:8080/api/v1/rules

--- a/docs/runbooks/job-watchdog.md
+++ b/docs/runbooks/job-watchdog.md
@@ -370,10 +370,29 @@ kubectl -n backup-offsite label --overwrite cronjob watchdog-selftest \
 5. **Group-by ohne `cronjob`.** Die Root-`group_by` in der Alertmanager-Route
    enthält kein `cronjob`-Label. Drei gleichzeitig stale Backups ergeben deshalb
    eine ntfy-Nachricht mit drei Zeilen statt drei Nachrichten — das ist gewollt.
-6. **Keine CI-Prüfung der Queries.** Es gibt keinen VMRule-Admission-Webhook und
-   keine Expression-Validierung in der CI-Pipeline. Eine kaputte Query landet
-   still im Cluster. Nach jeder Änderung an diesem VMRule die vmalert-Rules-API
-   prüfen (Befehl siehe oben, Abschnitt 3).
+6. **Keine CI-Prüfung der Queries.** Die CI-Pipeline validiert nur YAML und
+   Kubernetes-Schema, keine MetricsQL. Eine semantisch leere Query — eine, die
+   syntaktisch stimmt, aber nie Daten liefert — landet still im Cluster. Nach
+   jeder Änderung an diesem VMRule die vmalert-Rules-API prüfen (Befehl siehe
+   Abschnitt 3).
+
+   **Zwei getrennte Prüfstellen, beide nötig:**
+
+   ```bash
+   # 1. Hat der VM-Operator die Regel ueberhaupt akzeptiert?
+   kubectl -n monitoring get vmrule
+   # STATUS muss "operational" sein. Bei "failed" den Grund lesen:
+   kubectl -n monitoring get vmrule <name> -o jsonpath='{.status.reason}'
+
+   # 2. Wertet vmalert sie fehlerfrei aus?  (health/lastError, siehe Abschnitt 3)
+   ```
+
+   Die erste Stelle fängt Syntaxfehler und **unbekannte Template-Funktionen in
+   den Annotations** — und zwar hart: schlägt eine einzige Annotation fehl,
+   wird die **komplette VMRule** abgelehnt und keine ihrer Regeln ist aktiv.
+   Am 15.08.2026 hat ein `{{ $labels.kind | lower }}` so alle vier Flux-Regeln
+   auf einen Schlag stillgelegt. Die Template-Engine kennt `lower` nicht — in
+   Annotations grundsätzlich ohne Funktionsaufrufe auskommen.
 
 ## Abgelöst
 


### PR DESCRIPTION
Nachzug zu #672/#673. Die vier Flux-Regeln lagen auf `gotk_reconcile_condition` und `gotk_suspend_status` — **diese Metriken existieren in Flux 2.9 nicht mehr.**

Belegt nach dem Deploy: Die Controller exportieren auf ihrem Metrics-Port nur `controller_runtime_*`, `certwatcher_*` und `go_*`. Der Scrape war korrekt konfiguriert (Targets `up`, andere Metriken kommen an), `count(gotk_reconcile_condition)` lieferte trotzdem nichts. Die Regeln waren also wirkungslos — und das ist der schlechteste Zustand, weil sie nach Abdeckung aussehen.

## Ersatz

kube-state-metrics **Custom Resource State** — dieselbe KSM-Instanz, die schon läuft, keine neue Komponente. Sie liest die Flux-CRs direkt:

```
flux_resource_ready{namespace,name,kind,type,status}   Info, Wert immer 1
flux_resource_suspended{namespace,name,kind}           Gauge 0/1
```

Abgedeckt: `Kustomization`, `HelmRelease`, `GitRepository`, `OCIRepository`, `HelmRepository`, `HelmChart`.

Die vier Alerts und ihre Schwellen bleiben unverändert, nur die Queries sind umgeschrieben — und deutlich einfacher als vorher.

## Zwei Details, die nicht vereinfacht werden dürfen

**`status` steht als Label, nicht als Metrikwert.** Ein Gauge mit `valueFrom: [status]` hätte `"False"` **und** `"Unknown"` beide auf `0.0` abgebildet (kube-state-metrics konvertiert alles außer `"true"`/`"yes"` zu `0.0`). Damit wäre genau die Unterscheidung weg, auf die es ankommt: Am 14.08. stand die **Ursache** auf `Ready=Unknown` (Health-Check im Dauer-Timeout), nur die **Folgefehler** der abhängigen Kustomizations auf `Ready=False`.

**RBAC läuft über `rbac.extraRules`.** Das naheliegende `rbac.customResourceState.createClusterRoleRules` existiert im gebündelten Subchart 7.5.3 nicht und deckt ohnehin nur die CRD-Discovery ab. Ohne die Leserechte auf die Flux-API-Gruppen liefert CRS still keine Daten.

## Verifiziert

Gegen den gepinnten Chart gerendert: Die ConfigMap `vm-k8s-stack-kube-state-metrics-customresourcestate-config` enthält alle sechs `groupVersionKind`-Blöcke, die ClusterRole die drei `extraRules` mit `list`/`watch`.

Der VMPodScrape auf die Controller bleibt — `controller_runtime_*` ist für Reconcile-Fehlerraten und Latenzen nützlich —, aber der Kommentar, er liefere `gotk_*`, ist raus.

Nach dem Merge zu prüfen: `kubectl -n monitoring get vmrule homelab-flux` auf `operational`, `count(flux_resource_ready)` > 0, und dass `FluxControllerDown` sich auflöst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)