### PR TITLE
fix(velero): allow node-agent host paths

### DIFF
--- a/infrastructure/AGENTS.md
+++ b/infrastructure/AGENTS.md
@@ -13,7 +13,7 @@ Cluster-wide services: database operator, storage, networking/ingress, backup + 
 - Single CNPG cluster operator in `base/database/cnpg/`. Per-app DB clusters live in `overlays/main/database-clusters/<app>/`.
 - CNPG `barmanObjectStore` (S3-compatible) for base-backup + WAL archiving. S3 creds never plaintext — SealedSecrets/ExternalSecrets placeholders.
 - DR overlay `overlays/disaster-recovery/` patches CNPG `Cluster` with `spec.bootstrap.recovery`. Restore flow: apply DR overlay → CNPG restores → Flux syncs apps.
-- Velero protects Kubernetes volumes with filesystem backups: `deployNodeAgent: true`, one node-agent per node, and `snapshotsEnabled: false`. Keep unused democratic-csi snapshotter sidecars disabled unless snapshot CRDs and a tested snapshot restore path are introduced together.
+- Velero protects Kubernetes volumes with filesystem backups: `deployNodeAgent: true`, one node-agent per node, and `snapshotsEnabled: false`. Its namespace uses privileged Pod Security labels because node-agent mounts kubelet host paths. Keep unused democratic-csi snapshotter sidecars disabled unless snapshot CRDs and a tested snapshot restore path are introduced together.
 - Storage: CNPG databases use node-local `local-path`; democratic-csi iSCSI serves app RWO volumes; NFS serves large media.
 - Ingress: NGINX with `nginx.org/*` annotations + Cilium CNI.
 

--- a/infrastructure/base/backup/namespace.yaml
+++ b/infrastructure/base/backup/namespace.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   name: velero
   labels:
-    pod-security.kubernetes.io/enforce: baseline
-    pod-security.kubernetes.io/audit: restricted
-    pod-security.kubernetes.io/warn: restricted
+    # Filesystem backups require node-agent hostPath access to kubelet data.
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged


### PR DESCRIPTION
## Summary

- label Velero namespace as Pod Security `privileged`
- document required node-agent hostPath contract

## Validation

- `just validate`
- `just validate-full` (Kind admission stage skipped: unavailable/disabled)
- targeted `yamllint` and `kubeconform`
- `kustomize build infrastructure/base` renders all Velero Pod Security labels as `privileged`